### PR TITLE
Draw allPlay outfielders on the diamond, and drop the catcher

### DIFF
--- a/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
@@ -91,9 +91,10 @@ Scoped to fit **6 weeks of evenings and weekends**.
 - **Positions** — drag players onto a labeled diamond, likewise **standing** and likewise
   permanent (no inning rotation, no per-game chart). The nine standard defensive
   positions: **P, C, 1B, 2B, 3B, SS, LF, CF, RF** — `C` is Catcher, `CF` is Center Field.
-  `allPlay = true` → one kid per infield position (P, C, 1B, 2B, 3B, SS), outfield holds
-  all remaining players. `allPlay = false` → one kid per position, remainder sit in a
-  Bench/Dugout zone. Cancel / Save.
+  `allPlay = true` → one kid per infield position **except catcher** (P, 1B, 2B, 3B, SS),
+  outfield holds all remaining players; at this level the coach pitches and nobody plays
+  behind the plate, so C is not a spot that can be filled. `allPlay = false` → one kid per
+  position, remainder sit in a Bench/Dugout zone. Cancel / Save.
 - **Next-game readiness** — the one place attendance meets the chart. For the team's
   **next game only** — not practices, not later games — the app shows who's out and which
   positions that leaves uncovered. It never rearranges the chart on the coach's behalf;

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
@@ -66,6 +66,30 @@ describe("PositionsEditor", () => {
     expect(screen.queryByRole("region", { name: "Bench" })).not.toBeInTheDocument();
   });
 
+  it("marks the catcher's empty spot with a filled circle under allPlay", () => {
+    // Not a drop target and not an "Open" marker — a solid disc, so the coach
+    // reads "no catcher at this level" rather than "a target failed to render".
+    render(
+      <PositionsEditor teamId="team-1" allPlay={true} entries={[entry("a")]} />,
+    );
+
+    const field = screen.getByRole("region", { name: "Diamond" });
+    expect(field.querySelector("circle")).toHaveClass(
+      "fill-muted-foreground/30",
+    );
+    expect(field).toHaveTextContent("the coach pitches");
+  });
+
+  it("draws no such circle when the catcher is a real spot", () => {
+    render(
+      <PositionsEditor teamId="team-1" allPlay={false} entries={[entry("a")]} />,
+    );
+
+    const field = screen.getByRole("region", { name: "Diamond" });
+    expect(field.querySelector("circle")).toBeNull();
+    expect(field).toHaveTextContent("C");
+  });
+
   it("puts the zone above the diamond", () => {
     // The zone is where every player starts and where the coach's thumb comes
     // back between drags; below a 400x520 board it is off the bottom of a

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
@@ -39,7 +39,7 @@ beforeEach(() => {
 });
 
 describe("PositionsEditor", () => {
-  it("renders six infield targets and an Outfield zone when allPlay is true", () => {
+  it("renders five infield targets and an Outfield zone when allPlay is true", () => {
     render(
       <PositionsEditor
         teamId="team-1"
@@ -49,17 +49,41 @@ describe("PositionsEditor", () => {
     );
 
     const field = screen.getByRole("region", { name: "Diamond" });
-    // P, C, 1B, 2B, 3B, SS — the outfield is one zone, not three spots.
-    for (const label of ["P", "C", "1B", "2B", "3B", "SS"]) {
+    // P, 1B, 2B, 3B, SS — the outfield is one zone, not three spots, and an
+    // allPlay team has no catcher because the coach pitches.
+    for (const label of ["P", "1B", "2B", "3B", "SS"]) {
       expect(field).toHaveTextContent(label);
     }
     expect(field).not.toHaveTextContent("LF");
     expect(field).not.toHaveTextContent("RF");
+    expect(
+      field.querySelector('[data-position="CATCHER"]'),
+    ).not.toBeInTheDocument();
 
     const zone = screen.getByRole("region", { name: "Outfield" });
     expect(zone).toHaveTextContent("Player-b");
     expect(zone).toHaveTextContent("Player-c");
     expect(screen.queryByRole("region", { name: "Bench" })).not.toBeInTheDocument();
+  });
+
+  it("puts the zone above the diamond", () => {
+    // The zone is where every player starts and where the coach's thumb comes
+    // back between drags; below a 400x520 board it is off the bottom of a
+    // phone. DOCUMENT_POSITION_FOLLOWING = the diamond comes after the zone.
+    render(
+      <PositionsEditor
+        teamId="team-1"
+        allPlay={true}
+        entries={[entry("a", "PITCHER"), entry("b")]}
+      />,
+    );
+
+    const zone = screen.getByRole("region", { name: "Outfield" });
+    const field = screen.getByRole("region", { name: "Diamond" });
+
+    expect(zone.compareDocumentPosition(field)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
 
   it("renders all nine targets and a Bench zone when allPlay is false", () => {
@@ -168,8 +192,8 @@ describe("PositionsEditor", () => {
       />,
     );
 
-    // Six infield spots, one filled.
-    expect(screen.getAllByText("Open")).toHaveLength(5);
+    // Five infield spots, one filled.
+    expect(screen.getAllByText("Open")).toHaveLength(4);
   });
 
   it("shows only first names on the diamond and full names in the zone", () => {
@@ -199,7 +223,7 @@ describe("PositionsEditor", () => {
       <PositionsEditor
         teamId="team-1"
         allPlay={true}
-        entries={[entry("a", "PITCHER"), entry("b", "CATCHER"), entry("c")]}
+        entries={[entry("a", "PITCHER"), entry("b", "SHORTSTOP"), entry("c")]}
       />,
     );
 
@@ -214,7 +238,7 @@ describe("PositionsEditor", () => {
     ).toBe("team-1");
     // Only the diamond is posted; the zone is everyone else, and the server
     // nulls them in phase 1 of the write.
-    expect(payloadOf()).toEqual({ PITCHER: "a", CATCHER: "b" });
+    expect(payloadOf()).toEqual({ PITCHER: "a", SHORTSTOP: "b" });
   });
 
   it("gives every player a keyboard drag handle", () => {

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
@@ -22,9 +22,12 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   DIAMOND_GEOMETRY,
   DIAMOND_POLYGON,
-  diamondHeight,
   positionPercent,
 } from "@/components/diamond-geometry";
+import {
+  NO_CATCHER_TEXT,
+  NoCatcherMarker,
+} from "@/components/NoCatcherMarker";
 import { Button } from "@/components/ui/button";
 import type { Position } from "@/generated/prisma/enums";
 import {
@@ -233,22 +236,21 @@ function Field({
   draft: PositionsDraft;
   byId: Map<string, PositionsEditorEntry>;
 }) {
-  // An allPlay board has no catcher, so the band below home plate that holds
-  // one is dead space. `positionPercent` has to be told the same thing, or
-  // every target lands at the wrong depth inside the box.
-  const withCatcher = draft.positions.includes("CATCHER");
-  const height = diamondHeight(withCatcher);
+  // An allPlay board has no catcher. The spot is still drawn — as the disc
+  // that says nobody plays it — so the coach isn't left wondering whether the
+  // target failed to render.
+  const noCatcher = !draft.positions.includes("CATCHER");
 
   return (
     <section aria-label="Diamond">
       <div
         className="relative mx-auto w-full max-w-sm"
         style={{
-          aspectRatio: `${DIAMOND_GEOMETRY.width} / ${height}`,
+          aspectRatio: `${DIAMOND_GEOMETRY.width} / ${DIAMOND_GEOMETRY.height}`,
         }}
       >
         <svg
-          viewBox={`0 0 ${DIAMOND_GEOMETRY.width} ${height}`}
+          viewBox={`0 0 ${DIAMOND_GEOMETRY.width} ${DIAMOND_GEOMETRY.height}`}
           aria-hidden="true"
           focusable="false"
           className="absolute inset-0 h-full w-full"
@@ -258,13 +260,15 @@ function Field({
             className="fill-none stroke-border"
             strokeWidth={2}
           />
+          {noCatcher ? <NoCatcherMarker /> : null}
         </svg>
+
+        {noCatcher ? <p className="sr-only">{NO_CATCHER_TEXT}</p> : null}
 
         {draft.positions.map((position) => (
           <PositionTarget
             key={position}
             position={position}
-            withCatcher={withCatcher}
             entry={
               draft.assigned[position] !== undefined
                 ? byId.get(draft.assigned[position])
@@ -279,15 +283,13 @@ function Field({
 
 function PositionTarget({
   position,
-  withCatcher,
   entry,
 }: {
   position: Position;
-  withCatcher: boolean;
   entry: PositionsEditorEntry | undefined;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: position });
-  const { x, y } = positionPercent(position, withCatcher);
+  const { x, y } = positionPercent(position);
 
   return (
     <div

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
@@ -22,6 +22,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   DIAMOND_GEOMETRY,
   DIAMOND_POLYGON,
+  diamondHeight,
   positionPercent,
 } from "@/components/diamond-geometry";
 import { Button } from "@/components/ui/button";
@@ -175,8 +176,12 @@ export function PositionsEditor({
       onDragEnd={handleDragEnd}
     >
       <div className="space-y-6">
-        <Field draft={draft} byId={byId} />
+        {/* Zone above the diamond, deliberately. It is where every player
+            starts and where the coach's thumb returns between drags, so on a
+            phone it belongs above the fold rather than below a 400x520 board
+            the coach has to scroll past to reach it. */}
         <Zone draft={draft} byId={byId} allPlay={allPlay} />
+        <Field draft={draft} byId={byId} />
 
         <form
           action={savePositionsAction}
@@ -228,16 +233,22 @@ function Field({
   draft: PositionsDraft;
   byId: Map<string, PositionsEditorEntry>;
 }) {
+  // An allPlay board has no catcher, so the band below home plate that holds
+  // one is dead space. `positionPercent` has to be told the same thing, or
+  // every target lands at the wrong depth inside the box.
+  const withCatcher = draft.positions.includes("CATCHER");
+  const height = diamondHeight(withCatcher);
+
   return (
     <section aria-label="Diamond">
       <div
         className="relative mx-auto w-full max-w-sm"
         style={{
-          aspectRatio: `${DIAMOND_GEOMETRY.width} / ${DIAMOND_GEOMETRY.height}`,
+          aspectRatio: `${DIAMOND_GEOMETRY.width} / ${height}`,
         }}
       >
         <svg
-          viewBox={`0 0 ${DIAMOND_GEOMETRY.width} ${DIAMOND_GEOMETRY.height}`}
+          viewBox={`0 0 ${DIAMOND_GEOMETRY.width} ${height}`}
           aria-hidden="true"
           focusable="false"
           className="absolute inset-0 h-full w-full"
@@ -253,6 +264,7 @@ function Field({
           <PositionTarget
             key={position}
             position={position}
+            withCatcher={withCatcher}
             entry={
               draft.assigned[position] !== undefined
                 ? byId.get(draft.assigned[position])
@@ -267,17 +279,20 @@ function Field({
 
 function PositionTarget({
   position,
+  withCatcher,
   entry,
 }: {
   position: Position;
+  withCatcher: boolean;
   entry: PositionsEditorEntry | undefined;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: position });
-  const { x, y } = positionPercent(position);
+  const { x, y } = positionPercent(position, withCatcher);
 
   return (
     <div
       ref={setNodeRef}
+      data-position={position}
       style={{ left: `${x}%`, top: `${y}%` }}
       className={`absolute flex w-20 -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1 rounded-md border p-1 text-center ${
         isOver ? "border-ring bg-muted/60" : "border-dashed border-border"

--- a/src/app/t/[teamId]/chart/positions/actions.test.ts
+++ b/src/app/t/[teamId]/chart/positions/actions.test.ts
@@ -211,12 +211,12 @@ describe("savePositionsAction", () => {
 
   it("refuses a save when another coach moved someone since the page loaded", async () => {
     // Two coaches, two phones, one field. This one loaded an empty diamond and
-    // is placing "a" at pitcher; the other has since put "b" at catcher. The
+    // is placing "a" at pitcher; the other has since put "b" at shortstop. The
     // write nulls every position and rewrites, so going through would erase
-    // catcher with no error and no history to recover it.
+    // shortstop with no error and no history to recover it.
     getChart.mockResolvedValue([
       chartEntry("a"),
-      { ...chartEntry("b"), position: "CATCHER" },
+      { ...chartEntry("b"), position: "SHORTSTOP" },
       chartEntry("c"),
     ]);
 
@@ -232,10 +232,10 @@ describe("savePositionsAction", () => {
 
   it("allows the save once the baseline matches what is stored", async () => {
     // Same board as above — the coach reloaded, so their baseline now includes
-    // the other coach's catcher and the save is no longer blind.
+    // the other coach's shortstop and the save is no longer blind.
     getChart.mockResolvedValue([
       chartEntry("a"),
-      { ...chartEntry("b"), position: "CATCHER" },
+      { ...chartEntry("b"), position: "SHORTSTOP" },
       chartEntry("c"),
     ]);
 
@@ -243,15 +243,15 @@ describe("savePositionsAction", () => {
       savePositionsAction(
         form({
           teamId: "team-1",
-          positions: '{"PITCHER":"a","CATCHER":"b"}',
-          baseline: '{"CATCHER":"b"}',
+          positions: '{"PITCHER":"a","SHORTSTOP":"b"}',
+          baseline: '{"SHORTSTOP":"b"}',
         }),
       ),
     );
 
     expect(savePositions).toHaveBeenCalledWith("team-1", [
       { entryId: "a", position: "PITCHER" },
-      { entryId: "b", position: "CATCHER" },
+      { entryId: "b", position: "SHORTSTOP" },
     ]);
   });
 
@@ -321,7 +321,7 @@ describe("savePositionsAction", () => {
   it("rejects the same player standing at two positions", async () => {
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a","CATCHER":"a"}' }),
+        form({ teamId: "team-1", positions: '{"PITCHER":"a","SHORTSTOP":"a"}' }),
       ),
     );
 

--- a/src/app/t/[teamId]/view/Diamond.test.tsx
+++ b/src/app/t/[teamId]/view/Diamond.test.tsx
@@ -3,8 +3,23 @@ import { describe, it, expect } from "vitest";
 import {
   DIAMOND_GEOMETRY,
   POSITION_COORDS,
+  outfieldZoneCoords,
 } from "@/components/diamond-geometry";
-import { ALL_POSITIONS } from "@/lib/positions";
+import {
+  ALL_PLAY_INFIELD_POSITIONS,
+  ALL_POSITIONS,
+  OUTFIELD_POSITIONS,
+} from "@/lib/positions";
+
+/// Big enough to cover any youth roster, and then some.
+const ZONE_SIZES = Array.from({ length: 12 }, (_, index) => index + 1);
+
+function apart(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
 
 /// Layout invariants for the diamond. These failures are otherwise silent:
 /// an SVG child drawn outside the viewBox is simply clipped, and two markers
@@ -65,5 +80,42 @@ describe("diamond geometry", () => {
         expect(a.y + tagOffset).toBeLessThan(b.y - markerRadius);
       }
     }
+  });
+
+  it("never overlaps two markers in the outfield zone", () => {
+    for (const count of ZONE_SIZES) {
+      const coords = outfieldZoneCoords(count);
+      for (let i = 0; i < coords.length; i++) {
+        for (let j = i + 1; j < coords.length; j++) {
+          expect(apart(coords[i], coords[j])).toBeGreaterThan(markerRadius * 2);
+        }
+      }
+    }
+  });
+
+  it("never overlaps an outfield zone marker with an infield one", () => {
+    for (const count of ZONE_SIZES) {
+      for (const coord of outfieldZoneCoords(count)) {
+        for (const position of ALL_PLAY_INFIELD_POSITIONS) {
+          expect(apart(coord, POSITION_COORDS[position])).toBeGreaterThan(
+            markerRadius * 2,
+          );
+        }
+      }
+    }
+  });
+
+  it("puts the zone exactly on LF/CF/RF, so nothing may ever draw both", () => {
+    // The coincidence is deliberate — three outfielders should read as the
+    // standard diamond. It also means a board drawing a named outfield marker
+    // AND a zone would stack two markers on one spot, with both names
+    // unreadable and neither an error. `buildChartView` is what makes that
+    // unreachable: under allPlay it pools anyone stored at a named outfield
+    // spot, so `byPosition` cannot hold one while `outfield` is non-empty.
+    expect(outfieldZoneCoords(3)).toEqual(
+      OUTFIELD_POSITIONS.map((position) => POSITION_COORDS[position]).sort(
+        (a, b) => a.x - b.x,
+      ),
+    );
   });
 });

--- a/src/app/t/[teamId]/view/Diamond.tsx
+++ b/src/app/t/[teamId]/view/Diamond.tsx
@@ -2,13 +2,16 @@ import {
   DIAMOND_GEOMETRY,
   DIAMOND_POLYGON,
   POSITION_COORDS,
+  diamondHeight,
+  outfieldZoneCoords,
 } from "@/components/diamond-geometry";
 import { RSVP_STYLE } from "@/components/rsvp-style";
 import type { Position } from "@/generated/prisma/enums";
 import type { ChartViewPlayer } from "@/lib/chart-view";
 import {
-  INFIELD_POSITIONS,
-  OUTFIELD_POSITIONS,
+  ALL_PLAY_INFIELD_POSITIONS,
+  ALL_POSITIONS,
+  OUTFIELD_ZONE_LABEL,
   POSITION_LABELS,
 } from "@/lib/positions";
 
@@ -19,7 +22,6 @@ import {
 const MARKER_RADIUS = DIAMOND_GEOMETRY.markerRadius;
 const NAME_OFFSET = DIAMOND_GEOMETRY.nameOffset;
 const TAG_OFFSET = DIAMOND_GEOMETRY.tagOffset;
-const VIEWBOX_HEIGHT = DIAMOND_GEOMETRY.height;
 
 /// Only the first name goes on the diamond. Markers sit as little as 60px
 /// apart, so a full name overruns its neighbour; the batting order list
@@ -29,14 +31,21 @@ function shortName(name: string): string {
   return name.trim().split(/\s+/)[0] || name;
 }
 
-function PositionMarker({
-  position,
+/// One circle on the grass: an abbreviation inside, the player's first name
+/// under it, their RSVP state under that. Takes coordinates and a label rather
+/// than a `Position`, because the allPlay outfield draws the same marker for
+/// players who hold no position at all.
+function Marker({
+  x,
+  y,
+  label,
   player,
 }: {
-  position: Position;
+  x: number;
+  y: number;
+  label: string;
   player: ChartViewPlayer | undefined;
 }) {
-  const { x, y } = POSITION_COORDS[position];
   const style = player ? RSVP_STYLE[player.rsvpState] : null;
 
   return (
@@ -55,7 +64,7 @@ function PositionMarker({
         dy={4}
         className="fill-foreground text-[11px] font-bold"
       >
-        {POSITION_LABELS[position]}
+        {label}
       </text>
 
       <text
@@ -86,24 +95,31 @@ function PositionMarker({
 }
 
 /**
- * On an allPlay team the outfield is one zone rather than three named spots,
- * so everyone not on the infield stands out there and persists as
- * `position = null` (#11, Decision 1). Drawing LF/CF/RF as "Open" would be
- * doubly wrong for those teams: the spots aren't open, and the kids filling
- * them would be missing from the diamond entirely — which is the one thing a
- * parent opens this page to see.
+ * Which named spots the diamond draws.
  *
- * A stale named-outfield row (hand-set during #9, or left over from before
- * allPlay was switched on) still draws its marker, so nothing silently
+ * An allPlay team fields neither a catcher nor three named outfielders: the
+ * coach pitches, and the outfield is one zone holding everyone the infield
+ * leaves over, persisting as `position = null` (#11, Decision 1). Drawing C or
+ * LF/CF/RF as "Open" would be doubly wrong for those teams — the spots aren't
+ * open, they don't exist, and the kids playing out there would be missing from
+ * the diamond entirely, which is the one thing a parent opens this page to see.
+ * `Diamond` draws them from the `outfield` prop instead.
+ *
+ * A stale row on one of those positions (hand-set during #9, or left over from
+ * before allPlay was switched on) still draws its marker, so nothing silently
  * vanishes before the coach's next save collapses it.
  */
-function outfieldPositionsToDraw(
+function positionsToDraw(
   allPlay: boolean,
   byPosition: Map<Position, ChartViewPlayer>,
 ): readonly Position[] {
-  return allPlay
-    ? OUTFIELD_POSITIONS.filter((position) => byPosition.has(position))
-    : OUTFIELD_POSITIONS;
+  if (!allPlay) {
+    return ALL_POSITIONS;
+  }
+  return ALL_POSITIONS.filter(
+    (position) =>
+      ALL_PLAY_INFIELD_POSITIONS.includes(position) || byPosition.has(position),
+  );
 }
 
 export function Diamond({
@@ -113,15 +129,17 @@ export function Diamond({
 }: {
   byPosition: Map<Position, ChartViewPlayer>;
   allPlay: boolean;
-  /// Players with no position. Rendered as the outfield zone on an allPlay
-  /// team, and ignored otherwise — a benched player belongs in neither.
+  /// Players with no position. Drawn as the outfield zone on an allPlay team,
+  /// and ignored otherwise — a benched player belongs on neither.
   outfield?: readonly ChartViewPlayer[];
 }) {
-  const drawn = [
-    ...INFIELD_POSITIONS,
-    ...outfieldPositionsToDraw(allPlay, byPosition),
-  ];
+  const drawn = positionsToDraw(allPlay, byPosition);
   const zone = allPlay ? outfield : [];
+  const zoneCoords = outfieldZoneCoords(zone.length);
+
+  // Keyed on the marker, not on allPlay: a stale CATCHER row still draws one at
+  // y=452 and still needs the taller box, or its name clips off the bottom.
+  const height = diamondHeight(drawn.includes("CATCHER"));
 
   return (
     <>
@@ -129,7 +147,7 @@ export function Diamond({
           SVG's aria-label and nothing inside it, so the assignments would
           otherwise be unreachable without sight. */}
       <svg
-        viewBox={`0 0 400 ${VIEWBOX_HEIGHT}`}
+        viewBox={`0 0 ${DIAMOND_GEOMETRY.width} ${height}`}
         aria-hidden="true"
         focusable="false"
         className="mx-auto w-full max-w-sm"
@@ -140,38 +158,29 @@ export function Diamond({
           strokeWidth={2}
         />
 
-        {drawn.map((position) => (
-          <PositionMarker
-            key={position}
-            position={position}
-            player={byPosition.get(position)}
+        {drawn.map((position) => {
+          const { x, y } = POSITION_COORDS[position];
+          return (
+            <Marker
+              key={position}
+              x={x}
+              y={y}
+              label={POSITION_LABELS[position]}
+              player={byPosition.get(position)}
+            />
+          );
+        })}
+
+        {zone.map((player, index) => (
+          <Marker
+            key={player.playerId}
+            x={zoneCoords[index].x}
+            y={zoneCoords[index].y}
+            label={OUTFIELD_ZONE_LABEL}
+            player={player}
           />
         ))}
       </svg>
-
-      {zone.length > 0 ? (
-        <div className="mx-auto mt-2 w-full max-w-sm">
-          <h4 className="mb-1 text-center text-xs font-medium text-muted-foreground">
-            Outfield
-          </h4>
-          <div className="flex flex-wrap justify-center gap-2">
-            {zone.map((player) => {
-              const style = RSVP_STYLE[player.rsvpState];
-              return (
-                <span
-                  key={player.playerId}
-                  className={`rounded border border-border px-2 py-1 text-xs font-medium ${style.nameClassName}`}
-                >
-                  {player.playerName}
-                  <span className={`ml-1 ${style.tagClassName}`}>
-                    {style.label}
-                  </span>
-                </span>
-              );
-            })}
-          </div>
-        </div>
-      ) : null}
 
       <ul className="sr-only">
         {drawn.map((position) => {

--- a/src/app/t/[teamId]/view/Diamond.tsx
+++ b/src/app/t/[teamId]/view/Diamond.tsx
@@ -2,9 +2,12 @@ import {
   DIAMOND_GEOMETRY,
   DIAMOND_POLYGON,
   POSITION_COORDS,
-  diamondHeight,
   outfieldZoneCoords,
 } from "@/components/diamond-geometry";
+import {
+  NO_CATCHER_TEXT,
+  NoCatcherMarker,
+} from "@/components/NoCatcherMarker";
 import { RSVP_STYLE } from "@/components/rsvp-style";
 import type { Position } from "@/generated/prisma/enums";
 import type { ChartViewPlayer } from "@/lib/chart-view";
@@ -137,9 +140,9 @@ export function Diamond({
   const zone = allPlay ? outfield : [];
   const zoneCoords = outfieldZoneCoords(zone.length);
 
-  // Keyed on the marker, not on allPlay: a stale CATCHER row still draws one at
-  // y=452 and still needs the taller box, or its name clips off the bottom.
-  const height = diamondHeight(drawn.includes("CATCHER"));
+  // Not `allPlay` on its own: a stale CATCHER row draws a real marker there, and
+  // the spot can't say both "somebody plays here" and "nobody does".
+  const noCatcher = !drawn.includes("CATCHER");
 
   return (
     <>
@@ -147,7 +150,7 @@ export function Diamond({
           SVG's aria-label and nothing inside it, so the assignments would
           otherwise be unreachable without sight. */}
       <svg
-        viewBox={`0 0 ${DIAMOND_GEOMETRY.width} ${height}`}
+        viewBox={`0 0 ${DIAMOND_GEOMETRY.width} ${DIAMOND_GEOMETRY.height}`}
         aria-hidden="true"
         focusable="false"
         className="mx-auto w-full max-w-sm"
@@ -157,6 +160,8 @@ export function Diamond({
           className="fill-none stroke-border"
           strokeWidth={2}
         />
+
+        {noCatcher ? <NoCatcherMarker /> : null}
 
         {drawn.map((position) => {
           const { x, y } = POSITION_COORDS[position];
@@ -183,6 +188,7 @@ export function Diamond({
       </svg>
 
       <ul className="sr-only">
+        {noCatcher ? <li>{NO_CATCHER_TEXT}</li> : null}
         {drawn.map((position) => {
           const player = byPosition.get(position);
           return (

--- a/src/app/t/[teamId]/view/Diamond.tsx
+++ b/src/app/t/[teamId]/view/Diamond.tsx
@@ -97,52 +97,29 @@ function Marker({
   );
 }
 
-/**
- * Which named spots the diamond draws.
- *
- * An allPlay team fields neither a catcher nor three named outfielders: the
- * coach pitches, and the outfield is one zone holding everyone the infield
- * leaves over, persisting as `position = null` (#11, Decision 1). Drawing C or
- * LF/CF/RF as "Open" would be doubly wrong for those teams — the spots aren't
- * open, they don't exist, and the kids playing out there would be missing from
- * the diamond entirely, which is the one thing a parent opens this page to see.
- * `Diamond` draws them from the `outfield` prop instead.
- *
- * A stale row on one of those positions (hand-set during #9, or left over from
- * before allPlay was switched on) still draws its marker, so nothing silently
- * vanishes before the coach's next save collapses it.
- */
-function positionsToDraw(
-  allPlay: boolean,
-  byPosition: Map<Position, ChartViewPlayer>,
-): readonly Position[] {
-  if (!allPlay) {
-    return ALL_POSITIONS;
-  }
-  return ALL_POSITIONS.filter(
-    (position) =>
-      ALL_PLAY_INFIELD_POSITIONS.includes(position) || byPosition.has(position),
-  );
-}
-
 export function Diamond({
   byPosition,
   allPlay,
   outfield = [],
 }: {
+  /// Seated players, keyed by position. Only ever holds spots this team
+  /// fields — `buildChartView` pools the rest, including an allPlay team's
+  /// stale LF/CF/RF or CATCHER row, so the markers below cannot collide with
+  /// the zone drawn at those same coordinates.
   byPosition: Map<Position, ChartViewPlayer>;
   allPlay: boolean;
-  /// Players with no position. Drawn as the outfield zone on an allPlay team,
-  /// and ignored otherwise — a benched player belongs on neither.
+  /// Everyone the diamond doesn't seat. Drawn as the outfield zone on an
+  /// allPlay team, and ignored otherwise — a benched player belongs on neither.
   outfield?: readonly ChartViewPlayer[];
 }) {
-  const drawn = positionsToDraw(allPlay, byPosition);
+  // An allPlay team fields neither a catcher nor three named outfielders: the
+  // coach pitches, and the outfield is one zone holding everyone the infield
+  // leaves over (#11, Decision 1). Drawing C or LF/CF/RF as "Open" would be
+  // doubly wrong for them — the spots aren't open, they don't exist — so those
+  // players come from `outfield` instead, and C gets the disc.
+  const drawn = allPlay ? ALL_PLAY_INFIELD_POSITIONS : ALL_POSITIONS;
   const zone = allPlay ? outfield : [];
   const zoneCoords = outfieldZoneCoords(zone.length);
-
-  // Not `allPlay` on its own: a stale CATCHER row draws a real marker there, and
-  // the spot can't say both "somebody plays here" and "nobody does".
-  const noCatcher = !drawn.includes("CATCHER");
 
   return (
     <>
@@ -161,7 +138,7 @@ export function Diamond({
           strokeWidth={2}
         />
 
-        {noCatcher ? <NoCatcherMarker /> : null}
+        {allPlay ? <NoCatcherMarker /> : null}
 
         {drawn.map((position) => {
           const { x, y } = POSITION_COORDS[position];
@@ -188,7 +165,7 @@ export function Diamond({
       </svg>
 
       <ul className="sr-only">
-        {noCatcher ? <li>{NO_CATCHER_TEXT}</li> : null}
+        {allPlay ? <li>{NO_CATCHER_TEXT}</li> : null}
         {drawn.map((position) => {
           const player = byPosition.get(position);
           return (

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -224,6 +224,65 @@ describe("ViewPage chart rendering", () => {
     for (const label of ["LF", "CF", "RF"]) {
       expect(html).not.toContain(`>${label}<`);
     }
+    // On the grass, in a circle, like everyone else — not listed underneath.
+    // A parent looking for their kid scans the diamond, not a caption.
+    expect(html).toContain(">OF<");
+  });
+
+  it("draws one OF marker per outfielder on an allPlay team", async () => {
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+    getChart.mockResolvedValue([
+      ...fullChart,
+      ...["cal", "dee", "eli"].map((playerId, index) => ({
+        playerId,
+        playerName: playerId,
+        jerseyNumber: 20 + index,
+        battingOrder: 3 + index,
+        position: null,
+      })),
+    ]);
+
+    const html = await render();
+
+    expect(html.split(">OF<")).toHaveLength(4);
+  });
+
+  it("draws no catcher for an allPlay team — the coach pitches", async () => {
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+
+    const html = await render();
+
+    expect(html).not.toContain(">C<");
+    expect(html).toContain(">P<");
+  });
+
+  it("still draws an allPlay team's stale catcher row", async () => {
+    // Same reasoning as the stale named-outfield row below: the coach's next
+    // save collapses it, and until then nobody vanishes off the diamond.
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+    getChart.mockResolvedValue([
+      {
+        playerId: "cal",
+        playerName: "Cal",
+        jerseyNumber: 3,
+        battingOrder: 1,
+        position: "CATCHER" as const,
+      },
+    ]);
+
+    const html = await render();
+
+    expect(html).toContain(">C<");
+    // ...and in the taller box, or that marker's name clips off the bottom.
+    expect(html).toContain('viewBox="0 0 400 520"');
+  });
+
+  it("drops the catcher's band from the box when no catcher is drawn", async () => {
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+
+    const html = await render();
+
+    expect(html).toContain('viewBox="0 0 400 440"');
   });
 
   it("still draws an allPlay team's stale named-outfield row", async () => {

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -256,6 +256,24 @@ describe("ViewPage chart rendering", () => {
     expect(html).toContain(">P<");
   });
 
+  it("marks the empty catcher spot with a filled circle rather than a gap", async () => {
+    // A blank spot behind the plate reads as something missing from the chart;
+    // the disc says the level simply doesn't have the position.
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+
+    const html = await render();
+
+    expect(html).toContain("fill-muted-foreground/30");
+    expect(html).toContain("the coach pitches");
+  });
+
+  it("draws no such circle when a catcher is a real spot", async () => {
+    // allPlay off by default in this file — nine named positions, C among them.
+    const html = await render();
+
+    expect(html).not.toContain("fill-muted-foreground/30");
+  });
+
   it("still draws an allPlay team's stale catcher row", async () => {
     // Same reasoning as the stale named-outfield row below: the coach's next
     // save collapses it, and until then nobody vanishes off the diamond.
@@ -273,16 +291,8 @@ describe("ViewPage chart rendering", () => {
     const html = await render();
 
     expect(html).toContain(">C<");
-    // ...and in the taller box, or that marker's name clips off the bottom.
-    expect(html).toContain('viewBox="0 0 400 520"');
-  });
-
-  it("drops the catcher's band from the box when no catcher is drawn", async () => {
-    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
-
-    const html = await render();
-
-    expect(html).toContain('viewBox="0 0 400 440"');
+    // A real marker there, so no disc claiming nobody plays it.
+    expect(html).not.toContain("fill-muted-foreground/30");
   });
 
   it("still draws an allPlay team's stale named-outfield row", async () => {

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -274,9 +274,9 @@ describe("ViewPage chart rendering", () => {
     expect(html).not.toContain("fill-muted-foreground/30");
   });
 
-  it("still draws an allPlay team's stale catcher row", async () => {
-    // Same reasoning as the stale named-outfield row below: the coach's next
-    // save collapses it, and until then nobody vanishes off the diamond.
+  it("shows an allPlay team's stale catcher row in the outfield", async () => {
+    // Same as the stale named-outfield row: the spot isn't one this team
+    // fields, so the kid stands in the outfield until the next save says so.
     getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
     getChart.mockResolvedValue([
       {
@@ -290,14 +290,17 @@ describe("ViewPage chart rendering", () => {
 
     const html = await render();
 
-    expect(html).toContain(">C<");
-    // A real marker there, so no disc claiming nobody plays it.
-    expect(html).not.toContain("fill-muted-foreground/30");
+    expect(html).toContain("Cal");
+    expect(html).toContain(">OF<");
+    expect(html).not.toContain(">C<");
   });
 
-  it("still draws an allPlay team's stale named-outfield row", async () => {
+  it("shows an allPlay team's stale named-outfield row in the outfield", async () => {
     // Hand-set during #9, or left over from before allPlay was switched on.
-    // The coach's next save collapses it; until then nothing vanishes.
+    // The coach's next save collapses it; until then the kid is in the
+    // outfield, which is both where the editor shows them and where that save
+    // will put them. Drawing them at CF instead would land the marker on the
+    // zone's own first coordinate, with two names on one spot.
     getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
     getChart.mockResolvedValue([
       {
@@ -311,8 +314,35 @@ describe("ViewPage chart rendering", () => {
 
     const html = await render();
 
-    expect(html).toContain(">CF<");
-    expect(html).not.toContain(">LF<");
+    expect(html).toContain("Cal");
+    expect(html).toContain(">OF<");
+    expect(html).not.toContain(">CF<");
+  });
+
+  it("draws one marker per player when a stale row sits beside a real outfielder", async () => {
+    // The collision case: the zone's first coordinate IS center field.
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+    getChart.mockResolvedValue([
+      {
+        playerId: "cal",
+        playerName: "Cal",
+        jerseyNumber: 3,
+        battingOrder: 1,
+        position: "CENTER_FIELD" as const,
+      },
+      {
+        playerId: "dee",
+        playerName: "Dee",
+        jerseyNumber: 4,
+        battingOrder: 2,
+        position: null,
+      },
+    ]);
+
+    const html = await render();
+
+    expect(html.split(">OF<")).toHaveLength(3);
+    expect(html).not.toContain(">CF<");
   });
 
   it("exposes an allPlay outfield to screen readers", async () => {

--- a/src/app/t/[teamId]/view/page.tsx
+++ b/src/app/t/[teamId]/view/page.tsx
@@ -89,7 +89,7 @@ export default async function ViewPage({
     chartEntries.map((entry) => entry.playerId),
     rsvpRows,
   );
-  const chart = buildChartView(chartEntries, rsvpStates);
+  const chart = buildChartView(chartEntries, rsvpStates, team?.allPlay ?? true);
 
   const heading = game.opponent ? `Next game vs ${game.opponent}` : "Next game";
 

--- a/src/components/NoCatcherMarker.tsx
+++ b/src/components/NoCatcherMarker.tsx
@@ -1,0 +1,34 @@
+import { DIAMOND_GEOMETRY, POSITION_COORDS } from "@/components/diamond-geometry";
+
+/**
+ * The catcher's spot on an allPlay board, where nobody plays.
+ *
+ * An allPlay team has no catcher — the coach pitches — so the spot is neither a
+ * drop target nor an "Open" marker (`ALL_PLAY_INFIELD_POSITIONS`). Leaving it
+ * blank raised the very question it was meant to settle: a gap behind the plate
+ * reads as something missing from the chart rather than as something the level
+ * doesn't have. So the absence is drawn.
+ *
+ * A solid disc, deliberately unlike both the stroked circles that hold a player
+ * and the dashed ones that mean "Open" — it is the one marker on the field that
+ * is not a spot anyone can fill. It carries no label and no name because there
+ * is nobody to name; the disc is the whole statement.
+ *
+ * Shared by the view page's diamond and the drag editor's for the same reason
+ * their coordinates are: a spot one draws and the other doesn't is its own kind
+ * of bug. Both render it inside an aria-hidden SVG, so both owe a screen reader
+ * the same fact in their own text — `NO_CATCHER_TEXT`.
+ */
+export function NoCatcherMarker() {
+  return (
+    <circle
+      cx={POSITION_COORDS.CATCHER.x}
+      cy={POSITION_COORDS.CATCHER.y}
+      r={DIAMOND_GEOMETRY.markerRadius}
+      className="fill-muted-foreground/30"
+    />
+  );
+}
+
+/// What the disc says, for the readers who can't see it.
+export const NO_CATCHER_TEXT = "Catcher: nobody — the coach pitches.";

--- a/src/components/diamond-geometry.test.ts
+++ b/src/components/diamond-geometry.test.ts
@@ -81,6 +81,18 @@ describe("outfieldZoneCoords", () => {
     expect(outfieldZoneCoords(8)[0].y).not.toBe(outfieldZoneCoords(8)[7].y);
   });
 
+  it("packs its two rows fuller rather than opening a third", () => {
+    // `perRowTarget` opens the second row, it does not cap either one: 12
+    // outfielders is 6 and 6, not 5 and 5 with two players dropped. That needs
+    // a 17-player allPlay roster to reach, but the alternative — a third row —
+    // would land on the middle infielders at y=252.
+    const coords = outfieldZoneCoords(12);
+
+    expect(coords).toHaveLength(12);
+    expect(new Set(coords.map((coord) => Math.round(coord.y))).size).toBeLessThanOrEqual(6);
+    expect(Math.max(...coords.map((coord) => coord.y))).toBeLessThan(INFIELD_BACK);
+  });
+
   it("keeps every marker inside the box and clear of the infield", () => {
     // A whole youth roster in the outfield is not a real team, but the layout
     // must not fall off the canvas or land on the middle infielders if one

--- a/src/components/diamond-geometry.test.ts
+++ b/src/components/diamond-geometry.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from "vitest";
 import {
   DIAMOND_GEOMETRY,
   POSITION_COORDS,
-  diamondHeight,
   outfieldZoneCoords,
   positionPercent,
 } from "./diamond-geometry";
@@ -12,38 +11,22 @@ import {
 /// reach it, or an outfielder's circle sits on top of the middle infielders.
 const INFIELD_BACK = 230;
 
-describe("diamondHeight", () => {
-  it("keeps the full box when a catcher is drawn", () => {
-    // The catcher's RSVP tag lands at 452 + 47 = 499, and clipping it would be
-    // silent — an off-canvas name renders without error.
-    expect(diamondHeight(true)).toBe(DIAMOND_GEOMETRY.height);
+describe("DIAMOND_GEOMETRY", () => {
+  it("is tall enough for the catcher's name and RSVP tag", () => {
+    // The clipping this guards against is silent — an off-canvas name renders
+    // without error and simply cannot be seen.
     expect(POSITION_COORDS.CATCHER.y + DIAMOND_GEOMETRY.tagOffset).toBeLessThan(
-      diamondHeight(true),
+      DIAMOND_GEOMETRY.height,
     );
-  });
-
-  it("drops the catcher's band when there is none", () => {
-    const height = diamondHeight(false);
-    expect(height).toBeLessThan(DIAMOND_GEOMETRY.height);
-    // Still room for the pitcher's tag and the whole plate at y=420.
-    expect(POSITION_COORDS.PITCHER.y + DIAMOND_GEOMETRY.tagOffset).toBeLessThan(
-      height,
-    );
-    expect(height).toBeGreaterThan(420);
   });
 });
 
 describe("positionPercent", () => {
-  it("scales against the box it will actually be placed in", () => {
-    const tall = positionPercent("PITCHER", true);
-    const short = positionPercent("PITCHER", false);
-
-    expect(tall.x).toBe(short.x);
-    // Same marker, shorter box — so it sits proportionally lower.
-    expect(short.y).toBeGreaterThan(tall.y);
-    expect(tall.y).toBeCloseTo(
-      (POSITION_COORDS.PITCHER.y / DIAMOND_GEOMETRY.height) * 100,
-    );
+  it("scales the coordinates against the box", () => {
+    expect(positionPercent("CATCHER")).toEqual({
+      x: (POSITION_COORDS.CATCHER.x / DIAMOND_GEOMETRY.width) * 100,
+      y: (POSITION_COORDS.CATCHER.y / DIAMOND_GEOMETRY.height) * 100,
+    });
   });
 });
 

--- a/src/components/diamond-geometry.test.ts
+++ b/src/components/diamond-geometry.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  DIAMOND_GEOMETRY,
+  POSITION_COORDS,
+  diamondHeight,
+  outfieldZoneCoords,
+  positionPercent,
+} from "./diamond-geometry";
+
+/// The back point of the infield polygon. Nothing in the outfield zone may
+/// reach it, or an outfielder's circle sits on top of the middle infielders.
+const INFIELD_BACK = 230;
+
+describe("diamondHeight", () => {
+  it("keeps the full box when a catcher is drawn", () => {
+    // The catcher's RSVP tag lands at 452 + 47 = 499, and clipping it would be
+    // silent — an off-canvas name renders without error.
+    expect(diamondHeight(true)).toBe(DIAMOND_GEOMETRY.height);
+    expect(POSITION_COORDS.CATCHER.y + DIAMOND_GEOMETRY.tagOffset).toBeLessThan(
+      diamondHeight(true),
+    );
+  });
+
+  it("drops the catcher's band when there is none", () => {
+    const height = diamondHeight(false);
+    expect(height).toBeLessThan(DIAMOND_GEOMETRY.height);
+    // Still room for the pitcher's tag and the whole plate at y=420.
+    expect(POSITION_COORDS.PITCHER.y + DIAMOND_GEOMETRY.tagOffset).toBeLessThan(
+      height,
+    );
+    expect(height).toBeGreaterThan(420);
+  });
+});
+
+describe("positionPercent", () => {
+  it("scales against the box it will actually be placed in", () => {
+    const tall = positionPercent("PITCHER", true);
+    const short = positionPercent("PITCHER", false);
+
+    expect(tall.x).toBe(short.x);
+    // Same marker, shorter box — so it sits proportionally lower.
+    expect(short.y).toBeGreaterThan(tall.y);
+    expect(tall.y).toBeCloseTo(
+      (POSITION_COORDS.PITCHER.y / DIAMOND_GEOMETRY.height) * 100,
+    );
+  });
+});
+
+describe("outfieldZoneCoords", () => {
+  it("places nobody when the infield takes everyone", () => {
+    expect(outfieldZoneCoords(0)).toEqual([]);
+    expect(outfieldZoneCoords(-1)).toEqual([]);
+  });
+
+  it("returns one coordinate per player", () => {
+    for (let count = 1; count <= 12; count += 1) {
+      expect(outfieldZoneCoords(count)).toHaveLength(count);
+    }
+  });
+
+  it("puts a lone outfielder in centre field", () => {
+    expect(outfieldZoneCoords(1)).toEqual([
+      { x: 200, y: POSITION_COORDS.CENTER_FIELD.y },
+    ]);
+  });
+
+  it("lands three outfielders exactly on LF, CF and RF", () => {
+    // A team that happens to field three should read as the standard diamond
+    // rather than as some other chart.
+    expect(outfieldZoneCoords(3)).toEqual([
+      POSITION_COORDS.LEFT_FIELD,
+      POSITION_COORDS.CENTER_FIELD,
+      POSITION_COORDS.RIGHT_FIELD,
+    ]);
+  });
+
+  it("bows each row: the ends play shallower than the middle", () => {
+    const row = outfieldZoneCoords(5);
+
+    expect(row[0].y).toBeGreaterThan(row[1].y);
+    expect(row[1].y).toBeGreaterThan(row[2].y);
+    expect(row[2].y).toBeLessThan(row[3].y);
+    expect(row[3].y).toBeLessThan(row[4].y);
+  });
+
+  it("is symmetric about the centre line", () => {
+    const row = outfieldZoneCoords(4);
+    const centre = DIAMOND_GEOMETRY.width / 2;
+
+    expect(row[0].x - centre).toBeCloseTo(centre - row[3].x);
+    expect(row[0].y).toBeCloseTo(row[3].y);
+  });
+
+  it("adds a second row rather than crowding one", () => {
+    const depths = new Set(outfieldZoneCoords(8).map((coord) => coord.y));
+    expect(depths.size).toBeGreaterThan(3);
+    expect(outfieldZoneCoords(8)[0].y).not.toBe(outfieldZoneCoords(8)[7].y);
+  });
+
+  it("keeps every marker inside the box and clear of the infield", () => {
+    // A whole youth roster in the outfield is not a real team, but the layout
+    // must not fall off the canvas or land on the middle infielders if one
+    // shows up — an off-canvas marker fails silently.
+    for (let count = 1; count <= 12; count += 1) {
+      for (const { x, y } of outfieldZoneCoords(count)) {
+        expect(x - DIAMOND_GEOMETRY.markerRadius).toBeGreaterThanOrEqual(0);
+        expect(x + DIAMOND_GEOMETRY.markerRadius).toBeLessThanOrEqual(
+          DIAMOND_GEOMETRY.width,
+        );
+        expect(y - DIAMOND_GEOMETRY.markerRadius).toBeGreaterThanOrEqual(0);
+        expect(y + DIAMOND_GEOMETRY.markerRadius).toBeLessThanOrEqual(
+          INFIELD_BACK,
+        );
+      }
+    }
+  });
+});

--- a/src/components/diamond-geometry.ts
+++ b/src/components/diamond-geometry.ts
@@ -68,8 +68,10 @@ const OUTFIELD_ZONE = {
   /// Cap on that half-spread. Names are centred under their marker, so this is
   /// what keeps the outermost name inside the 400-wide box.
   maxSpread: 145,
-  /// Rows hold at most this many.
-  perRow: 5,
+  /// How many markers a row aims to hold: exceed it and a second row opens.
+  /// Not a hard cap — past `perRowTarget * maxRows` outfielders the two rows
+  /// simply get fuller, which is the intended degradation (see `maxRows`).
+  perRowTarget: 5,
   /// A third row would reach the middle infielders at y=252, so a very deep
   /// roster packs its two rows tighter rather than growing downward.
   maxRows: 2,
@@ -99,7 +101,7 @@ export function outfieldZoneCoords(
 
   const rows = Math.min(
     OUTFIELD_ZONE.maxRows,
-    Math.ceil(count / OUTFIELD_ZONE.perRow),
+    Math.ceil(count / OUTFIELD_ZONE.perRowTarget),
   );
   const coords: { x: number; y: number }[] = [];
   let placed = 0;

--- a/src/components/diamond-geometry.ts
+++ b/src/components/diamond-geometry.ts
@@ -6,19 +6,37 @@ import type { Position } from "@/generated/prisma/enums";
 /// be its own kind of bug.
 ///
 /// Coordinates mirror where each position actually stands, and the **catcher
-/// sits below home plate at y=452, which is why the viewBox is 520 tall**: the
-/// view page draws a name at y+34 and an RSVP tag at y+47 under each marker, so
-/// a shorter viewBox silently clips the catcher's name and state off the
-/// bottom. Check the lowest marker's y+47 against the viewBox height before
+/// sits below home plate at y=452, which is why the full viewBox is 520 tall**:
+/// the view page draws a name at y+34 and an RSVP tag at y+47 under each
+/// marker, so a shorter viewBox silently clips the catcher's name and state off
+/// the bottom. Check the lowest marker's y+47 against the viewBox height before
 /// moving anything. The clipping this guards against is silent — an off-canvas
 /// name renders without error and simply cannot be seen.
+///
+/// `catcherlessHeight` is that same box with the catcher's band cut off, for an
+/// allPlay team, which has no catcher (`ALL_PLAY_INFIELD_POSITIONS`). The
+/// lowest thing left is the pitcher's RSVP tag at 338+47=385, then the plate at
+/// y=420 — so 440 keeps the whole diamond and drops only dead space. Ask
+/// `diamondHeight` for it rather than picking a number: the answer turns on
+/// whether a catcher marker is actually drawn, and an allPlay team with a stale
+/// CATCHER row still draws one.
 export const DIAMOND_GEOMETRY = {
   width: 400,
   height: 520,
+  catcherlessHeight: 440,
   markerRadius: 20,
   nameOffset: 34,
   tagOffset: 47,
 } as const;
+
+/// The viewBox height to draw at. Keyed on whether a catcher marker appears —
+/// not on allPlay — because it is the marker at y=452 that needs the room, and
+/// a stale CATCHER row draws one on an allPlay board too.
+export function diamondHeight(withCatcher: boolean): number {
+  return withCatcher
+    ? DIAMOND_GEOMETRY.height
+    : DIAMOND_GEOMETRY.catcherlessHeight;
+}
 
 export const POSITION_COORDS: Record<Position, { x: number; y: number }> = {
   CATCHER: { x: 200, y: 452 },
@@ -40,10 +58,93 @@ export const DIAMOND_POLYGON = "200,420 290,320 200,230 110,320";
 /// with `getBoundingClientRect` and drags HTML chips by writing `transform`.
 /// Keeping targets and chips in the same coordinate system avoids fighting
 /// SVG's.
-export function positionPercent(position: Position): { x: number; y: number } {
+///
+/// `withCatcher` must match what the caller passed to `diamondHeight` for the
+/// box it is positioning inside, or every marker lands at the wrong depth.
+export function positionPercent(
+  position: Position,
+  withCatcher: boolean,
+): { x: number; y: number } {
   const { x, y } = POSITION_COORDS[position];
   return {
     x: (x / DIAMOND_GEOMETRY.width) * 100,
-    y: (y / DIAMOND_GEOMETRY.height) * 100,
+    y: (y / diamondHeight(withCatcher)) * 100,
   };
+}
+
+/// The shape of the allPlay outfield zone, in the same coordinate space as
+/// POSITION_COORDS. Tuned so a row of three reproduces LF/CF/RF exactly.
+const OUTFIELD_ZONE = {
+  /// Centre of the deepest row: CF's y.
+  depth: 75,
+  /// How much lower a row's outermost markers sit than its centre. 55 is what
+  /// makes a row of three reproduce LF/CF/RF.
+  arc: 55,
+  /// Distance between rows, when one row isn't enough.
+  rowGap: 78,
+  /// Half-spread per gap between neighbours, so two outfielders stand shoulder
+  /// to shoulder instead of straddling both foul lines.
+  spreadPerGap: 62.5,
+  /// Cap on that half-spread. Names are centred under their marker, so this is
+  /// what keeps the outermost name inside the 400-wide box.
+  maxSpread: 145,
+  /// Rows hold at most this many.
+  perRow: 5,
+  /// A third row would reach the middle infielders at y=252, so a very deep
+  /// roster packs its two rows tighter rather than growing downward.
+  maxRows: 2,
+} as const;
+
+/**
+ * Where an allPlay team's outfielders stand.
+ *
+ * That outfield is one zone rather than three named spots (#11), so the count
+ * is whatever the infield leaves over — five on a twelve-player roster, but it
+ * moves with the team. Markers are laid out in rows across the grass, each row
+ * bowed the way an outfield actually plays: centre deepest, the ends drawn down
+ * toward the foul lines.
+ *
+ * A row of three lands exactly on the LF/CF/RF coordinates above, which is the
+ * point — a team that happens to field three outfielders reads as the standard
+ * diamond rather than as some other chart.
+ *
+ * Returns one coordinate per player, in the order given.
+ */
+export function outfieldZoneCoords(
+  count: number,
+): { x: number; y: number }[] {
+  if (count <= 0) {
+    return [];
+  }
+
+  const rows = Math.min(
+    OUTFIELD_ZONE.maxRows,
+    Math.ceil(count / OUTFIELD_ZONE.perRow),
+  );
+  const coords: { x: number; y: number }[] = [];
+  let placed = 0;
+
+  for (let row = 0; row < rows; row += 1) {
+    // Spread the remainder over the rows that are left, so the deeper row takes
+    // the extra player when the count doesn't divide evenly.
+    const inRow = Math.ceil((count - placed) / (rows - row));
+    const spread = Math.min(
+      OUTFIELD_ZONE.maxSpread,
+      OUTFIELD_ZONE.spreadPerGap * (inRow - 1),
+    );
+    const depth = OUTFIELD_ZONE.depth + row * OUTFIELD_ZONE.rowGap;
+
+    for (let index = 0; index < inRow; index += 1) {
+      // -1 at the left end of the row, +1 at the right, 0 dead centre.
+      const offset = inRow === 1 ? 0 : (index / (inRow - 1)) * 2 - 1;
+      coords.push({
+        x: DIAMOND_GEOMETRY.width / 2 + offset * spread,
+        y: depth + OUTFIELD_ZONE.arc * offset * offset,
+      });
+    }
+
+    placed += inRow;
+  }
+
+  return coords;
 }

--- a/src/components/diamond-geometry.ts
+++ b/src/components/diamond-geometry.ts
@@ -6,37 +6,23 @@ import type { Position } from "@/generated/prisma/enums";
 /// be its own kind of bug.
 ///
 /// Coordinates mirror where each position actually stands, and the **catcher
-/// sits below home plate at y=452, which is why the full viewBox is 520 tall**:
-/// the view page draws a name at y+34 and an RSVP tag at y+47 under each
-/// marker, so a shorter viewBox silently clips the catcher's name and state off
-/// the bottom. Check the lowest marker's y+47 against the viewBox height before
+/// sits below home plate at y=452, which is why the viewBox is 520 tall**: the
+/// view page draws a name at y+34 and an RSVP tag at y+47 under each marker, so
+/// a shorter viewBox silently clips the catcher's name and state off the
+/// bottom. Check the lowest marker's y+47 against the viewBox height before
 /// moving anything. The clipping this guards against is silent — an off-canvas
 /// name renders without error and simply cannot be seen.
 ///
-/// `catcherlessHeight` is that same box with the catcher's band cut off, for an
-/// allPlay team, which has no catcher (`ALL_PLAY_INFIELD_POSITIONS`). The
-/// lowest thing left is the pitcher's RSVP tag at 338+47=385, then the plate at
-/// y=420 — so 440 keeps the whole diamond and drops only dead space. Ask
-/// `diamondHeight` for it rather than picking a number: the answer turns on
-/// whether a catcher marker is actually drawn, and an allPlay team with a stale
-/// CATCHER row still draws one.
+/// One height for every board, including an allPlay team's — which has no
+/// catcher (`ALL_PLAY_INFIELD_POSITIONS`) but still draws that spot, as the
+/// solid disc in `NoCatcherMarker`.
 export const DIAMOND_GEOMETRY = {
   width: 400,
   height: 520,
-  catcherlessHeight: 440,
   markerRadius: 20,
   nameOffset: 34,
   tagOffset: 47,
 } as const;
-
-/// The viewBox height to draw at. Keyed on whether a catcher marker appears —
-/// not on allPlay — because it is the marker at y=452 that needs the room, and
-/// a stale CATCHER row draws one on an allPlay board too.
-export function diamondHeight(withCatcher: boolean): number {
-  return withCatcher
-    ? DIAMOND_GEOMETRY.height
-    : DIAMOND_GEOMETRY.catcherlessHeight;
-}
 
 export const POSITION_COORDS: Record<Position, { x: number; y: number }> = {
   CATCHER: { x: 200, y: 452 },
@@ -58,17 +44,11 @@ export const DIAMOND_POLYGON = "200,420 290,320 200,230 110,320";
 /// with `getBoundingClientRect` and drags HTML chips by writing `transform`.
 /// Keeping targets and chips in the same coordinate system avoids fighting
 /// SVG's.
-///
-/// `withCatcher` must match what the caller passed to `diamondHeight` for the
-/// box it is positioning inside, or every marker lands at the wrong depth.
-export function positionPercent(
-  position: Position,
-  withCatcher: boolean,
-): { x: number; y: number } {
+export function positionPercent(position: Position): { x: number; y: number } {
   const { x, y } = POSITION_COORDS[position];
   return {
     x: (x / DIAMOND_GEOMETRY.width) * 100,
-    y: (y / diamondHeight(withCatcher)) * 100,
+    y: (y / DIAMOND_GEOMETRY.height) * 100,
   };
 }
 

--- a/src/lib/chart-view.test.ts
+++ b/src/lib/chart-view.test.ts
@@ -35,21 +35,21 @@ const noRsvps = new Map<string, RsvpState>();
 
 describe("buildChartView", () => {
   it("sorts the lineup ascending by batting order", () => {
-    const view = buildChartView(fullChart, noRsvps);
+    const view = buildChartView(fullChart, noRsvps, false);
 
     expect(view.lineup.map((p) => p.playerId)).toEqual(["ben", "ava", "cy"]);
   });
 
   it("excludes benched players from the lineup", () => {
-    const view = buildChartView(fullChart, noRsvps);
+    const view = buildChartView(fullChart, noRsvps, false);
 
     expect(view.lineup.some((p) => p.playerId === "eli")).toBe(false);
   });
 
-  it("collects players with no position", () => {
+  it("collects players the diamond doesn't seat", () => {
     // The outfield on an allPlay team, the bench otherwise — buildChartView
-    // doesn't know which, and deliberately doesn't decide.
-    const view = buildChartView(fullChart, noRsvps);
+    // knows which spots are fielded, but deliberately doesn't name the zone.
+    const view = buildChartView(fullChart, noRsvps, false);
 
     expect(view.unassigned.map((p) => p.playerId)).toEqual(["eli"]);
   });
@@ -65,7 +65,7 @@ describe("buildChartView", () => {
       { entryId: "re-2", playerId: "ben", playerName: "Ben", jerseyNumber: 3, battingOrder: null, position: null },
     ];
 
-    const view = buildChartView(scrambled, noRsvps);
+    const view = buildChartView(scrambled, noRsvps, false);
 
     expect(view.unassigned.map((p) => p.playerId)).toEqual([
       "ben", // 3
@@ -79,13 +79,14 @@ describe("buildChartView", () => {
     const view = buildChartView(
       fullChart,
       new Map<string, RsvpState>([["eli", "declined"]]),
+      false,
     );
 
     expect(view.unassigned[0].rsvpState).toBe("declined");
   });
 
   it("maps assigned positions to their player", () => {
-    const view = buildChartView(fullChart, noRsvps);
+    const view = buildChartView(fullChart, noRsvps, false);
 
     expect(view.byPosition.get("SHORTSTOP")?.playerId).toBe("ava");
     expect(view.byPosition.get("PITCHER")?.playerId).toBe("ben");
@@ -94,7 +95,7 @@ describe("buildChartView", () => {
   });
 
   it("defaults an unrepresented player's rsvpState to no-response", () => {
-    const view = buildChartView(fullChart, noRsvps);
+    const view = buildChartView(fullChart, noRsvps, false);
 
     expect(view.lineup.find((p) => p.playerId === "ben")?.rsvpState).toBe(
       "no-response",
@@ -108,7 +109,7 @@ describe("buildChartView", () => {
       ["cy", "no-response"],
     ]);
 
-    const view = buildChartView(fullChart, rsvps);
+    const view = buildChartView(fullChart, rsvps, false);
 
     // Same order and membership as the no-rsvp case above.
     expect(view.lineup.map((p) => p.playerId)).toEqual(["ben", "ava", "cy"]);
@@ -127,7 +128,7 @@ describe("buildChartView", () => {
       ["cy", "declined"],
     ]);
 
-    const view = buildChartView(fullChart, allDeclined);
+    const view = buildChartView(fullChart, allDeclined, false);
 
     expect(view.lineup.map((p) => p.playerId)).toEqual(["ben", "ava", "cy"]);
     expect(view.lineup.map((p) => p.battingOrder)).toEqual([1, 2, 3]);
@@ -146,7 +147,7 @@ describe("buildChartView", () => {
       },
     ];
 
-    expect(buildChartView(partial, noRsvps).hasChart).toBe(true);
+    expect(buildChartView(partial, noRsvps, false).hasChart).toBe(true);
   });
 
   it("reports hasChart true when only a position is set", () => {
@@ -161,7 +162,7 @@ describe("buildChartView", () => {
       },
     ];
 
-    expect(buildChartView(partial, noRsvps).hasChart).toBe(true);
+    expect(buildChartView(partial, noRsvps, false).hasChart).toBe(true);
   });
 
   it("reports hasChart false when every entry is fully benched", () => {
@@ -176,15 +177,84 @@ describe("buildChartView", () => {
       },
     ];
 
-    expect(buildChartView(empty, noRsvps).hasChart).toBe(false);
+    expect(buildChartView(empty, noRsvps, false).hasChart).toBe(false);
   });
 
   it("reports hasChart false for an empty roster", () => {
-    expect(buildChartView([], noRsvps).hasChart).toBe(false);
+    expect(buildChartView([], noRsvps, false).hasChart).toBe(false);
+  });
+
+  it("pools an allPlay team's stale named-outfield row instead of seating it", () => {
+    // The view page draws its outfield zone at the very coordinates a named
+    // outfield marker occupies, so seating this player would stack two markers
+    // on one spot and make both names unreadable. The editor already shows them
+    // in its zone; this is what keeps the two diamonds telling one story.
+    const stale: ChartViewEntry[] = [
+      {
+        entryId: "re-cal",
+        playerId: "cal",
+        playerName: "Cal",
+        jerseyNumber: 3,
+        battingOrder: 1,
+        position: "CENTER_FIELD",
+      },
+    ];
+
+    const view = buildChartView(stale, noRsvps, true);
+
+    expect(view.byPosition.has("CENTER_FIELD")).toBe(false);
+    expect(view.unassigned.map((p) => p.playerId)).toEqual(["cal"]);
+    // Nobody vanishes, and the chart still counts as set.
+    expect(view.hasChart).toBe(true);
+  });
+
+  it("pools an allPlay team's stale catcher row — the coach pitches", () => {
+    const stale: ChartViewEntry[] = [
+      {
+        entryId: "re-cal",
+        playerId: "cal",
+        playerName: "Cal",
+        jerseyNumber: 3,
+        battingOrder: 1,
+        position: "CATCHER",
+      },
+    ];
+
+    const view = buildChartView(stale, noRsvps, true);
+
+    expect(view.byPosition.has("CATCHER")).toBe(false);
+    expect(view.unassigned.map((p) => p.playerId)).toEqual(["cal"]);
+  });
+
+  it("seats those same rows when allPlay is off", () => {
+    const named: ChartViewEntry[] = [
+      {
+        entryId: "re-cal",
+        playerId: "cal",
+        playerName: "Cal",
+        jerseyNumber: 3,
+        battingOrder: 1,
+        position: "CENTER_FIELD",
+      },
+    ];
+
+    const view = buildChartView(named, noRsvps, false);
+
+    expect(view.byPosition.get("CENTER_FIELD")?.playerId).toBe("cal");
+    expect(view.unassigned).toEqual([]);
+  });
+
+  it("keeps the allPlay infield seated", () => {
+    const view = buildChartView(fullChart, noRsvps, true);
+
+    expect(view.byPosition.get("SHORTSTOP")?.playerId).toBe("ava");
+    expect(view.byPosition.get("PITCHER")?.playerId).toBe("ben");
+    expect(view.byPosition.get("FIRST_BASE")?.playerId).toBe("cy");
+    expect(view.unassigned.map((p) => p.playerId)).toEqual(["eli"]);
   });
 
   it("returns empty results for an empty roster", () => {
-    const view = buildChartView([], noRsvps);
+    const view = buildChartView([], noRsvps, false);
 
     expect(view.lineup).toEqual([]);
     expect(view.byPosition.size).toBe(0);

--- a/src/lib/chart-view.ts
+++ b/src/lib/chart-view.ts
@@ -1,4 +1,5 @@
 import { Position } from "@/generated/prisma/enums";
+import { ALL_PLAY_INFIELD_POSITIONS, ALL_POSITIONS } from "@/lib/positions";
 import type { RsvpState } from "@/lib/rsvp";
 
 /// The view page's read-only render model (#8).
@@ -35,12 +36,11 @@ export type ChartView = {
   lineup: ChartViewPlayer[];
   /// Every position that has an assigned player, keyed by position.
   byPosition: Map<Position, ChartViewPlayer>;
-  /// Players with no position, in the roster's jersey-then-name order. What
-  /// this means depends on
-  /// the team's `allPlay` setting, which is why it isn't named here: on an
-  /// allPlay team it's the outfield (the diamond's LF/CF/RF are one zone and
-  /// hold everyone left over — see `droppablePositions` in chart.ts), and
-  /// otherwise it's the bench. The page decides how to say it.
+  /// Everyone the diamond doesn't seat, in the roster's jersey-then-name order.
+  /// What this means depends on the team's `allPlay` setting, which is why it
+  /// isn't named here: on an allPlay team it's the outfield (LF/CF/RF are one
+  /// zone and hold everyone left over — see `droppablePositions` in chart.ts),
+  /// and otherwise it's the bench. The page decides how to say it.
   unassigned: ChartViewPlayer[];
   /// True when at least one roster entry has a batting order or a position
   /// set — a partial chart (entered incrementally by hand during the
@@ -63,9 +63,24 @@ function byJerseyThenName(a: ChartViewPlayer, b: ChartViewPlayer): number {
   return a.jerseyNumber - b.jerseyNumber;
 }
 
+/**
+ * @param allPlay Which spots this team actually fields. The read-side twin of
+ * `buildPositionsDraft`'s parameter of the same name, and it does the same job:
+ * a player stored at a position the team doesn't field — an allPlay team's
+ * stale LF/CF/RF or CATCHER row, hand-set during #9 or left behind when allPlay
+ * was switched on — is pooled rather than seated.
+ *
+ * That is what keeps the two diamonds telling one story. The editor already
+ * shows those players in its outfield zone, and the view page draws its zone at
+ * the very coordinates a named outfield marker would occupy, so seating them
+ * here would stack two markers on one spot and make both names unreadable.
+ * Nobody vanishes either way — they are in the outfield, which is where the
+ * coach's next save will put them.
+ */
 export function buildChartView(
   entries: readonly ChartViewEntry[],
   rsvpStates: ReadonlyMap<string, RsvpState>,
+  allPlay: boolean,
 ): ChartView {
   const players = entries.map((entry) => ({
     ...entry,
@@ -76,9 +91,24 @@ export function buildChartView(
     .filter((player) => player.battingOrder !== null)
     .sort((a, b) => a.battingOrder! - b.battingOrder!);
 
+  const fielded = new Set<Position>(
+    allPlay ? ALL_PLAY_INFIELD_POSITIONS : ALL_POSITIONS,
+  );
   const byPosition = new Map<Position, ChartViewPlayer>();
+  const unseated: ChartViewPlayer[] = [];
   for (const player of players) {
-    if (player.position !== null) byPosition.set(player.position, player);
+    // First writer wins, matching buildPositionsDraft. The unique index makes a
+    // collision unreachable from a real read, but the loser is pooled rather
+    // than dropped if it ever happens.
+    if (
+      player.position !== null &&
+      fielded.has(player.position) &&
+      !byPosition.has(player.position)
+    ) {
+      byPosition.set(player.position, player);
+    } else {
+      unseated.push(player);
+    }
   }
 
   // Sorted, not left in the order `getChart` handed over: that is a findMany
@@ -86,9 +116,7 @@ export function buildChartView(
   // two requests and the outfield cluster would visibly reshuffle. Jersey then
   // name is `sortRoster`'s order (roster-rules.ts), which is what the coach
   // arranged in the editor's zone.
-  const unassigned = players
-    .filter((player) => player.position === null)
-    .sort(byJerseyThenName);
+  const unassigned = unseated.sort(byJerseyThenName);
 
   const hasChart = players.some(
     (player) => player.battingOrder !== null || player.position !== null,

--- a/src/lib/chart.test.ts
+++ b/src/lib/chart.test.ts
@@ -459,10 +459,9 @@ describe("save then reload round trip", () => {
 });
 
 describe("droppablePositions", () => {
-  it("is the six infield spots under allPlay — the outfield is one zone", () => {
+  it("is the five infield spots under allPlay — no catcher, and the outfield is one zone", () => {
     expect(droppablePositions(true)).toEqual([
       "PITCHER",
-      "CATCHER",
       "FIRST_BASE",
       "SECOND_BASE",
       "THIRD_BASE",
@@ -712,13 +711,13 @@ describe("nextDroppableId", () => {
   const infield = droppablePositions(true);
 
   it("cycles forward through the positions and then the zone", () => {
-    expect(nextDroppableId(infield, "PITCHER", 1)).toBe("CATCHER");
+    expect(nextDroppableId(infield, "PITCHER", 1)).toBe("FIRST_BASE");
     expect(nextDroppableId(infield, "SHORTSTOP", 1)).toBe(POSITION_POOL_ID);
     expect(nextDroppableId(infield, POSITION_POOL_ID, 1)).toBe("PITCHER");
   });
 
   it("cycles backward too", () => {
-    expect(nextDroppableId(infield, "CATCHER", -1)).toBe("PITCHER");
+    expect(nextDroppableId(infield, "FIRST_BASE", -1)).toBe("PITCHER");
     expect(nextDroppableId(infield, "PITCHER", -1)).toBe(POSITION_POOL_ID);
   });
 
@@ -768,8 +767,22 @@ describe("validatePositions", () => {
 
   it("rejects the same player at two positions", () => {
     expect(
-      validatePositions({ PITCHER: "a", CATCHER: "a" }, roster, true),
+      validatePositions({ PITCHER: "a", SHORTSTOP: "a" }, roster, true),
     ).toEqual({ ok: false, reason: "duplicate-entry" });
+  });
+
+  it("rejects the catcher for an allPlay team — the coach pitches", () => {
+    expect(validatePositions({ CATCHER: "a" }, roster, true)).toEqual({
+      ok: false,
+      reason: "invalid-position",
+    });
+  });
+
+  it("accepts the catcher when allPlay is off", () => {
+    expect(validatePositions({ CATCHER: "a" }, roster, false)).toEqual({
+      ok: true,
+      assignments: [{ entryId: "a", position: "CATCHER" }],
+    });
   });
 
   it("rejects a named outfield position for an allPlay team", () => {
@@ -814,11 +827,15 @@ describe("positions save then reload round trip", () => {
 
   it("reloads an allPlay board to exactly what was persisted", () => {
     const roster = ["a", "b", "c"];
-    const result = validatePositions({ PITCHER: "a", CATCHER: "b" }, roster, true);
+    const result = validatePositions(
+      { PITCHER: "a", SHORTSTOP: "b" },
+      roster,
+      true,
+    );
     if (!result.ok) throw new Error("expected ok");
 
     const draft = reload(roster, result.assignments, true);
-    expect(draft.assigned).toEqual({ PITCHER: "a", CATCHER: "b" });
+    expect(draft.assigned).toEqual({ PITCHER: "a", SHORTSTOP: "b" });
     // 'c' persisted as null and comes back in the outfield zone.
     expect(draft.pool).toEqual(["c"]);
   });

--- a/src/lib/chart.ts
+++ b/src/lib/chart.ts
@@ -1,5 +1,5 @@
 import type { Position } from "@/generated/prisma/enums";
-import { ALL_POSITIONS, INFIELD_POSITIONS } from "@/lib/positions";
+import { ALL_PLAY_INFIELD_POSITIONS, ALL_POSITIONS } from "@/lib/positions";
 
 /// Pure chart editing logic: the batting order (#10) and the positions
 /// diamond (#11).
@@ -321,9 +321,13 @@ export type PositionChartEntry = {
  * player per named position — so LF/CF/RF are not droppable and are never
  * written for an allPlay team. Those players persist as `position = null`,
  * which is unambiguous because an allPlay team has no bench.
+ *
+ * An allPlay team has no catcher either — the coach pitches — so C is not
+ * droppable there for the same reason, and a catcher lands in the outfield
+ * along with everyone else off the infield.
  */
 export function droppablePositions(allPlay: boolean): readonly Position[] {
-  return allPlay ? INFIELD_POSITIONS : ALL_POSITIONS;
+  return allPlay ? ALL_PLAY_INFIELD_POSITIONS : ALL_POSITIONS;
 }
 
 /// Where `entryId` currently stands, or null if they're in the pool or absent.

--- a/src/lib/positions.ts
+++ b/src/lib/positions.ts
@@ -24,11 +24,36 @@ export const INFIELD_POSITIONS: readonly Position[] = [
   "SHORTSTOP",
 ] as const;
 
+/**
+ * The infield an allPlay team actually fields: no catcher.
+ *
+ * allPlay is the coach-pitch end of youth baseball, where the coach pitches and
+ * nobody crouches behind the plate — so C is not a spot a coach can fill, the
+ * same way LF/CF/RF aren't (the outfield is one zone there). Drawing it as
+ * "Open" would show every parent a hole in the lineup that cannot be filled.
+ *
+ * Filtered rather than relisted so it can't drift out of scorebook order, or
+ * out of sync with INFIELD_POSITIONS.
+ */
+export const ALL_PLAY_INFIELD_POSITIONS: readonly Position[] =
+  INFIELD_POSITIONS.filter((position) => position !== "CATCHER");
+
 export const OUTFIELD_POSITIONS: readonly Position[] = [
   "LEFT_FIELD",
   "CENTER_FIELD",
   "RIGHT_FIELD",
 ] as const;
+
+/**
+ * The label inside an outfielder's marker on an allPlay diamond.
+ *
+ * Not a `Position`: the allPlay outfield is one zone holding however many
+ * players the infield leaves over, and every one of them persists as
+ * `position = null`. It lives here anyway because it is drawn in the same
+ * circles as the position abbreviations, and AGENTS.md's rule is that diamond
+ * labels come from this module rather than being written by hand.
+ */
+export const OUTFIELD_ZONE_LABEL = "OF";
 
 /// All nine, in scorebook order.
 export const ALL_POSITIONS: readonly Position[] = [


### PR DESCRIPTION
## Summary

An allPlay team has no catcher — the coach pitches — so `C` now behaves exactly like LF/CF/RF for those teams: not a drop target, not drawn as "Open". The view page's outfielders also move off the caption below the diamond and onto the grass, in the same circles as everyone else, and the editor's outfield/bench zone moves above the diamond.

## Key Decisions

**The absent catcher is drawn, not omitted.** Leaving the spot blank raised the question it was meant to settle — a gap behind the plate reads as something missing from the chart rather than as something the level doesn't have. `NoCatcherMarker` draws a solid disc there, deliberately unlike both the stroked circles that hold a player and the dashed ones that mean "Open", with no label and no name because there is nobody to name. It's shared by the view diamond and the editor diamond for the same reason their coordinates are; both render it inside an `aria-hidden` SVG, so both carry `NO_CATCHER_TEXT` for screen readers.

**`ALL_PLAY_INFIELD_POSITIONS` is filtered from `INFIELD_POSITIONS`, not relisted,** so it can't drift out of scorebook order or out of sync with its parent.

**The outfield zone is laid out geometrically rather than capped.** That outfield is one zone, so the count is whatever the infield leaves over — five on a twelve-player roster, but it moves with the team. `outfieldZoneCoords` bows each row centre-deepest, one row up to five and two beyond. Three land exactly on the LF/CF/RF coordinates, which is the point: a team that happens to field three still reads as the standard diamond rather than as some other chart.

**`buildChartView` now takes `allPlay` and seats only positions the team actually fields.** This is the read-side twin of what `buildPositionsDraft` already does for the editor, and it's what makes the marker collision below structurally unreachable rather than merely avoided. A stale row still doesn't vanish — the kid stands in the outfield, which is both where the editor shows them and where the coach's next save will put them.

**The zone moved above the diamond in the editor** because it is where every player starts and where the coach's thumb returns between drags; below a 400×520 board it sat off the bottom of a phone.

## What's in Scope

- `ALL_PLAY_INFIELD_POSITIONS` and `OUTFIELD_ZONE_LABEL` in `positions.ts`; `droppablePositions(true)` drops `CATCHER`, so `validatePositions` rejects a submitted catcher for an allPlay team
- `outfieldZoneCoords` in `diamond-geometry.ts`, plus `NoCatcherMarker` / `NO_CATCHER_TEXT`
- View diamond: OF markers on the grass, the absence disc, updated `sr-only` list
- Positions editor: zone above the diamond, no catcher target, the absence disc, `data-position` test hook
- `buildChartView` takes `allPlay` and pools rows for positions the team doesn't field
- `product-brief.md`'s positions bullet — this revises the decision it recorded, rather than reflecting code

### Out of Scope

- The team home page's "Lineup" button. It came up during review and was explicitly left alone.
- `computeReadiness` still doesn't flag an absent outfielder on an allPlay team, since those players hold `position = null`. Pre-existing, unchanged here.

## Bugs Found and Fixed During Self-Review

**A stale named-outfield row collided with the outfield zone.** The zone is drawn at the very coordinates a named outfield marker occupies — deliberately, so three outfielders read as the standard diamond. That made a leftover `LEFT_FIELD`/`CENTER_FIELD`/`RIGHT_FIELD` row on an allPlay team a collision: the named marker and the zone's own first marker landed on the same point (0px apart at zone sizes 1, 3, 5, 6; 20px at 4, 7, 8 — inside the 40px circle), and both players' names became unreadable. Nothing errored, and nothing showed up in the markup.

Fixed by teaching `buildChartView` about `allPlay`, so `byPosition` can no longer hold a spot the diamond doesn't draw and `Diamond` loses its stale-row branch entirely. `Diamond.test.tsx` gains the invariants that would have caught it: no two zone markers overlap, no zone marker overlaps an infield one, and the zone-on-LF/CF/RF coincidence is pinned with a note on what makes drawing both unreachable. `page.test.tsx` gains the specific case — a stale `CENTER_FIELD` row beside a real outfielder now renders two distinct OF markers.

A second commit also reverted a variable viewBox height introduced in the first. It existed to reclaim the catcher's dead band under allPlay, and once the disc filled that band it was buying nothing, so `diamondHeight()` and `positionPercent`'s `withCatcher` argument are gone and there is one box height again.

## Known Gaps / Follow-ups

- No live database in this environment, so nothing here was exercised against real Postgres rows. All of it is pure-function and render-level, and every branch is covered by tests.
- Geometry was verified by rendering the component to SVG headlessly at zone sizes 1, 3, 5 and 8 plus the collision case, not by driving the running app.
- The two-row outfield layout is tuned for realistic rosters. Beyond ~12 outfielders (a 17-player allPlay roster) the two rows pack tighter rather than adding a third, which would reach the middle infielders. The bounds test covers up to 12.

## Test Plan

- [ ] Run `pnpm check` (lint → typecheck → tests). 711 tests pass. Note `pnpm build` needs `DATABASE_URL` because it runs `prisma migrate deploy` first; `pnpm exec next build` skips that step.
- [ ] `pnpm dev`, open `/t/<teamId>/view` for an **allPlay** team whose roster is bigger than five. Confirm: five infield circles (P, 1B, 2B, 3B, SS), no `C` label, a grey disc below home plate, and one `OF` circle per remaining player arranged across the outfield with names and RSVP tags.
- [ ] Open `/t/<teamId>/chart/positions` for that team. Confirm the Outfield zone renders **above** the diamond, there is no catcher drop target, and the same grey disc appears. Drag a player between the zone and an infield spot, Save, and confirm the view page matches.
- [ ] Switch the team to `allPlay = false` in team settings. Confirm all nine positions return including a dashed `C` marked "Open", the zone is labelled "Bench", and no grey disc appears.
- [ ] Edge case — stale rows: with `pnpm db:studio`, set one roster entry's `position` to `CENTER_FIELD` and another's to `CATCHER` on an allPlay team. Confirm both players appear as `OF` circles on the view page with no overlapping markers and no `CF`/`C` labels, and that the coach's next Save collapses both to null.
- [ ] Edge case — screen reader: confirm the `sr-only` list still announces each position, the `Outfield:` roll-up, and "Catcher: nobody — the coach pitches."