### PR TITLE
Sign a parent in when they accept, instead of mailing a second link

### DIFF
--- a/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
@@ -47,9 +47,12 @@ their keep by telling the coach when a week *isn't* normal.
 
 Scoped to fit **6 weeks of evenings and weekends**.
 
-- **Auth & onboarding** — coach enters parent emails; each gets an invitation link;
-  clicking it issues a one-time, expiring magic link and creates the account. No
-  passwords. No self-serve signup.
+- **Auth & onboarding** — coach enters parent emails; each gets a one-time, expiring
+  invitation link; opening it and accepting creates the account and signs the parent in on
+  that device, in one trip. (Revised 2026-08-18: accepting used to *mail* a magic link,
+  making onboarding two emails; real parents stopped at the second one. The magic link
+  remains what `/signin` sends for everyone who is already a member.) No passwords. No
+  self-serve signup.
 - **Teams** — the owner creates a team per season and keeps past teams around. Every
   screen operates on exactly one **active team**, chosen from a team switcher. **Past
   teams are read-only** — they render completely but reject every mutation, so there's no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,17 @@ production — the dev command can prompt, generate new migrations, and reset th
   **Which shape a real write actually returns is unverified** — this repo has not yet run a
   write against live Postgres that trips one of these constraints. Confirm it before relying
   on this in production, and adjust the matching in `roster-rules.ts` if it differs.
+- **Two things write the session cookie, and Auth.js is only one of them.** Accepting an
+  invitation at `/invite/[token]` signs the parent in directly — Auth.js v5 has no
+  "sign this user in" API under the database strategy, so `src/lib/sessions.ts` inserts the
+  `Session` row the way `@auth/core` does (a `randomUUID()` token, `expires` at now + max
+  age) and the action sets the cookie itself. Name and attributes come from
+  `src/lib/session-cookie.ts`, which restates Auth.js's defaults once for all three
+  consumers — Auth.js, that action, and `proxy.ts`. If `src/auth.ts` ever grows a `cookies`
+  block or a `session.generateSessionToken`, that module has to move with it or a parent
+  accepting an invitation gets a cookie the app cannot read. Accepting is a **POST**, never
+  a GET: it consumes the invitation, and corporate mail scanners follow every link in a
+  message before the recipient sees it.
 - Chart edits are permanent — no undo, no history. Patching the order because a kid is out
   makes that the order. This was chosen deliberately; flag it rather than silently adding
   per-game overrides.

--- a/src/app/invite/[token]/actions.test.ts
+++ b/src/app/invite/[token]/actions.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const getInvitationByToken = vi.fn();
+const resolveInvitedUser = vi.fn();
+const acceptInvitations = vi.fn();
+const createUserSession = vi.fn();
+const cookieSet = vi.fn();
+const headerGet = vi.fn();
+
+vi.mock("@/lib/invitations", () => ({
+  getInvitationByToken: (...args: unknown[]) => getInvitationByToken(...args),
+  resolveInvitedUser: (...args: unknown[]) => resolveInvitedUser(...args),
+  acceptInvitations: (...args: unknown[]) => acceptInvitations(...args),
+}));
+
+vi.mock("@/lib/sessions", () => ({
+  createUserSession: (...args: unknown[]) => createUserSession(...args),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ set: (...args: unknown[]) => cookieSet(...args) }),
+  headers: async () => ({ get: (...args: unknown[]) => headerGet(...args) }),
+}));
+
+// redirect() throws in Next; reproduce that so control flow matches production
+// and a "redirected" assertion can't pass by accident. Identified by message
+// prefix rather than a class, because vi.mock factories are hoisted above any
+// top-level declaration they'd reference.
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+  unstable_rethrow: (error: unknown) => {
+    if (error instanceof Error && error.message.startsWith("NEXT_REDIRECT:")) {
+      throw error;
+    }
+  },
+}));
+
+import { acceptInvitationAction } from "./actions";
+
+const NOW = new Date("2026-04-01T12:00:00Z");
+const EXPIRES = new Date("2026-07-01T12:00:00Z");
+
+function liveInvitation() {
+  return {
+    teamId: "team-1",
+    teamName: "Cubs",
+    email: "sam@example.com",
+    role: "PARENT" as const,
+    expiresAt: new Date(NOW.getTime() + 60_000),
+    acceptedAt: null,
+  };
+}
+
+function form(token: unknown) {
+  const data = new FormData();
+  if (token !== undefined) {
+    data.set("token", String(token));
+  }
+  return data;
+}
+
+/// Every success and failure path ends in a redirect, so the assertion is
+/// always "where did it throw us".
+async function destinationOf(data: FormData): Promise<string> {
+  try {
+    await acceptInvitationAction(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("NEXT_REDIRECT:")) {
+      return message.slice("NEXT_REDIRECT:".length);
+    }
+    throw error;
+  }
+  throw new Error("Expected the action to redirect");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+
+  getInvitationByToken.mockResolvedValue(liveInvitation());
+  resolveInvitedUser.mockResolvedValue({
+    id: "user-1",
+    email: "sam@example.com",
+  });
+  acceptInvitations.mockResolvedValue(1);
+  createUserSession.mockResolvedValue({
+    sessionToken: "session-token-1",
+    expires: EXPIRES,
+  });
+  headerGet.mockReturnValue("https");
+  delete process.env.AUTH_URL;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("acceptInvitationAction", () => {
+  it("grants the membership, writes a session cookie, and lands on the team", async () => {
+    expect(await destinationOf(form("tok-1"))).toBe("/t/team-1");
+
+    // The address comes from the invitation row, never from the form.
+    expect(resolveInvitedUser).toHaveBeenCalledWith("sam@example.com");
+    expect(acceptInvitations).toHaveBeenCalledWith("user-1", "sam@example.com");
+    expect(createUserSession).toHaveBeenCalledWith("user-1");
+    expect(cookieSet).toHaveBeenCalledWith(
+      "__Secure-authjs.session-token",
+      "session-token-1",
+      {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: true,
+        expires: EXPIRES,
+      },
+    );
+  });
+
+  it("writes the unprefixed cookie name over plain HTTP", async () => {
+    headerGet.mockReturnValue("http");
+
+    await destinationOf(form("tok-1"));
+
+    expect(cookieSet).toHaveBeenCalledWith(
+      "authjs.session-token",
+      "session-token-1",
+      expect.objectContaining({ secure: false }),
+    );
+  });
+
+  it("grants the membership before creating the session", async () => {
+    const order: string[] = [];
+    acceptInvitations.mockImplementation(async () => {
+      order.push("accept");
+      return 1;
+    });
+    createUserSession.mockImplementation(async () => {
+      order.push("session");
+      return { sessionToken: "session-token-1", expires: EXPIRES };
+    });
+
+    await destinationOf(form("tok-1"));
+
+    expect(order).toEqual(["accept", "session"]);
+  });
+
+  it("sends an unknown token back to the invite page without writing anything", async () => {
+    getInvitationByToken.mockResolvedValue(null);
+
+    expect(await destinationOf(form("tok-1"))).toBe("/invite/tok-1");
+    expect(acceptInvitations).not.toHaveBeenCalled();
+    expect(cookieSet).not.toHaveBeenCalled();
+  });
+
+  // Liveness is re-checked here rather than trusted from the page render: the
+  // invitation can expire between the page loading and this submitting.
+  it("sends an expired token back to the invite page without writing anything", async () => {
+    getInvitationByToken.mockResolvedValue({
+      ...liveInvitation(),
+      expiresAt: new Date(NOW.getTime() - 1),
+    });
+
+    expect(await destinationOf(form("tok-1"))).toBe("/invite/tok-1");
+    expect(acceptInvitations).not.toHaveBeenCalled();
+  });
+
+  it("sends an already-accepted token back to the invite page", async () => {
+    getInvitationByToken.mockResolvedValue({
+      ...liveInvitation(),
+      acceptedAt: NOW,
+    });
+
+    expect(await destinationOf(form("tok-1"))).toBe("/invite/tok-1");
+    expect(acceptInvitations).not.toHaveBeenCalled();
+  });
+
+  it("shows an error rather than a team page when the grant fails", async () => {
+    acceptInvitations.mockRejectedValue(new Error("db down"));
+
+    expect(await destinationOf(form("tok-1"))).toBe("/invite/tok-1?error=1");
+    expect(cookieSet).not.toHaveBeenCalled();
+  });
+
+  // The parent is a member by then, so /signin admits them — but they must not
+  // be sent to a team page they hold no session for.
+  it("shows an error when the session write fails after the grant succeeded", async () => {
+    createUserSession.mockRejectedValue(new Error("db down"));
+
+    expect(await destinationOf(form("tok-1"))).toBe("/invite/tok-1?error=1");
+  });
+
+  it("rejects a missing or placeholder token outright", async () => {
+    await expect(acceptInvitationAction(form(undefined))).rejects.toThrow(
+      "Invalid invitation token",
+    );
+    await expect(acceptInvitationAction(form("null"))).rejects.toThrow(
+      "Invalid invitation token",
+    );
+    await expect(acceptInvitationAction(form("  "))).rejects.toThrow(
+      "Invalid invitation token",
+    );
+    expect(getInvitationByToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/invite/[token]/actions.test.ts
+++ b/src/app/invite/[token]/actions.test.ts
@@ -106,9 +106,13 @@ describe("acceptInvitationAction", () => {
     expect(await destinationOf(form("tok-1"))).toBe("/t/team-1");
 
     // The address comes from the invitation row, never from the form.
-    expect(resolveInvitedUser).toHaveBeenCalledWith("sam@example.com");
-    expect(acceptInvitations).toHaveBeenCalledWith("user-1", "sam@example.com");
-    expect(createUserSession).toHaveBeenCalledWith("user-1");
+    expect(resolveInvitedUser).toHaveBeenCalledWith("sam@example.com", NOW);
+    expect(acceptInvitations).toHaveBeenCalledWith(
+      "user-1",
+      "sam@example.com",
+      NOW,
+    );
+    expect(createUserSession).toHaveBeenCalledWith("user-1", NOW);
     expect(cookieSet).toHaveBeenCalledWith(
       "__Secure-authjs.session-token",
       "session-token-1",
@@ -148,6 +152,32 @@ describe("acceptInvitationAction", () => {
     await destinationOf(form("tok-1"));
 
     expect(order).toEqual(["accept", "session"]);
+  });
+
+  // Regression: the action used to read the clock separately in each step, so
+  // an invitation could be live when checked and expired by the time
+  // acceptInvitations filtered on expiresAt — granting no Membership while
+  // still writing a session. The clock is advanced past expiry mid-action to
+  // force exactly that interleaving.
+  it("judges liveness and consumes the invitation at one instant", async () => {
+    getInvitationByToken.mockResolvedValue({
+      ...liveInvitation(),
+      expiresAt: new Date(NOW.getTime() + 1_000),
+    });
+    resolveInvitedUser.mockImplementation(async () => {
+      vi.advanceTimersByTime(5_000);
+      return { id: "user-1", email: "sam@example.com" };
+    });
+
+    expect(await destinationOf(form("tok-1"))).toBe("/t/team-1");
+
+    // Not merely "some Date" — the instant the liveness check passed at, which
+    // is the only one the write is entitled to act on.
+    expect(acceptInvitations).toHaveBeenCalledWith(
+      "user-1",
+      "sam@example.com",
+      NOW,
+    );
   });
 
   it("sends an unknown token back to the invite page without writing anything", async () => {

--- a/src/app/invite/[token]/actions.ts
+++ b/src/app/invite/[token]/actions.ts
@@ -1,51 +1,95 @@
 "use server";
 
+import { cookies, headers } from "next/headers";
 import { redirect, unstable_rethrow } from "next/navigation";
 
-import { signIn } from "@/auth";
-import { getInvitationByToken } from "@/lib/invitations";
+import {
+  acceptInvitations,
+  getInvitationByToken,
+  resolveInvitedUser,
+} from "@/lib/invitations";
 import { isLiveInvitation } from "@/lib/invitation-token";
+import {
+  sessionCookieName,
+  sessionCookieOptions,
+  usesSecureCookies,
+} from "@/lib/session-cookie";
+import { createUserSession } from "@/lib/sessions";
 
 /**
- * Send the magic link for a live invitation.
+ * Accept an invitation: grant the memberships it carries and sign the parent
+ * in on this device, right now.
  *
- * The address comes from the invitation row, never from the form — this is
- * what keeps an unauthenticated page from being a way to mail a stranger.
- * Liveness is re-checked here rather than trusted from the page render:
- * seconds can pass between the page loading and this submitting, and the
- * token could expire or be revoked in between.
+ * The token is the credential. It was mailed to the invited address and
+ * nowhere else, which is the same proof of mailbox possession a magic link
+ * gives — so sending a second email to establish the session bought no
+ * security and cost the app every parent who did not go back to their inbox a
+ * second time. This revises design-doc.md #4 Decision 1, which chose the
+ * two-step flow on the grounds that `acceptInvitations` was the one place
+ * memberships are granted. That still holds: this action calls the same
+ * function Auth.js's `events.signIn` calls, so there is still one grant path.
+ * What changes is only where the session comes from.
  *
- * Granting the Membership itself is NOT this action's job — that already
- * happens, idempotently, in acceptInvitations via Auth.js's events.signIn
- * once the emailed link is actually clicked. See design-doc.md #4
- * Decision 1.
+ * The magic link is not gone — it is what `/signin` still sends, and a parent
+ * whose session lapses next season signs in that way, admitted by the
+ * Membership this action created.
+ *
+ * This is a POST for a reason. Accepting consumes the invitation, and
+ * corporate mail scanners follow every link in a message before the recipient
+ * sees it: on GET, the scanner would burn the invitation and the parent would
+ * arrive to "Already accepted" with no way in.
  */
-export async function requestInvitationLinkAction(formData: FormData) {
+export async function acceptInvitationAction(formData: FormData) {
   const token = String(formData.get("token")).trim();
   if (!token || token === "null" || token === "undefined") {
     throw new Error("Invalid invitation token");
   }
 
+  // Set only once everything below has succeeded, so any failure leaves the
+  // parent on the invite page with an error rather than at a team URL they
+  // have no session for.
+  let destination = `/invite/${token}?error=1`;
+
   try {
     const invitation = await getInvitationByToken(token);
 
+    // Re-checked rather than trusted from the page render: seconds pass
+    // between the page loading and this submitting, and the invitation can
+    // expire or be revoked in between.
     if (!invitation || !isLiveInvitation(invitation, new Date())) {
       redirect(`/invite/${token}`);
     }
 
-    await signIn("resend", {
-      email: invitation.email,
-      redirectTo: `/t/${invitation.teamId}`,
-      redirect: false,
+    const user = await resolveInvitedUser(invitation.email);
+
+    // Order matters. This is the same idempotent write Auth.js runs from
+    // `events.signIn`, and it goes first: if the session insert below fails,
+    // the parent is already a member and `/signin` will let them in, whereas
+    // the reverse would sign them in with no team to land on.
+    await acceptInvitations(user.id, user.email);
+
+    const session = await createUserSession(user.id);
+    const secure = usesSecureCookies({
+      authUrl: process.env.AUTH_URL,
+      forwardedProto: (await headers()).get("x-forwarded-proto"),
     });
+
+    const cookieStore = await cookies();
+    cookieStore.set(
+      sessionCookieName(secure),
+      session.sessionToken,
+      sessionCookieOptions(secure, session.expires),
+    );
+
+    destination = `/t/${invitation.teamId}`;
   } catch (error) {
     // Next implements redirect() by throwing; never swallow that.
     unstable_rethrow(error);
 
-    // A Resend outage or missing env var is logged server-side and hidden
-    // from the visitor, matching src/app/signin/actions.ts.
-    console.warn("Invitation sign-in link not sent:", error);
+    // Logged with the reason server-side; the parent sees only that it did not
+    // work, and can try again or ask their coach for a fresh invite.
+    console.error("Invitation acceptance failed:", error);
   }
 
-  redirect(`/invite/${token}?sent=1`);
+  redirect(destination);
 }

--- a/src/app/invite/[token]/actions.ts
+++ b/src/app/invite/[token]/actions.ts
@@ -50,25 +50,41 @@ export async function acceptInvitationAction(formData: FormData) {
   // have no session for.
   let destination = `/invite/${token}?error=1`;
 
+  // One instant for the decision and for every write it authorizes. Each
+  // function below takes `now` precisely so its caller can pin it; reading the
+  // clock separately in each would let the invitation be live when it is
+  // checked and expired by the time `acceptInvitations` filters on
+  // `expiresAt`, which grants no Membership while still writing a session — an
+  // invited coach would land on a team page `requireTeamAccess` then rejects.
+  const now = new Date();
+
   try {
     const invitation = await getInvitationByToken(token);
 
     // Re-checked rather than trusted from the page render: seconds pass
     // between the page loading and this submitting, and the invitation can
     // expire or be revoked in between.
-    if (!invitation || !isLiveInvitation(invitation, new Date())) {
+    if (!invitation || !isLiveInvitation(invitation, now)) {
       redirect(`/invite/${token}`);
     }
 
-    const user = await resolveInvitedUser(invitation.email);
+    const user = await resolveInvitedUser(invitation.email, now);
 
     // Order matters. This is the same idempotent write Auth.js runs from
     // `events.signIn`, and it goes first: if the session insert below fails,
     // the parent is already a member and `/signin` will let them in, whereas
     // the reverse would sign them in with no team to land on.
-    await acceptInvitations(user.id, user.email);
+    //
+    // A shared `now` cannot close the read-then-write gap itself: a coach
+    // revoking the invitation between the read above and this write still
+    // consumes nothing. That is knowingly left open rather than half-guarded.
+    // Bailing when the count is zero would be wrong — a parent's Membership is
+    // created by `linkGuardian` when they are first linked, so revoking their
+    // invitation leaves them genuinely entitled to the team, and a count check
+    // would lock out the common case to catch a millisecond of the rare one.
+    await acceptInvitations(user.id, user.email, now);
 
-    const session = await createUserSession(user.id);
+    const session = await createUserSession(user.id, now);
     const secure = usesSecureCookies({
       authUrl: process.env.AUTH_URL,
       forwardedProto: (await headers()).get("x-forwarded-proto"),

--- a/src/app/invite/[token]/page.test.tsx
+++ b/src/app/invite/[token]/page.test.tsx
@@ -7,10 +7,10 @@ vi.mock("@/lib/invitations", () => ({
   getInvitationByToken: (...args: unknown[]) => getInvitationByToken(...args),
 }));
 
-// The real action pulls in Auth.js and the Prisma client; the page only
+// The real action pulls in the Prisma client and next/headers; the page only
 // needs something form-shaped to point at. Matches src/app/signin/page.test.tsx.
 vi.mock("./actions", () => ({
-  requestInvitationLinkAction: vi.fn(),
+  acceptInvitationAction: vi.fn(),
 }));
 
 const NOW = new Date("2026-04-01T12:00:00Z");
@@ -25,11 +25,11 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-async function render(token: string, sent?: string) {
+async function render(token: string, error?: string) {
   const { default: InvitePage } = await import("./page");
   const result = await InvitePage({
     params: Promise.resolve({ token }),
-    searchParams: Promise.resolve({ sent }),
+    searchParams: Promise.resolve({ error }),
   });
   return renderToStaticMarkup(result);
 }
@@ -80,7 +80,7 @@ describe("Invite page", () => {
     expect(markup).toContain("Invitation expired");
   });
 
-  it("shows the send-link form for a live invitation, with the email masked", async () => {
+  it("shows the accept form for a live invitation, with the email masked", async () => {
     getInvitationByToken.mockResolvedValue({
       teamId: "team-1",
       teamName: "Cubs",
@@ -93,11 +93,30 @@ describe("Invite page", () => {
     const markup = await render("tok-1");
 
     expect(markup).toContain("Cubs");
-    expect(markup).toContain("Send me a sign-in link");
+    expect(markup).toContain("Accept invitation");
+    expect(markup).toContain("tok-1");
     expect(markup).not.toContain("sam@example.com");
   });
 
-  it("shows the sent confirmation instead of the form once sent=1", async () => {
+  // The whole point of the change: accepting must not send them back to an
+  // inbox for a second link.
+  it("does not offer to email a sign-in link", async () => {
+    getInvitationByToken.mockResolvedValue({
+      teamId: "team-1",
+      teamName: "Cubs",
+      email: "sam@example.com",
+      role: "PARENT",
+      expiresAt: new Date(NOW.getTime() + 1000),
+      acceptedAt: null,
+    });
+
+    const markup = await render("tok-1");
+
+    expect(markup).not.toContain("Send me a sign-in link");
+    expect(markup).not.toContain("Check your email");
+  });
+
+  it("keeps the accept form on screen alongside a failure message", async () => {
     getInvitationByToken.mockResolvedValue({
       teamId: "team-1",
       teamName: "Cubs",
@@ -109,7 +128,7 @@ describe("Invite page", () => {
 
     const markup = await render("tok-1", "1");
 
-    expect(markup).toContain("Check your email");
-    expect(markup).not.toContain("Send me a sign-in link");
+    expect(markup).toContain("Something went wrong accepting your invitation");
+    expect(markup).toContain("Accept invitation");
   });
 });

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -13,14 +13,14 @@ import {
 import { getInvitationByToken } from "@/lib/invitations";
 import { isLiveInvitation } from "@/lib/invitation-token";
 
-import { requestInvitationLinkAction } from "./actions";
+import { acceptInvitationAction } from "./actions";
 
 export const metadata = {
   title: "You're invited — Youth Baseball Team Manager",
 };
 
 /// Masks all but the first character of the local part, so the page can
-/// confirm which address will receive mail without fully disclosing it to
+/// confirm which address the coach has on file without fully disclosing it to
 /// anyone who guesses or intercepts the link.
 function maskEmail(email: string): string {
   const [local, domain] = email.split("@");
@@ -32,19 +32,20 @@ function maskEmail(email: string): string {
 }
 
 /// Unauthenticated by design — proxy.ts's matcher is "/t/:path*" and this
-/// route is deliberately outside it. The token is the only credential: it
-/// authorizes sending mail to the address on the row, nothing more. Granting
-/// access itself happens later, when that emailed link is clicked — see
-/// design-doc.md #4 Decision 1.
+/// route is deliberately outside it. The token is the credential, and this
+/// page only reads it: accepting is the POST in actions.ts, which is what
+/// grants the membership and writes the session. Rendering must stay
+/// side-effect free, because mail scanners fetch this URL before the parent
+/// ever opens the message.
 export default async function InvitePage({
   params,
   searchParams,
 }: {
   params: Promise<{ token: string }>;
-  searchParams: Promise<{ sent?: string }>;
+  searchParams: Promise<{ error?: string }>;
 }) {
   const { token } = await params;
-  const { sent } = await searchParams;
+  const { error } = await searchParams;
 
   const invitation = await getInvitationByToken(token);
 
@@ -92,22 +93,33 @@ export default async function InvitePage({
           <CardHeader>
             <CardTitle>You&apos;re invited to join {invitation.teamName}</CardTitle>
             <CardDescription>
-              We&apos;ll email a one-time sign-in link to {maskEmail(invitation.email)}.
+              Accepting signs you in on this device — no password, and nothing
+              else to find in your inbox.
             </CardDescription>
           </CardHeader>
-          <CardContent>
-            {sent ? (
-              <p role="status" className="text-sm text-muted-foreground">
-                Check your email for the sign-in link.
+          <CardContent className="space-y-4">
+            {error ? (
+              <p role="alert" className="text-sm text-destructive">
+                Something went wrong accepting your invitation. Try again, or
+                ask your coach to send a new one.
               </p>
-            ) : (
-              <form action={requestInvitationLinkAction}>
-                <input type="hidden" name="token" value={token} />
-                <Button type="submit" className="w-full">
-                  Send me a sign-in link
-                </Button>
-              </form>
-            )}
+            ) : null}
+
+            <form action={acceptInvitationAction}>
+              <input type="hidden" name="token" value={token} />
+              <Button type="submit" className="w-full">
+                Accept invitation
+              </Button>
+            </form>
+
+            <p className="text-sm text-muted-foreground">
+              This invitation was sent to {maskEmail(invitation.email)}. It
+              works once — after that, sign in from{" "}
+              <Link href="/signin" className="font-medium text-primary underline">
+                the sign-in page
+              </Link>
+              .
+            </p>
           </CardContent>
         </Card>
       </div>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,6 +5,10 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import { db } from "@/lib/db";
 import { acceptInvitations, loadSignInContext } from "@/lib/invitations";
 import { decideSignIn } from "@/lib/signin-gate";
+import {
+  SESSION_MAX_AGE_SECONDS,
+  SESSION_UPDATE_AGE_SECONDS,
+} from "@/lib/sessions";
 
 /// Auth.js v5 — magic link only, gated by the Invitation table.
 ///
@@ -16,12 +20,6 @@ import { decideSignIn } from "@/lib/signin-gate";
 /// request rather than at import, so a missing RESEND_API_KEY fails when someone
 /// actually tries to sign in instead of at build time. src/lib/db.ts defers
 /// DATABASE_URL for the same reason — the build must not require secrets.
-
-/// Long enough that a parent at a ballfield is not re-authenticating on a phone,
-/// sliding so that opening the app keeps it alive. Database sessions make this
-/// safe: a 90-day window is revocable by deleting the row.
-const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 90;
-const SESSION_UPDATE_AGE_SECONDS = 60 * 60 * 24;
 
 function requireEnv(name: string): string {
   const value = process.env[name];

--- a/src/lib/invitations.ts
+++ b/src/lib/invitations.ts
@@ -93,6 +93,51 @@ export async function acceptInvitations(
   return pending.length;
 }
 
+/**
+ * The `User` row for an invited address, created if it is not there yet.
+ *
+ * A parent linked to a player already has one — `linkGuardian` upserts it long
+ * before they ever sign in — but a coach invited from the members page does
+ * not: nothing writes a row for them until Auth.js does. Accepting an
+ * invitation has to work for both.
+ *
+ * `emailVerified` is stamped here because accepting proves the person holds the
+ * mailbox the token was mailed to, which is the same thing a magic link proves.
+ * `@auth/core` stamps it at exactly this point in its own email flow.
+ *
+ * The lookup is case-insensitive for the same reason `loadSignInContext`'s is:
+ * a `User` row written before `normalizeEmail` existed can differ in case, and
+ * a create keyed on the normalized form would collide with it on `User.email`'s
+ * unique index rather than finding it.
+ */
+export async function resolveInvitedUser(
+  email: string,
+  now: Date = new Date(),
+): Promise<{ id: string; email: string }> {
+  const address = normalizeEmail(email);
+
+  const existing = await db.user.findFirst({
+    where: { email: { equals: address, mode: "insensitive" } },
+    select: { id: true, email: true, emailVerified: true },
+  });
+
+  if (existing) {
+    if (existing.emailVerified === null) {
+      await db.user.update({
+        where: { id: existing.id },
+        data: { emailVerified: now },
+      });
+    }
+
+    return { id: existing.id, email: existing.email };
+  }
+
+  return db.user.create({
+    data: { email: address, emailVerified: now },
+    select: { id: true, email: true },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Creating and looking up invitations (#4)
 // ---------------------------------------------------------------------------

--- a/src/lib/session-cookie.test.ts
+++ b/src/lib/session-cookie.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  SESSION_COOKIE_NAMES,
+  sessionCookieName,
+  sessionCookieOptions,
+  usesSecureCookies,
+} from "./session-cookie";
+
+describe("sessionCookieName", () => {
+  it("uses the __Secure- prefix only when the cookie is secure", () => {
+    expect(sessionCookieName(false)).toBe("authjs.session-token");
+    expect(sessionCookieName(true)).toBe("__Secure-authjs.session-token");
+  });
+
+  // Proxy reads this list; the accept action writes one of its members. A name
+  // in one and not the other is a session Proxy cannot see.
+  it("lists exactly the two names it can write", () => {
+    expect([...SESSION_COOKIE_NAMES].sort()).toEqual(
+      [sessionCookieName(false), sessionCookieName(true)].sort(),
+    );
+  });
+});
+
+describe("usesSecureCookies", () => {
+  it("takes AUTH_URL's protocol when it is set", () => {
+    expect(usesSecureCookies({ authUrl: "https://team.example.com" })).toBe(true);
+    expect(usesSecureCookies({ authUrl: "http://localhost:3000" })).toBe(false);
+  });
+
+  it("lets AUTH_URL win over a disagreeing forwarded protocol", () => {
+    expect(
+      usesSecureCookies({
+        authUrl: "http://localhost:3000",
+        forwardedProto: "https",
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to x-forwarded-proto when AUTH_URL is unset", () => {
+    expect(usesSecureCookies({ forwardedProto: "https" })).toBe(true);
+    expect(usesSecureCookies({ forwardedProto: "http" })).toBe(false);
+  });
+
+  it("accepts the header with or without a trailing colon, in any case", () => {
+    expect(usesSecureCookies({ forwardedProto: "HTTPS:" })).toBe(true);
+    expect(usesSecureCookies({ forwardedProto: " https " })).toBe(true);
+    expect(usesSecureCookies({ forwardedProto: "HTTP" })).toBe(false);
+  });
+
+  // Matches createActionURL in @auth/core, which defaults an absent protocol to
+  // https rather than to http.
+  it("defaults to secure when neither is available", () => {
+    expect(usesSecureCookies({})).toBe(true);
+    expect(usesSecureCookies({ authUrl: "", forwardedProto: null })).toBe(true);
+  });
+
+  it("falls through to the header on an unparseable AUTH_URL", () => {
+    expect(
+      usesSecureCookies({ authUrl: "not a url", forwardedProto: "http" }),
+    ).toBe(false);
+  });
+});
+
+describe("sessionCookieOptions", () => {
+  it("restates the Auth.js defaults, with the row's own expiry", () => {
+    const expires = new Date("2026-11-01T00:00:00Z");
+
+    expect(sessionCookieOptions(true, expires)).toEqual({
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      secure: true,
+      expires,
+    });
+  });
+
+  it("drops the secure flag alongside the prefix", () => {
+    expect(sessionCookieOptions(false, new Date()).secure).toBe(false);
+  });
+});

--- a/src/lib/session-cookie.ts
+++ b/src/lib/session-cookie.ts
@@ -1,0 +1,94 @@
+/// The session cookie: what it is called, and the attributes it is written
+/// with.
+///
+/// Three places have to agree on this. Auth.js writes the cookie when a magic
+/// link is clicked, `/invite/[token]` writes it when a parent accepts an
+/// invitation, and `proxy.ts` reads it. `src/auth.ts` deliberately passes no
+/// `cookies` config, so what this module states is Auth.js's own default,
+/// restated once instead of guessed at three times: `@auth/core`'s
+/// `defaultCookies` names the cookie `${prefix}authjs.session-token` with
+/// `httpOnly`, `sameSite: "lax"` and `path: "/"`, and applies the `__Secure-`
+/// prefix exactly when it marks the cookie secure.
+///
+/// Pure and dependency-free on purpose — `proxy.ts` imports it, and Proxy must
+/// not pull in Auth.js or the database.
+
+const BASE_NAME = "authjs.session-token";
+const SECURE_NAME = `__Secure-${BASE_NAME}`;
+
+/// Both spellings, for reading. Which one is present depends on whether the
+/// session was established over HTTPS. Database sessions store a short opaque
+/// token, so Auth.js's chunked `.0` variants never come into play.
+export const SESSION_COOKIE_NAMES = [BASE_NAME, SECURE_NAME] as const;
+
+export function sessionCookieName(secure: boolean): string {
+  return secure ? SECURE_NAME : BASE_NAME;
+}
+
+export type SecureCookieInput = {
+  /// `AUTH_URL`, when set. It wins, exactly as it does in Auth.js.
+  authUrl?: string | null;
+  /// The request's `x-forwarded-proto`, with or without a trailing colon.
+  forwardedProto?: string | null;
+};
+
+/**
+ * Whether cookies get the `secure` flag and the `__Secure-` prefix.
+ *
+ * Mirrors `createActionURL` in `@auth/core`: `AUTH_URL`'s protocol when that is
+ * set, otherwise `x-forwarded-proto`, otherwise https. Disagreeing with Auth.js
+ * here does not fail subtly — a `__Secure-` cookie sent over plain HTTP is
+ * dropped by the browser outright, and writing the other spelling than Auth.js
+ * reads would leave two sessions that never see each other.
+ *
+ * An unparseable `AUTH_URL` falls through to the header rather than throwing.
+ * Signing a parent in is not the place to discover a malformed env var, and
+ * Auth.js will raise its own error on the next request either way.
+ */
+export function usesSecureCookies({
+  authUrl,
+  forwardedProto,
+}: SecureCookieInput): boolean {
+  if (authUrl) {
+    try {
+      return new URL(authUrl).protocol === "https:";
+    } catch {
+      // Fall through to the header.
+    }
+  }
+
+  if (!forwardedProto) {
+    return true;
+  }
+
+  return forwardedProto.trim().replace(/:$/, "").toLowerCase() === "https";
+}
+
+export type SessionCookieOptions = {
+  httpOnly: true;
+  sameSite: "lax";
+  path: "/";
+  secure: boolean;
+  expires: Date;
+};
+
+/**
+ * The attributes Auth.js writes the session cookie with.
+ *
+ * `sameSite: "lax"` is load-bearing, for the reason `src/auth.ts` gives: a
+ * magic link clicked in an email client is a cross-site top-level navigation
+ * that "strict" would silently drop. `expires` matches the `Session` row's
+ * own expiry, so the cookie and the row die together.
+ */
+export function sessionCookieOptions(
+  secure: boolean,
+  expires: Date,
+): SessionCookieOptions {
+  return {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure,
+    expires,
+  };
+}

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from "node:crypto";
+
+import { db } from "./db";
+
+/// Database sessions, written directly.
+///
+/// Auth.js owns the `Session` table everywhere else. The one exception is
+/// invitation acceptance, which signs a parent in from the token they were
+/// mailed rather than making them fetch a second link out of their inbox — see
+/// `src/app/invite/[token]/actions.ts`. Auth.js v5 exposes no "sign this user
+/// in" API under the database strategy (`signIn` for an email provider always
+/// mails a link and returns nothing usable), so the row is created here.
+///
+/// It is created exactly the way `@auth/core` creates it: a `crypto.randomUUID()`
+/// token and `expires` at now plus the session max age. The cookie carries that
+/// token verbatim — database sessions hand out an opaque row key rather than
+/// encrypting a payload the way JWT sessions do, which is what makes writing
+/// one from outside Auth.js possible at all.
+
+/// Long enough that a parent at a ballfield is not re-authenticating on a
+/// phone, sliding so that opening the app keeps it alive. Database sessions
+/// make this safe: a 90-day window is revocable by deleting the row.
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 90;
+export const SESSION_UPDATE_AGE_SECONDS = 60 * 60 * 24;
+
+export type CreatedSession = {
+  sessionToken: string;
+  expires: Date;
+};
+
+export async function createUserSession(
+  userId: string,
+  now: Date = new Date(),
+): Promise<CreatedSession> {
+  return db.session.create({
+    data: {
+      sessionToken: randomUUID(),
+      userId,
+      expires: new Date(now.getTime() + SESSION_MAX_AGE_SECONDS * 1000),
+    },
+    select: { sessionToken: true, expires: true },
+  });
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { SESSION_COOKIE_NAMES } from "@/lib/session-cookie";
+
 /// Next.js 16 renamed Middleware to Proxy. This file lives in `src/` rather than
 /// the repository root because the convention is that it sits beside `app` — and
 /// this project's router is `src/app`. A root proxy.ts would simply never run,
@@ -17,14 +19,6 @@ import { NextResponse, type NextRequest } from "next/server";
 /// requireTeamAccess runs inside it.
 ///
 /// Cookie presence is not cookie validity. That is what "optimistic" means.
-
-/// Auth.js names the session cookie, adding the __Secure- prefix when cookies are
-/// secure (i.e. in production over HTTPS). Database sessions store a short token,
-/// so the chunked `.0` variants never come into play.
-const SESSION_COOKIE_NAMES = [
-  "authjs.session-token",
-  "__Secure-authjs.session-token",
-];
 
 export function proxy(request: NextRequest) {
   const hasSessionCookie = SESSION_COOKIE_NAMES.some((name) =>


### PR DESCRIPTION
## Summary

Accepting an invitation landed the parent on a page whose only control was "Send me a sign-in link" — a second email to find, in a flow that started with an email. Parents stopped there. Accepting now establishes the session itself, so onboarding is one email and one click.

Reported during #9's real-parent validation weekend: "parents who accept the sign up link end up on a page where they can request a link."

## Key Decisions

**The token already proves what the second email proved.** The invitation token is mailed to the invited address and nowhere else, which is exactly the proof of mailbox possession a magic link gives. The second round trip bought no security and cost the app every parent who did not go back to their inbox.

This revises design-doc.md #4 Decision 1, which chose the two-step flow to keep `acceptInvitations` the single place memberships are granted. That reasoning still holds and is preserved: the accept action calls the same function `events.signIn` calls, so there is still one grant path. Only the source of the session changes.

**Writing the session row directly, rather than reaching for Auth.js.** Auth.js v5 exposes no "sign this user in" API under the database strategy — `signIn` for an email provider always mails a link and returns nothing usable, and the Credentials provider forces JWT sessions, which this app does not use. Two alternatives were considered and rejected:

- *Mint a `VerificationToken` and redirect into Auth.js's own callback.* Requires reimplementing `@auth/core`'s `hashToken` (sha256 of token + secret), an internal detail with no stable import. Gets it wrong silently.
- *Keep the magic link but suppress the email.* Needs the emitted URL captured out of `sendVerificationRequest`, which means AsyncLocalStorage plumbing around a provider instance that exists only to be intercepted.

Instead `src/lib/sessions.ts` inserts the `Session` row the way `@auth/core` does — `crypto.randomUUID()` token, `expires` at now + max age — and the action sets the cookie. Verified against `@auth/core@0.41.3` (`lib/actions/session.js`) and `@auth/prisma-adapter` that `auth()` needs nothing beyond that row and a matching cookie: no `Account`, no `VerificationToken`. Database sessions hand out an opaque row key rather than an encrypted payload, which is what makes writing one from outside Auth.js viable at all.

**One definition of the session cookie.** `proxy.ts` already had the two cookie names inlined, so this change would have made three places that must agree. `src/lib/session-cookie.ts` restates Auth.js's defaults once and all three import it. `usesSecureCookies` mirrors `createActionURL`'s protocol resolution (`AUTH_URL` → `x-forwarded-proto` → https) — disagreeing there does not fail subtly, since a `__Secure-` cookie sent over plain HTTP is dropped by the browser outright.

**Accepting stays a POST.** Making the emailed link itself sign the parent in was considered and rejected: corporate mail scanners follow every link in a message before the recipient opens it. On GET, the scanner would consume the invitation and the parent would arrive to "Already accepted" with no way in. The page render stays side-effect free; the POST is what consumes.

**The grant runs before the session write.** If the session insert fails, the parent is already a member and `/signin` admits them. The reverse would sign them in with no team to land on.

## What's in Scope

- `src/lib/sessions.ts` — new. `createUserSession`, plus the 90-day session lifetime constants, which `src/auth.ts` now imports rather than declaring its own copy.
- `src/lib/session-cookie.ts` — new, pure. Cookie name, secure-cookie resolution, and cookie attributes. `proxy.ts` now imports the names it used to inline.
- `resolveInvitedUser` in `src/lib/invitations.ts` — an invited coach has no `User` row yet (only guardians get one, from `linkGuardian`), and `emailVerified` is stamped at the point `@auth/core` stamps it. Case-insensitive lookup, matching the rest of the module.
- `/invite/[token]` — `requestInvitationLinkAction` becomes `acceptInvitationAction`: grants the memberships, writes the session, redirects to `/t/[teamId]`. The page's copy and its `?sent=1` state become an accept button and an `?error=1` state.
- Docs: the onboarding bullet in `product-brief.md` (a recorded decision genuinely revised, not just code drift) and a gotcha in `AGENTS.md` about the cookie now having two writers.

### Out of Scope

- The magic link is untouched. `/signin` still sends one, and it remains how a parent whose session lapses next season gets back in — admitted by the `Membership` this action created.
- The archived `#4` planning doc is left as it was. The revision is recorded in the action's own comment instead.
- No schema change, no migration.

## Known Gaps / Follow-ups

- **No database was available in this session, so the cookie write has not been exercised end to end against live Postgres.** The row shape and cookie contract were verified by reading `@auth/core` and the Prisma adapter, not by signing in. If a parent accepts and lands back on `/signin`, the cookie name or `secure` flag is the first place to look.
- `usesSecureCookies` falls back to `true` when neither `AUTH_URL` nor `x-forwarded-proto` is present, faithfully matching `createActionURL`. Next sets the header, so this should not arise, but a local setup that strips it would write a `__Secure-` cookie over HTTP and the browser would drop it.

## Test Plan

- [ ] `pnpm check` (lint → typecheck → 764 tests) and `pnpm exec next build`. Both green on this branch; `next build` rather than `pnpm build` because the latter runs `prisma migrate deploy` first and needs `DATABASE_URL`.
- [ ] Invite a parent from `/t/[teamId]/roster/[entryId]`, open the invitation email, click **Accept invitation**, then click **Accept invitation** on the page. Expected: land on `/t/[teamId]` already signed in, with no second email involved. Confirm exactly one email arrived.
- [ ] Confirm the session actually persists — reload `/t/[teamId]` and navigate to another team page; Proxy must not bounce you to `/signin`. In devtools the cookie should be `__Secure-authjs.session-token` in production, `authjs.session-token` over local HTTP.
- [ ] Reopen the same invitation link. Expected: "Already accepted", with a working link to `/signin` — and signing in there still works, since the parent now holds a `Membership`.
- [ ] Invite a **coach** from `/t/[teamId]/members` to an address with no existing `User` row, and accept. Expected: same result, arriving with the COACH role. This is the path `resolveInvitedUser` exists for.
- [ ] Edge cases checked in unit tests rather than by hand: unknown token, expired token, already-accepted token, grant failure, and session-write failure after a successful grant.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wXsgRvpaqf3dNkVBFQych)_