### PR TITLE
Bulk parent invites with kids pre-linked and an optional coach message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,10 @@ src/generated/     # Prisma client output — gitignored, regenerate with pnpm d
 `src/app/` now has real routes: `/` (auth-gated landing), `/signin`, `/invite/[token]`
 (unauthenticated invitation accept page — deliberately outside proxy.ts's matcher), and
 `/t/[teamId]/` (team home, settings, roster, members, the owner-only returning-player
-picker at `roster/returning`, the member directory, the schedule at `schedule` /
-`schedule/[eventId]`, the read-only chart at `view`, and the two coach-only drag-and-drop
-chart editors — the batting order at `chart` and the positions diamond at
+picker at `roster/returning`, the coach-only bulk parent invite at `roster/invite`, the
+member directory, the schedule at `schedule` / `schedule/[eventId]`, the read-only chart
+at `view`, and the two coach-only drag-and-drop chart editors — the batting order at
+`chart` and the positions diamond at
 `chart/positions`) plus `/t/new` for owner-gated team creation.
 
 ## Tech Stack
@@ -234,3 +235,10 @@ production — the dev command can prompt, generate new migrations, and reset th
   whenever the draft builder normalized something — a stale `CENTER_FIELD` row under allPlay,
   or nine slots holding what used to be ten batters — and gating Save on the Cancel question
   leaves the coach looking at a change they cannot commit.
+- **The bulk invite action is the only place that sends in a loop, and three constants are
+  coupled across two files.** `bulkInviteGuardiansAction` paces sends `MIN_SEND_INTERVAL_MS`
+  (600ms) apart to stay under Resend's 2 req/s limit, caps a batch at `MAX_ROWS` (30), and
+  the page — not the action — declares `maxDuration = 60`, since that is the level governing
+  a Server Action's timeout. `MAX_ROWS × MIN_SEND_INTERVAL_MS` must stay well under
+  `maxDuration`, or an oversized batch times out half-finished instead of being rejected
+  cleanly. Raising the cap or the interval means revisiting the ceiling too.

--- a/src/app/t/[teamId]/roster/invite/actions.test.ts
+++ b/src/app/t/[teamId]/roster/invite/actions.test.ts
@@ -210,7 +210,7 @@ describe("bulkInviteGuardiansAction", () => {
   it("rejects an oversized batch before writing", async () => {
     const data = new FormData();
     data.set("teamId", "team-1");
-    for (let i = 0; i < 101; i += 1) {
+    for (let i = 0; i < 31; i += 1) {
       data.set(`email-entry-${i}`, `parent${i}@example.com`);
     }
 

--- a/src/app/t/[teamId]/roster/invite/actions.test.ts
+++ b/src/app/t/[teamId]/roster/invite/actions.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const requireTeamAccess = vi.fn();
+const getRosterEntry = vi.fn();
+const linkGuardian = vi.fn();
+const sendEmail = vi.fn();
+
+vi.mock("@/lib/team-access", () => ({
+  requireTeamAccess: (...args: unknown[]) => requireTeamAccess(...args),
+  TeamAccessError: class TeamAccessError extends Error {},
+}));
+
+vi.mock("@/lib/roster", () => ({
+  getRosterEntry: (...args: unknown[]) => getRosterEntry(...args),
+}));
+
+vi.mock("@/lib/invitations", () => ({
+  linkGuardian: (...args: unknown[]) => linkGuardian(...args),
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: unknown[]) => sendEmail(...args),
+}));
+
+vi.mock("@/lib/teams", () => ({
+  getTeamById: vi.fn().mockResolvedValue({ id: "team-1", name: "Cubs" }),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+// redirect() throws in Next; reproduce that so control flow matches
+// production — same shape as ../actions.test.ts.
+const REDIRECT_PREFIX = "NEXT_REDIRECT:";
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+  unstable_rethrow: (error: unknown) => {
+    if (error instanceof Error && error.message.startsWith("NEXT_REDIRECT:")) {
+      throw error;
+    }
+  },
+}));
+
+import { TeamAccessError } from "@/lib/team-access";
+import { bulkInviteGuardiansAction } from "./actions";
+
+function form(fields: Record<string, string>): FormData {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    data.set(key, value);
+  }
+  return data;
+}
+
+async function redirectUrlOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith(REDIRECT_PREFIX)) {
+      return error.message.slice(REDIRECT_PREFIX.length);
+    }
+    throw error;
+  }
+  throw new Error("expected a redirect");
+}
+
+function entryFor(id: string, playerId: string) {
+  return {
+    id,
+    jerseyNumber: null,
+    player: { id: playerId, name: "Kid", dateOfBirth: null },
+    guardians: [],
+  };
+}
+
+const INVITATION = {
+  token: "tok-1",
+  role: "PARENT",
+  expiresAt: new Date("2026-09-01T00:00:00Z"),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "coach-1" });
+  getRosterEntry.mockImplementation(async (_teamId: string, entryId: string) =>
+    entryFor(entryId, `player-of-${entryId}`),
+  );
+  linkGuardian.mockImplementation(async ({ email }: { email: string }) => ({
+    userId: "user-x",
+    email,
+    membershipCreated: true,
+    invitation: INVITATION,
+  }));
+  sendEmail.mockResolvedValue({ ok: true });
+});
+
+describe("bulkInviteGuardiansAction", () => {
+  it("links and emails every filled row, skipping blanks", async () => {
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({
+          teamId: "team-1",
+          "email-entry-1": "a@example.com",
+          "email-entry-2": "",
+          "email-entry-3": "b@example.com",
+        }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?sent=2");
+    expect(linkGuardian).toHaveBeenCalledTimes(2);
+    expect(linkGuardian).toHaveBeenCalledWith({
+      teamId: "team-1",
+      playerId: "player-of-entry-1",
+      email: "a@example.com",
+    });
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("derives playerId from the teamId-scoped entry, never the form", async () => {
+    await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({ teamId: "team-1", "email-entry-1": "a@example.com" }),
+      ),
+    );
+
+    expect(getRosterEntry).toHaveBeenCalledWith("team-1", "entry-1");
+  });
+
+  it("passes the coach's message into each email and omits it when blank", async () => {
+    await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({
+          teamId: "team-1",
+          message: "  See you at the field!  ",
+          "email-entry-1": "a@example.com",
+        }),
+      ),
+    );
+
+    const withMessage = sendEmail.mock.calls[0][0];
+    expect(JSON.stringify(withMessage.react)).toContain("See you at the field!");
+
+    sendEmail.mockClear();
+    await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({ teamId: "team-1", message: "   ", "email-entry-1": "a@example.com" }),
+      ),
+    );
+    const without = sendEmail.mock.calls[0][0];
+    expect(JSON.stringify(without.react)).not.toContain("whiteSpace");
+  });
+
+  it("rejects the whole batch before writing when any address is invalid", async () => {
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({
+          teamId: "team-1",
+          "email-entry-1": "a@example.com",
+          "email-entry-2": "not-an-email",
+        }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?error=invalid-email");
+    expect(linkGuardian).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects an over-long message before writing", async () => {
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({
+          teamId: "team-1",
+          message: "x".repeat(1001),
+          "email-entry-1": "a@example.com",
+        }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?error=invalid-message");
+    expect(linkGuardian).not.toHaveBeenCalled();
+  });
+
+  it("redirects with no-emails when every row is blank", async () => {
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(form({ teamId: "team-1", "email-entry-1": " " })),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?error=no-emails");
+  });
+
+  it("counts an already-member guardian as linked without emailing", async () => {
+    linkGuardian.mockResolvedValueOnce({
+      userId: "user-x",
+      email: "a@example.com",
+      membershipCreated: false,
+      invitation: null,
+    });
+
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({ teamId: "team-1", "email-entry-1": "a@example.com" }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?linked=1");
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("one failed row doesn't lose the rest of the batch", async () => {
+    sendEmail
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true });
+
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({
+          teamId: "team-1",
+          "email-entry-1": "a@example.com",
+          "email-entry-2": "b@example.com",
+        }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?sent=1&failed=1");
+  });
+
+  it("counts a vanished entry as failed and continues", async () => {
+    getRosterEntry
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(entryFor("entry-2", "player-2"));
+
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({
+          teamId: "team-1",
+          "email-entry-1": "a@example.com",
+          "email-entry-2": "b@example.com",
+        }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?sent=1&failed=1");
+    expect(linkGuardian).toHaveBeenCalledTimes(1);
+  });
+
+  it("a thrown row is counted as failed, not a 500", async () => {
+    linkGuardian
+      .mockRejectedValueOnce(new Error("db blinked"))
+      .mockImplementationOnce(async ({ email }: { email: string }) => ({
+        userId: "user-x",
+        email,
+        membershipCreated: true,
+        invitation: INVITATION,
+      }));
+
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({
+          teamId: "team-1",
+          "email-entry-1": "a@example.com",
+          "email-entry-2": "b@example.com",
+        }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?sent=1&failed=1");
+  });
+
+  it("redirects to access error when the caller lacks coach access", async () => {
+    requireTeamAccess.mockRejectedValue(new TeamAccessError("denied", "insufficient-role"));
+
+    const url = await redirectUrlOf(
+      bulkInviteGuardiansAction(
+        form({ teamId: "team-1", "email-entry-1": "a@example.com" }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/roster/invite?error=access");
+    expect(linkGuardian).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/t/[teamId]/roster/invite/actions.test.ts
+++ b/src/app/t/[teamId]/roster/invite/actions.test.ts
@@ -192,6 +192,34 @@ describe("bulkInviteGuardiansAction", () => {
     expect(url).toBe("/t/team-1/roster/invite?error=no-emails");
   });
 
+  it("keeps only the first row per entry, so a forged POST can't fan out", async () => {
+    const data = new FormData();
+    data.set("teamId", "team-1");
+    data.append("email-entry-1", "a@example.com");
+    data.append("email-entry-1", "attacker@example.com");
+
+    const url = await redirectUrlOf(bulkInviteGuardiansAction(data));
+
+    expect(url).toBe("/t/team-1/roster/invite?sent=1");
+    expect(linkGuardian).toHaveBeenCalledTimes(1);
+    expect(linkGuardian).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "a@example.com" }),
+    );
+  });
+
+  it("rejects an oversized batch before writing", async () => {
+    const data = new FormData();
+    data.set("teamId", "team-1");
+    for (let i = 0; i < 101; i += 1) {
+      data.set(`email-entry-${i}`, `parent${i}@example.com`);
+    }
+
+    const url = await redirectUrlOf(bulkInviteGuardiansAction(data));
+
+    expect(url).toBe("/t/team-1/roster/invite?error=too-many");
+    expect(linkGuardian).not.toHaveBeenCalled();
+  });
+
   it("counts an already-member guardian as linked without emailing", async () => {
     linkGuardian.mockResolvedValueOnce({
       userId: "user-x",

--- a/src/app/t/[teamId]/roster/invite/actions.ts
+++ b/src/app/t/[teamId]/roster/invite/actions.ts
@@ -1,0 +1,162 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect, unstable_rethrow } from "next/navigation";
+import { z } from "zod";
+
+import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
+import { getRosterEntry } from "@/lib/roster";
+import { linkGuardian } from "@/lib/invitations";
+import { getTeamById } from "@/lib/teams";
+import { sendEmail } from "@/lib/email";
+import { InvitationEmail } from "@/emails/InvitationEmail";
+import { buildInvitationEmail } from "@/emails/invitation-email";
+
+function extractTeamId(formData: FormData): string {
+  const teamId = String(formData.get("teamId")).trim();
+  if (!teamId || teamId === "null" || teamId === "undefined") {
+    throw new Error("Invalid team ID");
+  }
+  return teamId;
+}
+
+const emailSchema = z.email();
+
+/// Generous but bounded — the message rides inside the email body only, so
+/// the cap guards Resend's payload, not a database column.
+const messageSchema = z.string().trim().max(1000);
+
+/// One `email-<entryId>` field per player row. Blank rows are players the
+/// coach chose to skip, not errors.
+function collectRows(formData: FormData): { entryId: string; email: string }[] {
+  const rows: { entryId: string; email: string }[] = [];
+  for (const [key, value] of formData.entries()) {
+    if (!key.startsWith("email-") || typeof value !== "string") {
+      continue;
+    }
+    const email = value.trim();
+    if (!email) {
+      continue;
+    }
+    rows.push({ entryId: key.slice("email-".length), email });
+  }
+  return rows;
+}
+
+/**
+ * Invite many parents at once, each pre-linked to their kid.
+ *
+ * Per-row, this is exactly `linkGuardianAction` (../actions.ts): resolve the
+ * roster entry through the teamId-scoped lookup (never trusting a form
+ * playerId), let `linkGuardian` create the user, kid link, and membership,
+ * and mail the invitation only when the membership is new. The same address
+ * on two kids' rows therefore sends one email and links both kids — the
+ * second row's `invitation` comes back null.
+ *
+ * Rows are processed independently: one bad address or one Resend failure
+ * must not lose the rest of the batch, so each row's failure is counted and
+ * reported rather than thrown. A row whose entry has vanished (removed in
+ * another tab since render) is skipped the same way.
+ */
+export async function bulkInviteGuardiansAction(formData: FormData) {
+  const teamId = extractTeamId(formData);
+
+  const parsedMessage = messageSchema.safeParse(formData.get("message") ?? "");
+  if (!parsedMessage.success) {
+    redirect(`/t/${teamId}/roster/invite?error=invalid-message`);
+  }
+  const message = parsedMessage.data || undefined;
+
+  const rows = collectRows(formData);
+  if (rows.length === 0) {
+    redirect(`/t/${teamId}/roster/invite?error=no-emails`);
+  }
+  if (rows.some((row) => !emailSchema.safeParse(row.email).success)) {
+    redirect(`/t/${teamId}/roster/invite?error=invalid-email`);
+  }
+
+  let sent = 0;
+  let linked = 0;
+  let failed = 0;
+
+  try {
+    await requireTeamAccess(teamId, { intent: "write", minRole: "COACH" });
+
+    // One lookup for the whole batch — every email shares the team name and
+    // the env-derived base URL.
+    const team = await getTeamById(teamId);
+    const teamName = team?.name ?? "your team";
+    const env = {
+      AUTH_URL: process.env.AUTH_URL,
+      VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
+      VERCEL_URL: process.env.VERCEL_URL,
+    };
+
+    for (const row of rows) {
+      try {
+        const entry = await getRosterEntry(teamId, row.entryId);
+        if (!entry) {
+          failed += 1;
+          continue;
+        }
+
+        const result = await linkGuardian({
+          teamId,
+          playerId: entry.player.id,
+          email: row.email,
+        });
+
+        if (!result.invitation) {
+          // Already a member — the kid link is made, no email is owed.
+          linked += 1;
+          continue;
+        }
+
+        const { subject, acceptUrl } = buildInvitationEmail({
+          teamName,
+          token: result.invitation.token,
+          env,
+        });
+        const outcome = await sendEmail({
+          to: result.email,
+          subject,
+          react: InvitationEmail({
+            teamName,
+            acceptUrl,
+            expiresAt: result.invitation.expiresAt,
+            message,
+          }),
+        });
+
+        if (outcome.ok) {
+          sent += 1;
+        } else {
+          // The invitation row survives a failed send (design-doc.md #4
+          // Decision 7) — the player page's resend button can retry it.
+          failed += 1;
+        }
+      } catch (rowError) {
+        unstable_rethrow(rowError);
+        const detail =
+          rowError instanceof Error ? rowError.message : "Unknown error";
+        console.error(`Bulk invite failed for entry ${row.entryId}:`, detail);
+        failed += 1;
+      }
+    }
+  } catch (error) {
+    unstable_rethrow(error);
+    if (error instanceof TeamAccessError) {
+      redirect(`/t/${teamId}/roster/invite?error=access`);
+    }
+    throw error;
+  }
+
+  revalidatePath("/t/[teamId]/roster", "page");
+  revalidatePath("/t/[teamId]/roster/invite", "page");
+
+  const params = new URLSearchParams();
+  if (sent > 0) params.set("sent", String(sent));
+  if (linked > 0) params.set("linked", String(linked));
+  if (failed > 0) params.set("failed", String(failed));
+  redirect(`/t/${teamId}/roster/invite?${params.toString()}`);
+}

--- a/src/app/t/[teamId]/roster/invite/actions.ts
+++ b/src/app/t/[teamId]/roster/invite/actions.ts
@@ -27,12 +27,17 @@ const emailSchema = z.email();
 const messageSchema = z.string().trim().max(1000);
 
 /// Hard ceiling on rows in one batch. The rendered form never comes close —
-/// it is one row per unlinked player — but the action reads whatever fields
-/// the POST carries, and each row costs a query and (potentially) an email to
-/// an address taken straight from the request. Bounding the batch keeps a
-/// forged or repeated submission from turning one request into an unbounded
-/// send to arbitrary recipients.
-const MAX_ROWS = 100;
+/// it is one row per unlinked player, and a youth team is ~15 (product-brief.md)
+/// — but the action reads whatever fields the POST carries, and each row costs
+/// a query and (potentially) an email to an address taken straight from the
+/// request. Bounding the batch keeps a forged or repeated submission from
+/// turning one request into an unbounded send to arbitrary recipients.
+///
+/// Kept well under what MIN_SEND_INTERVAL_MS can fit inside the page's
+/// `maxDuration`: at 600ms a row, this is 18s of pacing before per-row work,
+/// against a 60s ceiling. A cap that could outlast the timeout would trade a
+/// clean rejection for a half-finished batch.
+const MAX_ROWS = 30;
 
 /// Resend's API is rate limited (2 requests/second by default), and a batch is
 /// the one place in this app that sends in a loop. Pace the sends so a

--- a/src/app/t/[teamId]/roster/invite/actions.ts
+++ b/src/app/t/[teamId]/roster/invite/actions.ts
@@ -26,10 +26,29 @@ const emailSchema = z.email();
 /// the cap guards Resend's payload, not a database column.
 const messageSchema = z.string().trim().max(1000);
 
+/// Hard ceiling on rows in one batch. The rendered form never comes close —
+/// it is one row per unlinked player — but the action reads whatever fields
+/// the POST carries, and each row costs a query and (potentially) an email to
+/// an address taken straight from the request. Bounding the batch keeps a
+/// forged or repeated submission from turning one request into an unbounded
+/// send to arbitrary recipients.
+const MAX_ROWS = 100;
+
+/// Resend's API is rate limited (2 requests/second by default), and a batch is
+/// the one place in this app that sends in a loop. Pace the sends so a
+/// full-team invite doesn't get its tail rejected as 429s — which would count
+/// as `failed` rows the coach can no longer retry from this page, since the
+/// guardian link already exists by then.
+const MIN_SEND_INTERVAL_MS = 600;
+
 /// One `email-<entryId>` field per player row. Blank rows are players the
 /// coach chose to skip, not errors.
+///
+/// Deduplicated by entryId, first row wins: the form renders exactly one input
+/// per player, so a repeated key can only come from a forged POST, and letting
+/// it through would mail several addresses per kid.
 function collectRows(formData: FormData): { entryId: string; email: string }[] {
-  const rows: { entryId: string; email: string }[] = [];
+  const byEntryId = new Map<string, string>();
   for (const [key, value] of formData.entries()) {
     if (!key.startsWith("email-") || typeof value !== "string") {
       continue;
@@ -38,9 +57,13 @@ function collectRows(formData: FormData): { entryId: string; email: string }[] {
     if (!email) {
       continue;
     }
-    rows.push({ entryId: key.slice("email-".length), email });
+    const entryId = key.slice("email-".length);
+    if (!entryId || byEntryId.has(entryId)) {
+      continue;
+    }
+    byEntryId.set(entryId, email);
   }
-  return rows;
+  return [...byEntryId].map(([entryId, email]) => ({ entryId, email }));
 }
 
 /**
@@ -71,6 +94,9 @@ export async function bulkInviteGuardiansAction(formData: FormData) {
   if (rows.length === 0) {
     redirect(`/t/${teamId}/roster/invite?error=no-emails`);
   }
+  if (rows.length > MAX_ROWS) {
+    redirect(`/t/${teamId}/roster/invite?error=too-many`);
+  }
   if (rows.some((row) => !emailSchema.safeParse(row.email).success)) {
     redirect(`/t/${teamId}/roster/invite?error=invalid-email`);
   }
@@ -91,6 +117,8 @@ export async function bulkInviteGuardiansAction(formData: FormData) {
       VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
       VERCEL_URL: process.env.VERCEL_URL,
     };
+
+    let lastSendAt = 0;
 
     for (const row of rows) {
       try {
@@ -117,6 +145,14 @@ export async function bulkInviteGuardiansAction(formData: FormData) {
           token: result.invitation.token,
           env,
         });
+        // Wait out only the remainder of the interval — a slow send has
+        // already paid for itself.
+        const waitMs = lastSendAt + MIN_SEND_INTERVAL_MS - Date.now();
+        if (waitMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, waitMs));
+        }
+        lastSendAt = Date.now();
+
         const outcome = await sendEmail({
           to: result.email,
           subject,

--- a/src/app/t/[teamId]/roster/invite/page.test.tsx
+++ b/src/app/t/[teamId]/roster/invite/page.test.tsx
@@ -102,6 +102,14 @@ describe("Bulk invite page", () => {
     expect(markup).not.toContain('name="message"');
   });
 
+  it("doesn't claim every player is covered when the roster reads empty", async () => {
+    getRosterWithGuardians.mockResolvedValue([]);
+
+    const markup = await renderPage();
+    expect(markup).toContain("No players on the roster yet");
+    expect(markup).not.toContain("Every player already has a parent linked");
+  });
+
   it("summarizes the batch outcome from query params", async () => {
     const markup = await renderPage({ sent: "3", linked: "1", failed: "2" });
 

--- a/src/app/t/[teamId]/roster/invite/page.test.tsx
+++ b/src/app/t/[teamId]/roster/invite/page.test.tsx
@@ -106,7 +106,7 @@ describe("Bulk invite page", () => {
     getRosterWithGuardians.mockResolvedValue([]);
 
     const markup = await renderPage();
-    expect(markup).toContain("No players on the roster yet");
+    expect(markup).toContain("No players to invite parents for");
     expect(markup).not.toContain("Every player already has a parent linked");
   });
 
@@ -115,7 +115,7 @@ describe("Bulk invite page", () => {
 
     expect(markup).toContain("3 invitations sent");
     expect(markup).toContain("1 already-member parent linked");
-    expect(markup).toContain("2 could not be sent");
+    expect(markup).toContain("2 could not be invited");
   });
 
   it("renders a friendly error banner", async () => {

--- a/src/app/t/[teamId]/roster/invite/page.test.tsx
+++ b/src/app/t/[teamId]/roster/invite/page.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const requireTeamAccess = vi.fn();
+const getRosterWithGuardians = vi.fn();
+const notFound = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+vi.mock("@/lib/team-access", () => ({
+  requireTeamAccess: (...args: unknown[]) => requireTeamAccess(...args),
+  TeamAccessError: class TeamAccessError extends Error {},
+}));
+
+vi.mock("@/lib/roster", () => ({
+  getRosterWithGuardians: (...args: unknown[]) => getRosterWithGuardians(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => notFound(),
+}));
+
+import { TeamAccessError } from "@/lib/team-access";
+
+function entry(
+  id: string,
+  name: string,
+  guardianEmails: string[],
+  jerseyNumber: number | null = null,
+) {
+  return {
+    id,
+    jerseyNumber,
+    player: { id: `player-${id}`, name, dateOfBirth: null },
+    guardianEmails,
+  };
+}
+
+async function renderPage(searchParams: Record<string, string> = {}) {
+  const { default: BulkInvitePage } = await import("./page");
+  const result = await BulkInvitePage({
+    params: Promise.resolve({ teamId: "team-1" }),
+    searchParams: Promise.resolve(searchParams),
+  });
+  return renderToStaticMarkup(result);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "coach-1" });
+  getRosterWithGuardians.mockResolvedValue([]);
+});
+
+describe("Bulk invite page", () => {
+  it("requires coach access and 404s a pasted parent URL", async () => {
+    requireTeamAccess.mockRejectedValue(new TeamAccessError("denied", "insufficient-role"));
+
+    await expect(renderPage()).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(requireTeamAccess).toHaveBeenCalledWith("team-1", {
+      intent: "read",
+      minRole: "COACH",
+    });
+  });
+
+  it("renders an email input only for players without guardians", async () => {
+    getRosterWithGuardians.mockResolvedValue([
+      entry("entry-1", "Ada", []),
+      entry("entry-2", "Zed", ["parent@example.com"]),
+    ]);
+
+    const markup = await renderPage();
+
+    expect(markup).toContain('name="email-entry-1"');
+    expect(markup).not.toContain('name="email-entry-2"');
+    expect(markup).toContain("parent@example.com");
+  });
+
+  it("orders rows by jersey number like the roster page", async () => {
+    getRosterWithGuardians.mockResolvedValue([
+      entry("entry-1", "Zed", [], 9),
+      entry("entry-2", "Ada", [], 3),
+    ]);
+
+    const markup = await renderPage();
+    expect(markup.indexOf("Ada")).toBeLessThan(markup.indexOf("Zed"));
+  });
+
+  it("offers the message box with the form", async () => {
+    getRosterWithGuardians.mockResolvedValue([entry("entry-1", "Ada", [])]);
+
+    const markup = await renderPage();
+    expect(markup).toContain('name="message"');
+  });
+
+  it("shows the empty state when every player is covered", async () => {
+    getRosterWithGuardians.mockResolvedValue([
+      entry("entry-1", "Ada", ["a@example.com"]),
+    ]);
+
+    const markup = await renderPage();
+    expect(markup).toContain("Every player already has a parent linked");
+    expect(markup).not.toContain('name="message"');
+  });
+
+  it("summarizes the batch outcome from query params", async () => {
+    const markup = await renderPage({ sent: "3", linked: "1", failed: "2" });
+
+    expect(markup).toContain("3 invitations sent");
+    expect(markup).toContain("1 already-member parent linked");
+    expect(markup).toContain("2 could not be sent");
+  });
+
+  it("renders a friendly error banner", async () => {
+    const markup = await renderPage({ error: "invalid-email" });
+    expect(markup).toContain("isn&#x27;t valid");
+  });
+});

--- a/src/app/t/[teamId]/roster/invite/page.tsx
+++ b/src/app/t/[teamId]/roster/invite/page.tsx
@@ -76,12 +76,14 @@ export default async function BulkInvitePage({
   const statusParts = [
     sent ? `${sent} invitation${sent === "1" ? "" : "s"} sent` : null,
     linked ? `${linked} already-member parent${linked === "1" ? "" : "s"} linked` : null,
-    // Deliberately not "try again here": a failed send still created the
-    // guardian link, so that kid has moved to the covered list below and no
-    // longer has a row on this form. The player's page is where the
-    // invitation can actually be resent.
+    // Deliberately not "try again here", and deliberately vague about where.
+    // `failed` covers three different states: a send that failed (the guardian
+    // link exists, so that kid has moved to the covered list below and has no
+    // row on this form — the player's page can resend), a roster entry that
+    // vanished between render and submit (no link, and no player to open), and
+    // a row that threw (indeterminate). Only the roster can tell them apart.
     failed
-      ? `${failed} could not be sent — open the player from the roster to resend`
+      ? `${failed} could not be invited — check those players on the roster`
       : null,
   ].filter(Boolean);
 
@@ -108,12 +110,13 @@ export default async function BulkInvitePage({
 
       {/* An empty roster reaches this page with nothing to invite for, and so
           does a database outage — getRosterWithGuardians swallows read errors
-          to an empty list. Neither is "every player already has a parent", so
-          they get their own, non-committal line. */}
+          to an empty list. Neither is "every player already has a parent", and
+          this page cannot tell the two apart, so the line commits to neither:
+          it points at the roster, which is right either way. */}
       {roster.length === 0 ? (
         <p className="text-sm text-muted-foreground">
-          No players on the roster yet. Add players first, then invite their
-          parents.
+          No players to invite parents for. Check the roster — invitations start
+          from the players on it.
         </p>
       ) : needingGuardians.length === 0 ? (
         <p className="text-sm text-muted-foreground">

--- a/src/app/t/[teamId]/roster/invite/page.tsx
+++ b/src/app/t/[teamId]/roster/invite/page.tsx
@@ -1,0 +1,178 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
+import { getRosterWithGuardians } from "@/lib/roster";
+import { sortRoster } from "@/lib/roster-rules";
+
+import { bulkInviteGuardiansAction } from "./actions";
+
+export const metadata = {
+  title: "Invite parents — Youth Baseball Team Manager",
+};
+
+const ERROR_MESSAGES: Record<string, string> = {
+  "invalid-email": "One of the email addresses isn't valid. Nothing was sent.",
+  "invalid-message": "The message is too long — keep it under 1,000 characters.",
+  "no-emails": "Enter at least one email address.",
+  access: "You no longer have access to make this change.",
+};
+
+/// Coach-only, like the chart editors: parents have no link here and minRole
+/// turns a pasted URL into a 404. Calls requireTeamAccess itself, independent
+/// of the layout — every page under /t/[teamId] does.
+export default async function BulkInvitePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ teamId: string }>;
+  searchParams: Promise<{
+    error?: string;
+    sent?: string;
+    linked?: string;
+    failed?: string;
+  }>;
+}) {
+  const { teamId } = await params;
+  const { error, sent, linked, failed } = await searchParams;
+
+  try {
+    await requireTeamAccess(teamId, { intent: "read", minRole: "COACH" });
+  } catch (caught) {
+    if (caught instanceof TeamAccessError) {
+      notFound();
+    }
+    throw caught;
+  }
+
+  const roster = sortRoster(await getRosterWithGuardians(teamId));
+  const needingGuardians = roster.filter(
+    (entry) => entry.guardianEmails.length === 0,
+  );
+  const covered = roster.filter((entry) => entry.guardianEmails.length > 0);
+
+  const errorMessage = error
+    ? (ERROR_MESSAGES[error] ?? "Something went wrong.")
+    : null;
+  const statusParts = [
+    sent ? `${sent} invitation${sent === "1" ? "" : "s"} sent` : null,
+    linked ? `${linked} already-member parent${linked === "1" ? "" : "s"} linked` : null,
+    failed ? `${failed} could not be sent — check the addresses and try again` : null,
+  ].filter(Boolean);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <h3 className="text-xl font-semibold text-foreground">Invite parents</h3>
+        <Button asChild variant="outline" size="sm">
+          <Link href={`/t/${teamId}/roster`}>Back to roster</Link>
+        </Button>
+      </div>
+
+      {errorMessage ? (
+        <p role="alert" className="text-sm text-destructive">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      {!errorMessage && statusParts.length > 0 ? (
+        <p role="status" className="text-sm text-muted-foreground">
+          {statusParts.join(". ")}.
+        </p>
+      ) : null}
+
+      {needingGuardians.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Every player already has a parent linked. To add another parent for a
+          kid, open the player from the roster.
+        </p>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Send invitations</CardTitle>
+            <CardDescription>
+              Enter a parent&apos;s email next to their kid — leave a row blank to
+              skip it. Each parent joins with their kid already linked, so
+              there&apos;s nothing for them to set up.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form action={bulkInviteGuardiansAction} className="space-y-4">
+              <input type="hidden" name="teamId" value={teamId} />
+
+              <ul className="space-y-3">
+                {needingGuardians.map((entry) => (
+                  <li key={entry.id} className="space-y-1">
+                    <label
+                      htmlFor={`email-${entry.id}`}
+                      className="block text-sm font-medium text-foreground"
+                    >
+                      {entry.player.name}
+                      {entry.jerseyNumber !== null ? ` (#${entry.jerseyNumber})` : ""}
+                    </label>
+                    <input
+                      id={`email-${entry.id}`}
+                      name={`email-${entry.id}`}
+                      type="email"
+                      placeholder="parent@example.com"
+                      className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </li>
+                ))}
+              </ul>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor="message"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  Message (optional)
+                </label>
+                <textarea
+                  id="message"
+                  name="message"
+                  rows={4}
+                  maxLength={1000}
+                  placeholder="A note included in every invitation email."
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+
+              <Button type="submit" className="w-full">
+                Send invitations
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      {covered.length > 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Already have a parent linked</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1">
+              {covered.map((entry) => (
+                <li key={entry.id} className="text-sm text-muted-foreground">
+                  <span className="font-medium text-foreground">
+                    {entry.player.name}
+                  </span>{" "}
+                  — {entry.guardianEmails.join(", ")}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/t/[teamId]/roster/invite/page.tsx
+++ b/src/app/t/[teamId]/roster/invite/page.tsx
@@ -19,10 +19,21 @@ export const metadata = {
   title: "Invite parents — Youth Baseball Team Manager",
 };
 
+/// Every other action in this app does one round trip; this one loops, and
+/// `bulkInviteGuardiansAction` paces its sends 600ms apart to stay under
+/// Resend's rate limit. A full first-season batch is one row per player —
+/// ~15 for a youth team (product-brief.md) — so roughly 15 × (600ms + the
+/// row's own queries and send), comfortably past the seconds a single-shot
+/// action needs but well inside this ceiling. Set at the page level because
+/// that is what governs a Server Action's timeout, per Next's route segment
+/// config docs.
+export const maxDuration = 60;
+
 const ERROR_MESSAGES: Record<string, string> = {
   "invalid-email": "One of the email addresses isn't valid. Nothing was sent.",
   "invalid-message": "The message is too long — keep it under 1,000 characters.",
   "no-emails": "Enter at least one email address.",
+  "too-many": "That's too many invitations for one batch. Nothing was sent.",
   access: "You no longer have access to make this change.",
 };
 
@@ -65,7 +76,13 @@ export default async function BulkInvitePage({
   const statusParts = [
     sent ? `${sent} invitation${sent === "1" ? "" : "s"} sent` : null,
     linked ? `${linked} already-member parent${linked === "1" ? "" : "s"} linked` : null,
-    failed ? `${failed} could not be sent — check the addresses and try again` : null,
+    // Deliberately not "try again here": a failed send still created the
+    // guardian link, so that kid has moved to the covered list below and no
+    // longer has a row on this form. The player's page is where the
+    // invitation can actually be resent.
+    failed
+      ? `${failed} could not be sent — open the player from the roster to resend`
+      : null,
   ].filter(Boolean);
 
   return (
@@ -89,7 +106,16 @@ export default async function BulkInvitePage({
         </p>
       ) : null}
 
-      {needingGuardians.length === 0 ? (
+      {/* An empty roster reaches this page with nothing to invite for, and so
+          does a database outage — getRosterWithGuardians swallows read errors
+          to an empty list. Neither is "every player already has a parent", so
+          they get their own, non-committal line. */}
+      {roster.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No players on the roster yet. Add players first, then invite their
+          parents.
+        </p>
+      ) : needingGuardians.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           Every player already has a parent linked. To add another parent for a
           kid, open the player from the roster.

--- a/src/app/t/[teamId]/roster/page.tsx
+++ b/src/app/t/[teamId]/roster/page.tsx
@@ -60,11 +60,18 @@ export default async function RosterPage({
     <div className="space-y-6">
       <div className="flex items-center justify-between gap-4">
         <h3 className="text-xl font-semibold text-foreground">Roster</h3>
-        {isOwner ? (
-          <Button asChild variant="outline" size="sm">
-            <Link href={`/t/${teamId}/roster/returning`}>Add returning player</Link>
-          </Button>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {canEdit ? (
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/t/${teamId}/roster/invite`}>Invite parents</Link>
+            </Button>
+          ) : null}
+          {isOwner ? (
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/t/${teamId}/roster/returning`}>Add returning player</Link>
+            </Button>
+          ) : null}
+        </div>
       </div>
 
       {errorMessage ? (

--- a/src/emails/InvitationEmail.tsx
+++ b/src/emails/InvitationEmail.tsx
@@ -16,6 +16,10 @@ export type InvitationEmailProps = {
   teamName: string;
   acceptUrl: string;
   expiresAt: Date;
+  /// A note the coach typed for this batch of invitations. Lives only in the
+  /// email — deliberately not stored on `Invitation`, so there is no message
+  /// column and nothing to render on the accept page.
+  message?: string;
 };
 
 function formatExpiry(date: Date): string {
@@ -30,6 +34,7 @@ export function InvitationEmail({
   teamName,
   acceptUrl,
   expiresAt,
+  message,
 }: InvitationEmailProps) {
   return (
     <Html>
@@ -38,6 +43,9 @@ export function InvitationEmail({
       <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
         <Container>
           <Text>You&apos;ve been invited to join {teamName}.</Text>
+          {message ? (
+            <Text style={{ whiteSpace: "pre-wrap" }}>{message}</Text>
+          ) : null}
           <Button
             href={acceptUrl}
             style={{

--- a/src/lib/roster.test.ts
+++ b/src/lib/roster.test.ts
@@ -52,6 +52,7 @@ import {
   getChart,
   getRoster,
   getRosterEntry,
+  getRosterWithGuardians,
   isReturningCandidate,
   listReturningCandidates,
   removeRosterEntry,
@@ -95,6 +96,46 @@ describe("getRoster", () => {
     findManyRosterEntries.mockRejectedValue(new Error("connection refused"));
 
     await expect(getRoster("team-1")).resolves.toEqual([]);
+  });
+});
+
+describe("getRosterWithGuardians", () => {
+  it("scopes the query to the team and flattens guardian emails", async () => {
+    findManyRosterEntries.mockResolvedValue([
+      {
+        id: "entry-1",
+        jerseyNumber: 4,
+        player: {
+          id: "player-1",
+          name: "Ada",
+          dateOfBirth: null,
+          guardians: [
+            { user: { email: "mom@example.com" } },
+            { user: { email: "dad@example.com" } },
+          ],
+        },
+      },
+    ]);
+
+    const result = await getRosterWithGuardians("team-1");
+
+    expect(findManyRosterEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { teamId: "team-1" } }),
+    );
+    expect(result).toEqual([
+      {
+        id: "entry-1",
+        jerseyNumber: 4,
+        player: { id: "player-1", name: "Ada", dateOfBirth: null },
+        guardianEmails: ["mom@example.com", "dad@example.com"],
+      },
+    ]);
+  });
+
+  it("returns an empty array when the database throws", async () => {
+    findManyRosterEntries.mockRejectedValue(new Error("connection refused"));
+
+    await expect(getRosterWithGuardians("team-1")).resolves.toEqual([]);
   });
 });
 

--- a/src/lib/roster.ts
+++ b/src/lib/roster.ts
@@ -84,6 +84,59 @@ export async function getRoster(teamId: string): Promise<RosterEntry[]> {
   }
 }
 
+export type RosterEntryWithGuardians = RosterEntry & {
+  /// Every guardian email linked to this player, in no particular order.
+  /// Empty means nobody has been invited for this kid yet — the signal the
+  /// bulk invite page (#4 follow-up) keys on.
+  guardianEmails: string[];
+};
+
+/**
+ * The roster with each player's linked guardian emails — for the bulk invite
+ * page, which needs to know which kids still have no parent attached.
+ *
+ * List shape, so database errors are swallowed to an empty result, matching
+ * `getRoster`'s rationale above.
+ */
+export async function getRosterWithGuardians(
+  teamId: string,
+): Promise<RosterEntryWithGuardians[]> {
+  try {
+    const entries = await db.rosterEntry.findMany({
+      where: { teamId },
+      select: {
+        id: true,
+        jerseyNumber: true,
+        player: {
+          select: {
+            id: true,
+            name: true,
+            dateOfBirth: true,
+            guardians: {
+              select: { user: { select: { email: true } } },
+            },
+          },
+        },
+      },
+    });
+
+    return entries.map((entry) => ({
+      id: entry.id,
+      jerseyNumber: entry.jerseyNumber,
+      player: {
+        id: entry.player.id,
+        name: entry.player.name,
+        dateOfBirth: entry.player.dateOfBirth,
+      },
+      guardianEmails: entry.player.guardians.map(({ user }) => user.email),
+    }));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Failed to fetch roster with guardians:", message);
+    return [];
+  }
+}
+
 /**
  * The team's standing chart — every roster entry with its batting order and
  * position, for #8's view page.


### PR DESCRIPTION
Closes #34

## Summary

Adds a coach-only **Invite parents** page (`/t/[teamId]/roster/invite`) that invites many parents in one submit — one email field per player who has no guardian linked yet, plus an optional message included in every invitation email. Each row runs the existing `linkGuardian` path, so every parent arrives with their kid, membership, and team already attached; after signing in there is nothing for them to select or set up.

## Key Decisions

- **The message lives only in the email.** It became an optional prop on `InvitationEmail`, not a column on `Invitation` — nothing to migrate, and nothing to render on the accept page. Chosen deliberately over storing it.
- **Roster-shaped form instead of a free-form email list.** Matching email→kid at entry time is what makes a "pick your kid" step unnecessary later, and it makes typos visible (the address sits next to the kid's name). Players who already have a guardian are shown in a read-only "already covered" list instead of an input row.
- **Rows fail independently.** A bad send, a thrown row, or an entry deleted in another tab is counted and reported without losing the rest of the batch — same posture as `notifyNewGuardians` in the returning-player flow. Invalid *addresses*, by contrast, reject the whole batch before any write, so a typo never produces a half-sent batch.
- **Per-row security matches `linkGuardianAction`:** `playerId` is derived from the teamId-scoped `getRosterEntry` lookup, never trusted from the form, and the action gates on `requireTeamAccess(minRole: "COACH", intent: "write")`. The page 404s a pasted parent URL, same as the chart editors.
- **Sibling handling falls out of `linkGuardian`:** the same address on two kids' rows sends one email and links both kids (the second row's `invitation` comes back null and is counted as "linked", not "sent").
- **Three constants are coupled across two files.** Sends are paced `MIN_SEND_INTERVAL_MS` (600ms) apart to stay under Resend's 2 req/s limit; `MAX_ROWS` (30) caps a batch; and the *page* declares `maxDuration = 60`, since that is the level governing a Server Action's timeout. Their product must stay under the ceiling — documented in `AGENTS.md`.

## What's in Scope

- New loader `getRosterWithGuardians` in `src/lib/roster.ts` (list shape, swallows DB errors like `getRoster`), with tests.
- New page `src/app/t/[teamId]/roster/invite/page.tsx` + server action `bulkInviteGuardiansAction`, both with co-located tests.
- Optional `message` prop on `InvitationEmail` (rendered `pre-wrap`, capped at 1,000 chars by zod and the textarea's `maxLength`).
- "Invite parents" button on the roster page header, visible to coaches and owners.
- `AGENTS.md`: the new route added to the route list, plus a gotcha for the timing coupling above.

### Out of Scope

- Parent self-service "add another parent for my kid" — coaches can already link additional guardians per kid from the player page.
- A message on the single-guardian form on the player page — that flow is unchanged.
- Preserving typed form values when a batch is rejected for an invalid address; needs `useActionState` plumbing and a client component, which is a change in shape for this page.

## Bugs Found and Fixed During Self-Review

- **Unthrottled sends.** A full-team batch tripped Resend's 2 req/s limit and counted its tail as `failed` — rows the coach could no longer retry from this page, since the guardian link already existed. Sends are now paced.
- **A false empty state.** `getRosterWithGuardians` swallows read errors to an empty list, so a database outage rendered "every player already has a parent linked". Now a separate branch that asserts neither cause.
- **Unactionable failure copy.** "Check the addresses and try again" was wrong: a failed send already created the link, so that kid had left the form. Reworded, then reworded again after review to cover vanished entries and thrown rows too.
- **Fan-out on a forged POST.** `collectRows` accepted repeated `email-<entryId>` keys with no batch ceiling — arbitrary recipients, attacker-controlled body, verified sending domain. Now deduped by entryId and capped.

## Known Gaps / Follow-ups

- Verified via the mocked-DB test suite only; this environment has no live Postgres or Resend key, so the end-to-end send wasn't exercised (same standing caveat as the existing invite flows). The manual steps below are the ones that need a real environment.
- `MAX_ROWS = 30` is now a product constraint, not just an abuse guard — a roster larger than 30 would be rejected. Well past the ~15 the product brief describes.

## Test Plan

- [x] Run this repo's full check gate (see `AGENTS.md` → `## Commands`): `pnpm check` — passes (lint, typecheck, 767 tests / 56 files).
- [ ] Run `pnpm dev`, sign in as a coach/owner, visit `/t/<teamId>/roster` → **Invite parents**. Confirm only players without a linked guardian get an email field, fill in two addresses plus a message, submit, and confirm the "2 invitations sent" banner and that each received email contains the message and an `/invite/<token>` link that lands on the accept page.
- [ ] Edge cases: submit with all rows blank (→ "Enter at least one email address"), one malformed address (→ whole batch rejected, nothing sent), the same address on two kids (→ one email, both kids linked), and visit the page as a PARENT via pasted URL (→ 404).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6sTcWjX2Lw6ae6ASf8TjF)_