### PR TITLE
Plan #9 validation gate, and apply migrations automatically on deploy

### DIFF
--- a/.agents/issue-planner/9/design-doc.md
+++ b/.agents/issue-planner/9/design-doc.md
@@ -106,7 +106,22 @@ findings and decide in the issue comment with reasoning. The under-5-minute line
 target is explicitly *not* measured here — editors don't exist; measure it at the end
 of #11.
 
-### Decision 4: Production pre-flight is part of this issue
+### Decision 4: RSVP never changes the chart — verify it, don't just assume it
+
+**Decision:** A player who hasn't RSVP'd (or who declined) stays in their batting slot
+and at their position. Removing or benching them is **the coach's decision alone**, made
+by hand, never an automatic consequence of RSVP state. This is already how the system is
+built — `src/lib/rsvp.ts` states "RSVP is reporting, never a gate," and #8's view page
+renders declined and no-response players greyed/marked *in place*, never dropped — but
+the weekend must confirm it holds on the real production page, and confirm parents
+*read* it that way (a no-response kid must never look "out").
+**Rationale:** This invariant is the product's core stance (standing chart, RSVPs as
+exception-signal). If the coach does choose to patch the chart during the weekend, that
+is a manual `db:studio` edit, it is permanent (no undo, per the repo's deliberate
+no-history rule), and it gets recorded in the findings as a coach decision — not as
+app behavior.
+
+### Decision 5: Production pre-flight is part of this issue
 
 **Decision:** Treat "the app is live, migrated, and can deliver email in production" as
 Phase 1 of the task doc rather than an assumption.

--- a/.agents/issue-planner/9/design-doc.md
+++ b/.agents/issue-planner/9/design-doc.md
@@ -1,0 +1,164 @@
+# Design Doc — Phase 9: Validation gate — one real game weekend (#9)
+
+## Overview
+
+Run the cheapest possible test of the product's core assumption — that parents will RSVP
+in an app without being chased by text — before building the expensive half of the app
+(both drag-and-drop editors, messaging, PWA install). **No code ships in this issue.**
+It is an operational plan that exercises everything built in #1–#8 against one real team
+and one real game weekend, and ends in an explicit go / fix-notifications-first decision.
+
+All eight prerequisite phases are closed (verified 2026-08-01). #9 blocks #10, #11, #13,
+and #14 by design: if the RSVP assumption fails, the fix is notification design, not more
+features.
+
+## Acceptance Criteria
+
+From the issue, unchanged:
+
+- [ ] Create the real team and seed the real roster through the UI
+- [ ] Invite the real parents and confirm invitation emails actually arrive — check spam
+- [ ] Set `battingOrder` and `position` on `RosterEntry` by hand via `pnpm db:studio`
+- [ ] Add the weekend's real game to the schedule
+- [ ] Send **one** email announcing the game
+- [ ] **Do not follow up by text** — a text reminder invalidates the result
+- [ ] Record: what percentage of parents RSVP'd before game day
+- [ ] Record: how many "what time / where / is he playing" texts arrived on game day
+- [ ] Record: anything parents got confused by, especially around the three RSVP states
+- [ ] Write the findings into this issue as a comment before closing it
+- [ ] Decide explicitly: proceed to the chart editors, or fix notification design first
+
+## Architecture & Data Model
+
+No schema, route, or module changes. This section maps each operational step to the
+built surface it exercises, so the weekend doubles as an end-to-end audit of #1–#8.
+
+### Operational flow map
+
+| Step | Surface | Built in |
+|---|---|---|
+| Create team | `/t/new` (owner-gated) | #3 |
+| Seed roster + jersey numbers | `/t/[teamId]/roster` | #4 |
+| Link guardians, send invitations | Roster player detail → `InvitationEmail` via Resend → `/invite/[token]` | #4 |
+| Hand-seed the chart | `pnpm db:studio` → `RosterEntry.battingOrder` / `RosterEntry.position` | schema (#3/#4) |
+| Add the game | `/t/[teamId]/schedule` (event create) | #6 |
+| Parents RSVP | `/t/[teamId]/schedule/[eventId]` tri-state toggle | #7 |
+| Parents check the chart | `/t/[teamId]/view` (read-only diamond + order, RSVP as decoration) | #8 |
+| Measure | `pnpm db:studio` read of `Rsvp` rows on game-day morning | — |
+
+### Data written by hand (db:studio)
+
+`RosterEntry.battingOrder` and `RosterEntry.position` only. Three unique constraints can
+trip during hand-editing (`@@unique([teamId, battingOrder])`, `@@unique([teamId, position])`,
+`@@unique([teamId, jerseyNumber])` — `prisma/schema.prisma:156-178`). Studio writes bypass
+`roster-rules.ts`'s friendly `P2002` translation, so a collision surfaces as a raw Prisma
+error. Mitigation: assign values in a single pass with no swaps; to swap two players later,
+null one side first.
+
+Positions are the `Position` enum — `C` is **Catcher**, `CF` is **Center Field**
+(`src/lib/positions.ts`).
+
+## Key Decisions
+
+### Decision 1: How the announcement email is sent
+
+**Options considered:**
+- Option A: Coach's personal email client, one message to the parent list
+- Option B: Build a minimal in-app broadcast now
+
+**Decision:** Option A.
+**Rationale:** In-app messaging is #13, which this gate deliberately *blocks*. Building
+any of it now inverts the phase ordering the milestone exists to protect. The one
+announcement email is manual and personal; it should link parents to the game's event
+page (`/t/[teamId]/schedule/[eventId]`), because the RSVP toggle — the behavior under
+test — lives there. Signed-out recipients pass through the magic-link sign-in and land
+back on the page via the callback URL handling from #2.
+
+### Decision 2: How "RSVP'd before game day" is measured
+
+**Options considered:**
+- Option A: Query `Rsvp.updatedAt` after the fact
+- Option B: Snapshot the `Rsvp` table on game-day morning, before first pitch
+
+**Decision:** Option B.
+**Rationale:** `Rsvp` has `updatedAt @updatedAt` but no `createdAt`
+(`prisma/schema.prisma:219-231`) — a parent who toggles again on game day overwrites the
+evidence of when they first responded. A snapshot taken on game-day morning *is* the
+metric, with no timestamp archaeology. **A response = any `Rsvp` row** — attending *and*
+declined both count; the failure mode being measured is no-response (the absent row,
+per `src/lib/rsvp.ts`). Denominator = rostered players; a family responding for their kid
+counts that player once.
+
+### Decision 3: What the decision rule is
+
+**Decision:** Apply the brief's Success Criteria verbatim, as directional signals — one
+team, one weekend is not a sample:
+
+| Signal | Target |
+|---|---|
+| Players with an RSVP recorded before game day | ≥ 70% |
+| "what time / where / is he playing" texts on game day | → 0 |
+
+Clearly at-or-above targets → close #9 and proceed to #10/#11. Clearly below → run a
+second game weekend; still low after two games → **fix notification design before
+building features** (the brief's explicit instruction). Mixed → record the confusion
+findings and decide in the issue comment with reasoning. The under-5-minute lineup
+target is explicitly *not* measured here — editors don't exist; measure it at the end
+of #11.
+
+### Decision 4: Production pre-flight is part of this issue
+
+**Decision:** Treat "the app is live, migrated, and can deliver email in production" as
+Phase 1 of the task doc rather than an assumption.
+**Rationale:** Nothing in the repo proves a production deploy has ever served a real
+user or that the single migration (`prisma/migrations/20260728053521_001`) has been
+applied to the production Neon branch. A dry run with a secondary email account —
+invitation → spam check → accept → sign in → RSVP → view page — is cheap and protects
+the one-shot weekend: real parents are a resource you can't re-run.
+
+## Security & Permissions
+
+No changes. The weekend exercises the existing boundaries as designed: owner-gated team
+creation, invitation-only accounts, `requireTeamAccess` inside every scoped loader and
+action, RSVP writes restricted to linked guardians. Any hole found is a finding, not a
+fix, for this issue.
+
+## Error Handling → Operational contingencies
+
+| Failure | Response |
+|---|---|
+| Invitation email in spam | Expected enough that the issue calls it out. Verify the Resend sending domain (SPF/DKIM) during pre-flight; if a real parent's invite lands in spam, telling them to check spam is allowed — it's not an RSVP reminder |
+| Parent can't sign in (magic link friction) | Help them; log it as a confusion finding. Fixing auth UX is legitimate follow-up work, not a violation of the experiment |
+| Chart edit trips a unique constraint in Studio | Null the colliding field first, then set. No app code involved |
+| Game postponed / rained out | The gate needs a real game; re-run the following weekend with the same seeded data. Do not close on a practice |
+| A text reminder slips out (spouse, assistant coach, team group chat) | The result is invalidated per the issue; record it honestly and re-run |
+
+## Testing Strategy → Measurement plan
+
+No code, no tests. The measurements, their instruments, and when they're taken:
+
+| Metric | Instrument | When |
+|---|---|---|
+| % players with an `Rsvp` row | `pnpm db:studio` (or the event page's own state map) | Game-day morning, before first pitch |
+| Game-day question texts | Coach's phone, tallied by hand | Game day |
+| Confusion reports | Anything parents say or ask, esp. about the three RSVP states | All weekend |
+| Email arrival / spam placement | Pre-flight dry run + asking one or two parents *after* game day | Pre-flight; post-game |
+
+## Config Changes
+
+- [ ] Schema / index changes — none
+- [ ] Access rule changes — none
+- [ ] Environment variables — none added; production values for `DATABASE_URL`,
+      `AUTH_SECRET`, `RESEND_API_KEY`, `EMAIL_FROM`, and the app URL must be verified
+      live in Vercel during pre-flight. `APP_TIMEZONE` defaults to `America/Chicago`
+- [ ] Dependency changes — none
+
+## Edge Cases & Risks
+
+| Scenario | Impact | Mitigation |
+|---|---|---|
+| Deliverability failure masquerades as apathy (emails unseen, not ignored) | High — wrong conclusion from the whole gate | Pre-flight dry run to a personal secondary address; post-game spot-check with 1–2 parents about whether the email arrived |
+| Event displays under the wrong day (UTC vs `America/Chicago`) | High — parents shown wrong date | Known gotcha; `calendar.ts` helpers handle it, but verify the created event's rendered date/time on the production site before announcing |
+| Hand-seeded chart contains an error (wrong kid at SS) | Med — parents' first impression is wrong data | Proofread `/t/[teamId]/view` on a phone against the paper chart before sending the announcement |
+| One-team sample over-read | Med | Decision 3 treats results as directional; two-game rule before the notification-redesign verdict |
+| Coach reflexively answers a "what time" text with the answer instead of a link | Low — but each one is a data point | Answering is fine (they're real parents); *tally it* — those texts are the metric, and answering by text is not an RSVP reminder |

--- a/.agents/issue-planner/9/proposal-doc.md
+++ b/.agents/issue-planner/9/proposal-doc.md
@@ -41,6 +41,9 @@ migration, or email delivery has ever been exercised end to end.
 6. Recorded: % of players with an RSVP before game day
 7. Recorded: count of "what time / where / is he playing" texts on game day
 8. Recorded: parent confusion, especially around the three RSVP states
+   — verified invariant: RSVP state never removes a player from the roster, lineup, or
+   diamond; declined and no-response players stay in place, and any chart change is the
+   coach's manual decision
 9. Findings written as a comment on #9
 10. Explicit decision: proceed to the chart editors, or fix notification design first
 

--- a/.agents/issue-planner/9/proposal-doc.md
+++ b/.agents/issue-planner/9/proposal-doc.md
@@ -1,0 +1,87 @@
+# Proposal — Phase 9: Validation gate — one real game weekend (#9)
+
+## Executive Summary
+
+Phases #1–#8 are all closed: auth, teams, roster, invitations, schedule, tri-state RSVP,
+and the read-only view page exist. Before building the expensive half of the milestone —
+both drag-and-drop editors, email messaging, PWA install — this issue runs the brief's
+cheapest test of the core assumption: **will parents RSVP in an app without being chased
+by text?** No code ships. The real team, roster, and weekend game are seeded through the
+production UI; the standing chart is hand-set via `pnpm db:studio` (the editors don't
+exist yet, deliberately); one announcement email goes out from the coach's personal
+account; then nobody sends a single text. Game-day morning, the RSVP table is
+snapshotted and the weekend's question-texts are tallied. The findings land as a comment
+on #9 with an explicit decision: proceed, re-run, or fix notification design first.
+
+The plan adds one thing the issue implies but doesn't spell out: a **production
+pre-flight dry run** with a throwaway team and a secondary email address, because real
+parents are a one-shot resource and nothing in the repo proves the production deploy,
+migration, or email delivery has ever been exercised end to end.
+
+## Scope
+
+### In Scope
+- Production pre-flight: deploy/env/migration verification and a full fake-parent walk-through
+- Seeding the real team, roster, guardians, invitations, game, and hand-set chart
+- One announcement email (personal email client — in-app broadcast is #13)
+- The no-text discipline, measurement, findings comment, and gate decision
+
+### Out of Scope
+- Any feature code, including "small" notification improvements (that's the *other* branch of the gate decision)
+- The under-5-minute lineup-editing target — unmeasurable until #11's editors exist
+- #10, #11, #13, #14 — all blocked on this gate's outcome
+
+## Acceptance Criteria
+
+1. Real team created and roster seeded through the UI
+2. Real parents invited; invitation arrival (and spam placement) confirmed
+3. `battingOrder` / `position` hand-set on `RosterEntry` via `pnpm db:studio`
+4. Weekend's real game on the schedule
+5. Exactly one announcement email sent; zero texts afterward
+6. Recorded: % of players with an RSVP before game day
+7. Recorded: count of "what time / where / is he playing" texts on game day
+8. Recorded: parent confusion, especially around the three RSVP states
+9. Findings written as a comment on #9
+10. Explicit decision: proceed to the chart editors, or fix notification design first
+
+## Implementation Phases
+
+| Phase | Description | Areas Affected |
+|---|---|---|
+| 1 | Production pre-flight dry run (fake parent, throwaway team) | Vercel env, Neon migration, Resend domain — no repo changes |
+| 2 | Seed real team, roster, invitations, game, hand-set chart | Production data only |
+| 3 | One announcement email, then hands off | — |
+| 4 | Game-day measurement (RSVP snapshot, text tally, confusion log) | — |
+| 5 | Findings comment on #9 + gate decision | GitHub issue |
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Email deliverability failure read as parent apathy | High | Pre-flight dry run to a secondary address; post-game spot-check with 1–2 parents |
+| Timezone bug shows the game under the wrong day in production | High | Verify rendered event time on the production site during pre-flight and after creating the real game |
+| Hand-seeded chart error is parents' first impression | Med | Proofread `/t/[teamId]/view` on a phone before announcing |
+| Unique-constraint collisions while editing in Studio | Low | Single-pass assignment; null-then-set for swaps |
+| A reminder text slips from spouse/assistant coach | Med — invalidates the result | Tell everyone with the chart about the rule; record violations honestly |
+| Rain-out | Low | Re-run next weekend with the same seeded data; the gate needs a real game |
+
+## Effort Estimate
+
+**Overall:** Small in effort, ~1 week in calendar time (dominated by waiting for the game).
+
+| Phase | Estimate |
+|---|---|
+| 1 — Pre-flight | 1–2 hours (plus fixes if the dry run finds deployment issues) |
+| 2 — Seeding | 1–2 hours |
+| 3 — Announcement | 15 minutes |
+| 4 — Measurement | 30 minutes across game day |
+| 5 — Findings + decision | 30–60 minutes |
+
+## Next Steps
+
+1. Review and approve this proposal.
+2. On approval, this proposal is posted as a comment on #9, and the coach executes
+   `task-doc.md` phase by phase against the real weekend.
+3. After the findings comment and a proceed decision, close #9 with the `finalize-issue`
+   skill (no PR to verify — archive `.agents/issue-planner/9/` and close the issue),
+   unblocking #10, #11, #13, #14.

--- a/.agents/issue-planner/9/task-doc.md
+++ b/.agents/issue-planner/9/task-doc.md
@@ -10,8 +10,10 @@ then a hands-off weekend.
 - [x] #1–#8 all closed (verified 2026-08-01)
 - [ ] Production deployment live on Vercel and reachable at its real URL
 - [x] Repo is deployable — verified 2026-08-01: `pnpm check` green (lint, typecheck,
-      491 tests across 44 files) and `pnpm build` succeeds with **no env vars set**,
-      confirming the lazy-config design. All 16 routes present
+      491 tests across 44 files) with no env vars set, and `pnpm exec next build`
+      succeeds with none either, confirming the lazy-config design keeps runtime
+      secrets out of the compile. All 16 routes present. Note `pnpm build` itself now
+      requires `DATABASE_URL` — it runs `prisma migrate deploy` first (see below)
 - [x] Production env vars confirmed in Vercel (screenshot, Production + Preview):
       `OWNER_EMAIL`, `DATABASE_URL`, `EMAIL_FROM`, `RESEND_API_KEY`
 - [ ] **`AUTH_SECRET` — verify it is set.** Not visible in the confirmed list. Auth.js

--- a/.agents/issue-planner/9/task-doc.md
+++ b/.agents/issue-planner/9/task-doc.md
@@ -1,0 +1,120 @@
+# Task Doc — Phase 9: Validation gate — one real game weekend (#9)
+
+No code ships in this issue. Every task below is operational, executed by the coach
+(Brian) against the production deployment. Phases are ordered by calendar: pre-flight
+early in the week, seeding by mid-week, the announcement once everything is verified,
+then a hands-off weekend.
+
+## Prerequisites
+
+- [x] #1–#8 all closed (verified 2026-08-01)
+- [ ] Production deployment live on Vercel and reachable at its real URL
+- [ ] Production env vars set in Vercel: `DATABASE_URL` (Neon), `AUTH_SECRET`,
+      `RESEND_API_KEY`, `EMAIL_FROM`, app URL / `APP_TIMEZONE` as applicable
+- [ ] Migration `prisma/migrations/20260728053521_001` applied to the production Neon
+      branch (`prisma migrate deploy` semantics, not a dev migration)
+- [ ] Resend sending domain verified (SPF/DKIM) so invitations don't start life in spam
+
+## Phase 1: Production pre-flight dry run (T-4 days or earlier)
+
+Use a personal secondary email address as a fake parent. Real parents are one-shot; this
+walk-through is the rehearsal.
+
+- [ ] Sign in as owner on the production site; confirm magic-link email arrives and works
+- [ ] Create a throwaway team via `/t/new`
+- [ ] Add a test player, link the secondary email as guardian, send the invitation
+- [ ] Confirm the invitation email arrives — note inbox vs spam placement
+- [ ] Accept via `/invite/[token]`, sign in as the fake parent, RSVP on the event page,
+      and load `/t/[teamId]/view` — the full path a real parent will walk
+- [ ] Create a test event; verify its rendered date/time is correct on the production
+      site (the `TZ=UTC` vs `America/Chicago` gotcha is invisible on a dev machine)
+- [ ] Delete the throwaway team (cascades take roster, events, RSVPs with it —
+      `onDelete: Cascade` throughout `prisma/schema.prisma`)
+- [ ] Fix anything broken before proceeding — deployment/config fixes are in scope;
+      feature code is not
+
+## Phase 2: Seed the real team (T-3 days)
+
+- [ ] Create the real team via `/t/new`
+- [ ] Seed the real roster with jersey numbers via `/t/[teamId]/roster`
+- [ ] Link each kid's real guardian email(s) and send invitations
+- [ ] Confirm with a light touch that invitations arrived (asking "did you get the
+      invite email?" is allowed — the no-reminder rule applies to the *game
+      announcement*, not to account setup)
+- [ ] Add the weekend's real game via `/t/[teamId]/schedule` (date, time, location,
+      opponent); verify its displayed date/time
+- [ ] Set `battingOrder` and `position` on each `RosterEntry` via `pnpm db:studio`
+      pointed at the **production** `DATABASE_URL`. Single pass, no swaps —
+      `@@unique([teamId, battingOrder])` and `@@unique([teamId, position])` will reject
+      collisions with a raw error. To swap later: null one side, save, then set both.
+      `C` = Catcher, `CF` = Center Field
+- [ ] Proofread `/t/[teamId]/view` on a phone against the intended chart: all nine
+      positions labeled and filled as expected, batting order correct, benched kids
+      shown as expected
+
+## Phase 3: Announce, then hands off (T-2 days)
+
+- [ ] Send **one** email from the coach's personal email client to all parents:
+      what the app is, the link to the game's event page
+      (`/t/[teamId]/schedule/[eventId]`), and a sentence asking them to RSVP their kid
+      (in-app broadcast is #13 and does not exist yet — see design doc, Decision 1)
+- [ ] From this moment: **no texts, no reminders, no nudges**, from anyone with the
+      chart — including spouse or assistant coaches. Tell them the rule
+- [ ] Answering an *incoming* parent question is fine — but every "what time / where /
+      is he playing" text gets tallied; those are the metric
+
+## Phase 4: Game-day measurement
+
+- [ ] Morning of the game, before first pitch: snapshot RSVPs via `pnpm db:studio` —
+      count players with an `Rsvp` row (attending **and** declined both count as
+      responses) over total rostered players
+- [ ] Tally every "what time / where / is he playing" text received on game day
+- [ ] Note every confusion report all weekend, especially anything about the three RSVP
+      states (attending / declined / no-response) on the view page
+
+## Phase 5: Findings and the gate decision
+
+- [ ] Write the findings as a comment on #9 (template below)
+- [ ] Decide explicitly, in the comment: **proceed to #10/#11**, or **run a second game
+      weekend**, or (only after two low-participation games) **fix notification design
+      before building more features**
+- [ ] Close #9 only alongside a proceed decision; a "second weekend" verdict keeps it open
+
+### Findings comment template
+
+```markdown
+## Validation weekend findings — [date]
+
+**Game:** [opponent, date, time]
+**Roster size:** [N players / N families]
+
+| Signal | Target | Actual |
+|---|---|---|
+| Players with an RSVP before game day | ≥ 70% | X of N (Y%) |
+| "what time / where / is he playing" texts on game day | → 0 | X |
+
+**RSVP breakdown:** X attending / X declined / X no response
+
+**Confusion observed:**
+- [what, from whom, about which screen]
+
+**Deliverability:** [invitations + any spot-check on whether the announcement was seen]
+
+**Protocol violations:** [none | what slipped]
+
+**Decision:** [Proceed to #10/#11 | Second game weekend | Fix notification design first]
+**Reasoning:** [1–3 sentences]
+```
+
+## Pre-Commit Gate
+
+Not applicable — no code ships in this issue. The only repo change is these planning
+docs; `pnpm check` (lint → typecheck → test) is unaffected by markdown under `.agents/`.
+
+## Files Modified / Created
+
+| File | Change |
+|---|---|
+| `.agents/issue-planner/9/design-doc.md` | Created — this plan |
+| `.agents/issue-planner/9/task-doc.md` | Created — this checklist |
+| `.agents/issue-planner/9/proposal-doc.md` | Created — proposal summary |

--- a/.agents/issue-planner/9/task-doc.md
+++ b/.agents/issue-planner/9/task-doc.md
@@ -51,6 +51,9 @@ walk-through is the rehearsal.
 - [ ] Proofread `/t/[teamId]/view` on a phone against the intended chart: all nine
       positions labeled and filled as expected, batting order correct, benched kids
       shown as expected
+- [ ] Verify the invariant: a player with no RSVP (or a declined one) still appears in
+      their batting slot and at their position — greyed/marked, never removed. RSVP
+      must never change the chart; only the coach does, by hand
 
 ## Phase 3: Announce, then hands off (T-2 days)
 
@@ -70,7 +73,11 @@ walk-through is the rehearsal.
       responses) over total rostered players
 - [ ] Tally every "what time / where / is he playing" text received on game day
 - [ ] Note every confusion report all weekend, especially anything about the three RSVP
-      states (attending / declined / no-response) on the view page
+      states (attending / declined / no-response) on the view page — in particular
+      whether anyone read a no-response or declined kid as removed from the lineup
+- [ ] If the chart gets patched during the weekend, that's a coach decision made by hand
+      in `db:studio` — record what changed and why in the findings (the edit is
+      permanent; there is no undo)
 
 ## Phase 5: Findings and the gate decision
 

--- a/.agents/issue-planner/9/task-doc.md
+++ b/.agents/issue-planner/9/task-doc.md
@@ -22,11 +22,15 @@ then a hands-off weekend.
       Only set it if the team is in another zone
 - [ ] No app URL variable needed: `absoluteUrl` falls back to Vercel's auto-provided
       `VERCEL_PROJECT_PRODUCTION_URL` when `AUTH_URL` is unset (`src/lib/absolute-url.ts:23-34`)
-- [ ] **Apply the migration to production.** `pnpm build` does *not* run migrations —
-      deliberately, so the build needs no secrets. Run it by hand, once:
-      `DATABASE_URL="<production-neon-url>" pnpm db:deploy`. Use `db:deploy`
-      (`prisma migrate deploy`), never `db:migrate` (`prisma migrate dev`), which can
-      prompt, create migrations, and reset the database
+- [x] **Migration applies automatically on deploy** — `pnpm build` is now
+      `prisma migrate deploy && next build`, so the next Vercel deploy brings the
+      production database up to date on its own. Verified end-to-end 2026-08-01 against
+      a local Postgres 16: all 14 tables created, re-run is a clean no-op, full build
+      green. A DB failure exits non-zero before `next build`, failing the deploy loudly
+- [ ] **Trigger a deploy and confirm the build log** shows
+      `Applying migration 20260728053521_001` (first deploy) or `No pending migrations
+      to apply` (subsequent). This is the moment the production schema is created —
+      if the build fails here, the database is unreachable, not the app broken
 - [ ] Resend sending domain verified (SPF/DKIM) so invitations don't start life in spam
 
 ## Phase 1: Production pre-flight dry run (T-4 days or earlier)

--- a/.agents/issue-planner/9/task-doc.md
+++ b/.agents/issue-planner/9/task-doc.md
@@ -16,10 +16,11 @@ then a hands-off weekend.
       requires `DATABASE_URL` — it runs `prisma migrate deploy` first (see below)
 - [x] Production env vars confirmed in Vercel (screenshot, Production + Preview):
       `OWNER_EMAIL`, `DATABASE_URL`, `EMAIL_FROM`, `RESEND_API_KEY`
-- [ ] **`AUTH_SECRET` — verify it is set.** Not visible in the confirmed list. Auth.js
+- [x] **`AUTH_SECRET` set in Vercel** — confirmed by the repo owner 2026-08-01. Auth.js
       reads it at `node_modules/next-auth/lib/env.js:22`
-      (`process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET`); without it sign-in
-      fails at runtime, not at build. Generate with `npx auth secret` if missing
+      (`process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET`); nothing checks it at
+      build time, so a missing value would have produced a green build and a broken
+      sign-in
 - [ ] `APP_TIMEZONE` — optional; defaults to `America/Chicago` (`src/lib/calendar.ts:73`).
       Only set it if the team is in another zone
 - [ ] No app URL variable needed: `absoluteUrl` falls back to Vercel's auto-provided

--- a/.agents/issue-planner/9/task-doc.md
+++ b/.agents/issue-planner/9/task-doc.md
@@ -9,10 +9,24 @@ then a hands-off weekend.
 
 - [x] #1–#8 all closed (verified 2026-08-01)
 - [ ] Production deployment live on Vercel and reachable at its real URL
-- [ ] Production env vars set in Vercel: `DATABASE_URL` (Neon), `AUTH_SECRET`,
-      `RESEND_API_KEY`, `EMAIL_FROM`, app URL / `APP_TIMEZONE` as applicable
-- [ ] Migration `prisma/migrations/20260728053521_001` applied to the production Neon
-      branch (`prisma migrate deploy` semantics, not a dev migration)
+- [x] Repo is deployable — verified 2026-08-01: `pnpm check` green (lint, typecheck,
+      491 tests across 44 files) and `pnpm build` succeeds with **no env vars set**,
+      confirming the lazy-config design. All 16 routes present
+- [x] Production env vars confirmed in Vercel (screenshot, Production + Preview):
+      `OWNER_EMAIL`, `DATABASE_URL`, `EMAIL_FROM`, `RESEND_API_KEY`
+- [ ] **`AUTH_SECRET` — verify it is set.** Not visible in the confirmed list. Auth.js
+      reads it at `node_modules/next-auth/lib/env.js:22`
+      (`process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET`); without it sign-in
+      fails at runtime, not at build. Generate with `npx auth secret` if missing
+- [ ] `APP_TIMEZONE` — optional; defaults to `America/Chicago` (`src/lib/calendar.ts:73`).
+      Only set it if the team is in another zone
+- [ ] No app URL variable needed: `absoluteUrl` falls back to Vercel's auto-provided
+      `VERCEL_PROJECT_PRODUCTION_URL` when `AUTH_URL` is unset (`src/lib/absolute-url.ts:23-34`)
+- [ ] **Apply the migration to production.** `pnpm build` does *not* run migrations —
+      deliberately, so the build needs no secrets. Run it by hand, once:
+      `DATABASE_URL="<production-neon-url>" pnpm db:deploy`. Use `db:deploy`
+      (`prisma migrate deploy`), never `db:migrate` (`prisma migrate dev`), which can
+      prompt, create migrations, and reset the database
 - [ ] Resend sending domain verified (SPF/DKIM) so invitations don't start life in spam
 
 ## Phase 1: Production pre-flight dry run (T-4 days or earlier)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,14 +155,21 @@ tables). Creating further migrations needs a live Postgres URL: a Neon dev branc
 `prisma dev`, which provisions Prisma Postgres, a different service than Decision 3's
 choice.
 
-**Deploying is a separate, manual step.** `pnpm build` is `next build` alone — it does not
-apply migrations, deliberately, so the build never requires `DATABASE_URL` (the same reason
-`src/lib/db.ts` and `src/auth.ts` defer their secrets). Applying the schema to a real
-database is therefore something a human runs on purpose:
+**Migrations apply automatically on deploy.** `pnpm build` is
+`prisma migrate deploy && next build`, so every Vercel deploy brings the database up to
+date before the app ships. Re-running is a no-op once migrations are applied, and a
+failure exits non-zero *before* `next build` runs — a database problem fails the deploy
+loudly instead of shipping an app that crashes on its first query.
 
-```bash
-DATABASE_URL="<production-url>" pnpm db:deploy
-```
+The cost is deliberate: **`pnpm build` now requires `DATABASE_URL`**, unlike
+`src/lib/db.ts` and `src/auth.ts`, which still defer their secrets to request time. A bare
+checkout with no `.env` cannot `pnpm build` — run `pnpm check` (lint → typecheck → test),
+which needs no database, or use `pnpm exec next build` to skip the migration step.
+
+Because Preview and Production share one `DATABASE_URL`, **a preview deploy applies
+migrations to the production database.** With one operator and a schema that already
+covers every planned feature this is acceptable, but if branch-level schema work ever
+starts, guard the migrate step on `VERCEL_ENV=production` first.
 
 Use `db:deploy` (`prisma migrate deploy`), never `db:migrate` (`prisma migrate dev`) against
 production — the dev command can prompt, generate new migrations, and reset the database.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ team creation.
 | Tests (watch) | `pnpm test:watch` |
 | **All checks** | `pnpm check` |
 | Regenerate Prisma client | `pnpm db:generate` |
-| Create + apply a migration | `pnpm db:migrate` |
+| Create + apply a migration (dev only) | `pnpm db:migrate` |
+| Apply existing migrations (production) | `pnpm db:deploy` |
 | Browse data | `pnpm db:studio` |
 
 `pnpm check` runs lint → typecheck → test and is what to run before reporting work done.
@@ -149,10 +150,22 @@ pnpm db:generate     # required — the client is gitignored
 Copy `.env.example` to `.env` and fill it in — it documents every variable and where its
 name comes from. `DATABASE_URL` and `AUTH_SECRET` are the two needed to boot.
 
-**No migrations exist yet.** The schema validates and generates but has never been applied
-to a real database, so `pnpm db:migrate` is documented and unproven. The first run needs a
-live Postgres URL — a Neon dev branch (not `prisma dev`, which provisions Prisma Postgres,
-a different service than Decision 3's choice) — and will create the initial migration.
+**One migration exists** — `prisma/migrations/20260728053521_001`, the initial schema (14
+tables). Creating further migrations needs a live Postgres URL: a Neon dev branch, not
+`prisma dev`, which provisions Prisma Postgres, a different service than Decision 3's
+choice.
+
+**Deploying is a separate, manual step.** `pnpm build` is `next build` alone — it does not
+apply migrations, deliberately, so the build never requires `DATABASE_URL` (the same reason
+`src/lib/db.ts` and `src/auth.ts` defer their secrets). Applying the schema to a real
+database is therefore something a human runs on purpose:
+
+```bash
+DATABASE_URL="<production-url>" pnpm db:deploy
+```
+
+Use `db:deploy` (`prisma migrate deploy`), never `db:migrate` (`prisma migrate dev`) against
+production — the dev command can prompt, generate new migrations, and reset the database.
 
 ## Gotchas & Notes
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Requires **Node 22** and **pnpm 10**.
 pnpm install
 cp .env.example .env     # then fill in DATABASE_URL and AUTH_SECRET
 pnpm db:generate         # required — the Prisma client is gitignored
-pnpm db:migrate          # creates the first migration; needs a live database
+pnpm db:deploy           # applies the existing migrations; needs a live database
 pnpm dev
 ```
 
 Open http://localhost:3000.
 
-You need a Postgres database before `db:migrate` or `dev` will work. Point `DATABASE_URL`
+You need a Postgres database before `db:deploy` or `dev` will work. Point `DATABASE_URL`
 at a [Neon](https://neon.tech) dev branch — not Prisma Postgres (`prisma dev`), which is a
 different service than the one this project is built on (see Decision 3). See
 `.env.example` for every variable and what it's for.
@@ -105,14 +105,16 @@ different service than the one this project is built on (see Decision 3). See
 | Purpose | Command |
 |---|---|
 | Dev server | `pnpm dev` |
-| Production build | `pnpm build` |
+| Production build (applies migrations — needs `DATABASE_URL`) | `pnpm build` |
+| Build without touching the database | `pnpm exec next build` |
 | Lint | `pnpm lint` |
 | Type check | `pnpm typecheck` |
 | Tests | `pnpm test` |
 | Tests (watch) | `pnpm test:watch` |
 | **Everything** | `pnpm check` |
 | Regenerate Prisma client | `pnpm db:generate` |
-| Create + apply a migration | `pnpm db:migrate` |
+| Create a new migration (dev only) | `pnpm db:migrate` |
+| Apply existing migrations (production) | `pnpm db:deploy` |
 | Browse data | `pnpm db:studio` |
 
 Run `pnpm check` before pushing — it chains lint, typecheck, and tests.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma migrate deploy && next build",
     "postinstall": "prisma generate",
     "start": "next start",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check": "pnpm lint && pnpm typecheck && pnpm test",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
+    "db:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Plans #9 (the validation-gate weekend) into design/task/proposal docs, and fixes the one
thing that actually blocked it: **the production database had no safe path to being
migrated.** `pnpm build` was `next build` alone, and the only migration script was
`db:migrate` — that's `prisma migrate dev`, which can prompt, generate new migrations, and
reset the database. Pointing it at production would have been destructive.

`build` is now `prisma migrate deploy && next build`, so every Vercel deploy brings the
database up to date before the app ships. Relates to #9 — **this PR does not close it.**
#9's deliverable is a real game weekend that hasn't happened yet; this is its pre-flight.

## Key Decisions

**Migrations run in the build rather than by hand.** The alternative was keeping `build`
pure and running `pnpm db:deploy` manually before each deploy. Automatic won because there
is one operator and no CI, so a manual step is a step that eventually gets skipped. The
deliberate cost — documented in `AGENTS.md` — is that **`pnpm build` now requires
`DATABASE_URL`**, unlike `src/lib/db.ts` and `src/auth.ts`, which still defer their secrets
to request time. `pnpm check` needs no database, so day-to-day work is unaffected.

**A migrate failure fails the deploy.** `prisma migrate deploy` exits non-zero before
`next build` runs, so a database problem breaks the build loudly instead of shipping an app
that crashes on its first query. Vercel doesn't promote a failed build, so the current
deployment stays up.

**Preview deploys migrate the production database.** Preview and Production share one
`DATABASE_URL`, so this was already true of the running app's reads and writes — the
migrate step doesn't create a new category of risk. Acceptable with one operator and a
schema that already covers every planned feature through #14. Noted in `AGENTS.md`: if
branch-level schema work ever starts, guard the migrate step on `VERCEL_ENV=production`.

**RSVP never changes the chart** is written into the plan as a verifiable invariant, at the
repo owner's direction. A player who hasn't responded, or who declined, stays in their
batting slot and at their position; removal is the coach's manual decision alone. This is
already how `src/lib/rsvp.ts` and the #8 view page behave — the weekend confirms it holds
in production and that parents read it that way.

## What's in Scope

- `.agents/issue-planner/9/` — design, task, and proposal docs for the validation weekend
- `build` → `prisma migrate deploy && next build`
- New `db:deploy` script (`prisma migrate deploy`) for applying migrations from a terminal
- `AGENTS.md`: commands table gains `db:deploy`, `db:migrate` marked dev-only, and the
  deploy/migration section rewritten
- `README.md`: setup used `db:migrate` to "create the first migration" — that migration has
  existed since Jul 28. Setup now uses `db:deploy`, and the commands table distinguishes
  creating a migration (dev) from applying one (production)
- `AGENTS.md` correction: the "No migrations exist yet" note was stale for the same reason

### Out of Scope

- Any app code. The deployed application is byte-identical to `main`
- The validation weekend itself — operational work in #9, executed at a ballpark
- #10, #11, #13, #14, all blocked on #9's outcome

## Bugs Found and Fixed During Self-Review

- **Contradictory build claims in `task-doc.md`** (caught by Copilot review): the
  prerequisites asserted `pnpm build` succeeds with no env vars — true when written, but
  invalidated two commits later when `build` gained the migrate step. The same file then
  correctly documented the new behavior eight lines below. Fixed in 18b4696 to
  `pnpm exec next build`, and re-verified with no env vars set
- The same stale claim was then found in `README.md` and fixed in 3d77fef

## Known Gaps / Follow-ups

- **Migrations were verified against local Postgres 16, not Neon.** Neon's pooled connection
  can interfere with the advisory lock Prisma takes during migration; if the deploy hangs at
  the migrate step, the fix is to point `DATABASE_URL` at Neon's direct/unpooled connection
- Email deliverability and the Resend sending domain (SPF/DKIM) are unverified — that's the
  first task of the #9 pre-flight dry run
- ~~`AUTH_SECRET` is unverified~~ — confirmed set in Vercel by the repo owner, 2026-08-01

## Test Plan

- [x] `pnpm check` — lint, typecheck, 491 tests across 44 files, green with **no**
      `DATABASE_URL` set
- [x] `pnpm exec next build` succeeds with no env vars set — runtime secrets stay out of
      the compile
- [x] `pnpm build` succeeds end to end with a database reachable
- [x] Migration applies cleanly to an empty Postgres 16 database — all 14 application
      tables plus `_prisma_migrations` created:

      createdb baseball_test
      DATABASE_URL="postgresql://...localhost/baseball_test" pnpm db:deploy
      # → Applying migration `20260728053521_001` … successfully applied
      psql "$DATABASE_URL" -c "\dt"

- [x] **Re-running is a clean no-op** — `No pending migrations to apply.` This is what
      every deploy after the first will do
- [x] **Failure mode**: with `DATABASE_URL` unset, `pnpm build` exits 1 with
      `The datasource.url property is required…` and `next build` never runs
- [ ] Reviewer: after merge, confirm the Vercel build log shows
      `Applying migration 20260728053521_001` on the first deploy, or
      `No pending migrations to apply` if the schema was applied by hand beforehand