### PR TITLE
Pastoral Banana Ball: design plan + full implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,13 @@ production — the dev command can prompt, generate new migrations, and reset th
   **Which shape a real write actually returns is unverified** — this repo has not yet run a
   write against live Postgres that trips one of these constraints. Confirm it before relying
   on this in production, and adjust the matching in `roster-rules.ts` if it differs.
+- **`docs/design/design-plan.md` is checked against the code by a test.**
+  `src/design-plan-drift.test.ts` reads that document and asserts its colour-token values
+  against `globals.css` and its ``FIELD_ART.key = n`` geometry claims against
+  `diamond-geometry.ts`, because the document drifted from the code four times in its
+  first week. Changing a design token or a field radius will fail `pnpm check` until the
+  document is updated to match. Fix whichever side is wrong — usually the document — and
+  never delete the claim to silence the test. §13 of the document explains the format.
 - Chart edits are permanent — no undo, no history. Patching the order because a kid is out
   makes that the order. This was chosen deliberately; flag it rather than silently adding
   per-game overrides.

--- a/docs/design/assets/components.svg
+++ b/docs/design/assets/components.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 680" font-family="Helvetica, Arial, sans-serif">
+  <style>
+    .h    { font: 800 20px 'Arial Black', Arial, sans-serif; letter-spacing: 1px; fill: #1E2A4A; }
+    .sec  { font: 800 12px 'Arial Black', Arial, sans-serif; letter-spacing: 2px; fill: #6B665A; }
+    .slab { font: 800 26px 'Arial Black', Arial, sans-serif; fill: #1E2A4A; }
+    .slab2{ font: 800 15px 'Arial Black', Arial, sans-serif; fill: #1E2A4A; }
+    .body { font: 12px Helvetica, Arial, sans-serif; fill: #4C4A40; }
+    .tag  { font: 700 10px Arial, sans-serif; }
+    .mono { font: 700 14px 'Courier New', monospace; }
+    .num  { font: 800 14px 'Arial Black', Arial, sans-serif; fill: #FAF3E3; }
+  </style>
+  <rect width="960" height="680" fill="#FAF3E3"/>
+  <text x="30" y="40" class="h">COMPONENT SKETCHES</text>
+
+  <!-- stitch divider demo -->
+  <path d="M30,58 Q480,74 930,58" fill="none" stroke="#C8102E" stroke-width="2" stroke-dasharray="7 6" stroke-linecap="round"/>
+
+  <!-- ============ A: ticket-stub event card ============ -->
+  <text x="30" y="100" class="sec">SCHEDULE → GAME AS A TICKET STUB</text>
+  <g transform="translate(30,114)">
+    <rect width="430" height="132" rx="12" fill="#FFFDF6" stroke="#C9793F" stroke-width="2"/>
+    <!-- perforation -->
+    <line x1="318" y1="8" x2="318" y2="124" stroke="#C9793F" stroke-width="2" stroke-dasharray="3 6" stroke-linecap="round"/>
+    <circle cx="318" cy="0" r="7" fill="#FAF3E3" stroke="#C9793F" stroke-width="2"/>
+    <circle cx="318" cy="132" r="7" fill="#FAF3E3" stroke="#C9793F" stroke-width="2"/>
+    <!-- left: the game -->
+    <text x="20" y="34" class="tag" fill="#C8102E" letter-spacing="2">GAME · HOME</text>
+    <text x="20" y="64" class="slab">vs HORNETS</text>
+    <text x="20" y="88" class="body">Sat June 14 · 9:00 AM</text>
+    <text x="20" y="106" class="body">Veterans Park — Field 3</text>
+    <!-- rsvp pills -->
+    <g transform="translate(20,114)">
+      <rect width="66" height="0" fill="none"/>
+    </g>
+    <!-- right: stub -->
+    <rect x="330" y="12" width="88" height="108" rx="8" fill="#FFC72C"/>
+    <text x="374" y="46" text-anchor="middle" class="slab2">9</text>
+    <text x="374" y="62" text-anchor="middle" class="tag" fill="#1E2A4A">GOING</text>
+    <text x="374" y="86" text-anchor="middle" class="tag" fill="#7A5A00">2 OUT</text>
+    <text x="374" y="102" text-anchor="middle" class="tag" fill="#7A5A00">1 QUIET</text>
+  </g>
+  <text x="30" y="270" class="body">Practices print on plain cream stock — no stub, clay-dashed border — so games read as the main event at a glance.</text>
+
+  <!-- ============ B: batting order jersey rows ============ -->
+  <text x="520" y="100" class="sec">BATTING ORDER → DUGOUT ROSTER ROWS</text>
+  <g transform="translate(520,114)">
+    <rect width="410" height="132" rx="12" fill="#FFFDF6" stroke="#E3D9C2" stroke-width="2"/>
+    <!-- row 1 -->
+    <g transform="translate(14,14)">
+      <rect width="382" height="32" rx="8" fill="#FAF3E3"/>
+      <circle cx="20" cy="16" r="13" fill="#1E2A4A"/>
+      <text x="20" y="21" text-anchor="middle" class="num">1</text>
+      <text x="44" y="21" class="slab2" font-size="13">Maya Ortiz</text>
+      <text x="140" y="21" class="body" fill="#8A8574">#12</text>
+      <rect x="316" y="7" width="58" height="18" rx="9" fill="#2F6B3A"/>
+      <text x="345" y="20" text-anchor="middle" class="tag" fill="#FAF3E3">GOING</text>
+    </g>
+    <!-- row 2 -->
+    <g transform="translate(14,52)">
+      <rect width="382" height="32" rx="8" fill="#FAF3E3"/>
+      <circle cx="20" cy="16" r="13" fill="#1E2A4A"/>
+      <text x="20" y="21" text-anchor="middle" class="num">2</text>
+      <text x="44" y="21" class="slab2" font-size="13" fill="#8A8574">Theo Banks</text>
+      <text x="150" y="21" class="body" fill="#8A8574">#7</text>
+      <rect x="296" y="7" width="78" height="18" rx="9" fill="none" stroke="#C8102E" stroke-width="1.5"/>
+      <text x="335" y="20" text-anchor="middle" class="tag" fill="#C8102E">NOT GOING</text>
+    </g>
+    <!-- row 3 -->
+    <g transform="translate(14,90)">
+      <rect width="382" height="32" rx="8" fill="#FAF3E3"/>
+      <circle cx="20" cy="16" r="13" fill="#1E2A4A"/>
+      <text x="20" y="21" text-anchor="middle" class="num">3</text>
+      <text x="44" y="21" class="slab2" font-size="13">Sam Reyes</text>
+      <text x="142" y="21" class="body" fill="#8A8574">#3</text>
+      <rect x="282" y="7" width="92" height="18" rx="9" fill="none" stroke="#8A8574" stroke-width="1.5" stroke-dasharray="3 3"/>
+      <text x="328" y="20" text-anchor="middle" class="tag" fill="#6B665A">NO RESPONSE</text>
+    </g>
+  </g>
+  <text x="520" y="270" class="body">Slot number becomes a navy jersey dot. Declined fades the name, never the slot — same rule as today.</text>
+
+  <!-- ============ C: pennant header ============ -->
+  <text x="30" y="330" class="sec">TEAM HEADER → PENNANT</text>
+  <g transform="translate(30,348)">
+    <rect width="430" height="120" rx="12" fill="#FFFDF6" stroke="#E3D9C2" stroke-width="2"/>
+    <!-- pinstripe hint -->
+    <g stroke="#1E2A4A" stroke-width="1" opacity="0.06">
+      <line x1="30" y1="0" x2="30" y2="120"/><line x1="60" y1="0" x2="60" y2="120"/>
+      <line x1="90" y1="0" x2="90" y2="120"/><line x1="120" y1="0" x2="120" y2="120"/>
+      <line x1="150" y1="0" x2="150" y2="120"/><line x1="180" y1="0" x2="180" y2="120"/>
+      <line x1="210" y1="0" x2="210" y2="120"/><line x1="240" y1="0" x2="240" y2="120"/>
+      <line x1="270" y1="0" x2="270" y2="120"/><line x1="300" y1="0" x2="300" y2="120"/>
+      <line x1="330" y1="0" x2="330" y2="120"/><line x1="360" y1="0" x2="360" y2="120"/>
+      <line x1="390" y1="0" x2="390" y2="120"/>
+    </g>
+    <!-- pennant -->
+    <path d="M24,28 L200,44 L24,92 Z" fill="#2F6B3A"/>
+    <path d="M24,28 L200,44 L24,92 Z" fill="none" stroke="#1E4A28" stroke-width="2"/>
+    <circle cx="20" cy="28" r="4" fill="#C9793F"/>
+    <circle cx="20" cy="92" r="4" fill="#C9793F"/>
+    <text x="44" y="64" class="slab2" fill="#FAF3E3" transform="rotate(4 44 64)">RIVER CATS</text>
+    <text x="220" y="52" class="slab2">River Cats — Spring 2026</text>
+    <text x="220" y="74" class="body">12 rostered · next game Sat 9:00 AM</text>
+    <rect x="220" y="86" width="86" height="22" rx="11" fill="#FFC72C"/>
+    <text x="263" y="101" text-anchor="middle" class="tag" fill="#1E2A4A">VIEW LINEUP</text>
+  </g>
+
+  <!-- ============ D: scoreboard readiness ============ -->
+  <text x="520" y="330" class="sec">READINESS → THE SCOREBOARD</text>
+  <g transform="translate(520,348)">
+    <rect width="410" height="120" rx="12" fill="#14181F"/>
+    <rect x="6" y="6" width="398" height="108" rx="8" fill="none" stroke="#FFD24D" stroke-width="1.5" opacity="0.6"/>
+    <text x="24" y="34" class="mono" fill="#EDE7D6">NEXT GAME · SAT 9:00 AM · vs HORNETS</text>
+    <text x="24" y="62" class="mono" fill="#FFD24D">GOING 9 / 12</text>
+    <text x="190" y="62" class="mono" fill="#F08A9B">OUT: THEO (SS)</text>
+    <text x="24" y="90" class="mono" fill="#F08A9B">UNCOVERED: SS</text>
+    <text x="220" y="90" class="mono" fill="#8FD08F">ALL OTHER SPOTS ✓</text>
+  </g>
+
+  <!-- footer note -->
+  <path d="M30,510 Q480,526 930,510" fill="none" stroke="#C8102E" stroke-width="2" stroke-dasharray="7 6" stroke-linecap="round"/>
+  <text x="30" y="548" class="sec">TEXTURE VOCABULARY</text>
+  <text x="30" y="574" class="body">· Stitch divider — the red dashed arc above, replacing every plain &lt;hr&gt;: two curved dashed lines like a baseball seam.</text>
+  <text x="30" y="594" class="body">· Pinstripes — 6% navy vertical stripes on header surfaces only (see pennant card), never behind body text.</text>
+  <text x="30" y="614" class="body">· Chalk borders — dashed cream/navy borders for empty states and drop zones, like a freshly chalked box.</text>
+  <text x="30" y="634" class="body">· Ticket perforation — dashed cut line + notch circles marks anything RSVP-able.</text>
+  <text x="30" y="654" class="body">· Banana yellow is the scarcity color: one big yellow thing per screen, no more.</text>
+</svg>

--- a/docs/design/assets/diamond-field.svg
+++ b/docs/design/assets/diamond-field.svg
@@ -1,0 +1,283 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 640" font-family="Helvetica, Arial, sans-serif">
+  <style>
+    .h { font: 800 20px 'Arial Black', Arial, sans-serif; letter-spacing: 1px; }
+    .cap { font: 12px Helvetica, Arial, sans-serif; }
+    .abbr { font: 800 11px Arial, sans-serif; }
+    .name { font: 700 11px Arial, sans-serif; }
+    .tag { font: 600 8px Arial, sans-serif; }
+
+    /* ------ day game ------ */
+    .day .sky      { fill: #FAF3E3; }
+    .day .grass    { fill: #7FB069; }
+    .day .stripe   { stroke: #8CBB77; }
+    .day .track    { stroke: #D9A05B; }
+    .day .fence    { stroke: #FFC72C; }
+    .day .dirt     { fill: #CE9455; }
+    .day .ingrass  { fill: #6EA25C; }
+    .day .chalk    { stroke: #FFFFFF; }
+    .day .base     { fill: #FFFFFF; stroke: #B98A50; }
+    .day .rubber   { fill: #FFFFFF; }
+    .day .m-going  { fill: #FAF3E3; stroke: #2F6B3A; }
+    .day .m-none   { fill: #FAF3E3; stroke: #1E2A4A; }
+    .day .m-out    { fill: #E7E2D4; stroke: #8A8574; }
+    .day .abbr     { fill: #1E2A4A; }
+    .day .abbr-out { fill: #8A8574; }
+    .day .name     { fill: #1E2A4A; }
+    .day .name-out { fill: #4C4A40; opacity: .65; }
+    .day .pill     { fill: #FAF3E3; opacity: .92; }
+    .day .t-going  { fill: #2F6B3A; }
+    .day .t-out    { fill: #C8102E; }
+    .day .t-none   { fill: #6B665A; }
+
+    /* ------ night game ------ */
+    .night .sky     { fill: #14181F; }
+    .night .grass   { fill: #234230; }
+    .night .stripe  { stroke: #294B37; }
+    .night .track   { stroke: #6B4A32; }
+    .night .fence   { stroke: #FFD24D; }
+    .night .dirt    { fill: #7A563A; }
+    .night .ingrass { fill: #1F3A2A; }
+    .night .chalk   { stroke: #EDE7D6; }
+    .night .base    { fill: #EDE7D6; stroke: #4A352A; }
+    .night .rubber  { fill: #EDE7D6; }
+    .night .m-going { fill: #1B2620; stroke: #8FD08F; }
+    .night .m-none  { fill: #1E2530; stroke: #C9C2AE; }
+    .night .m-out   { fill: #1A1E26; stroke: #5A5648; }
+    .night .abbr    { fill: #EDE7D6; }
+    .night .abbr-out{ fill: #8A8574; }
+    .night .name    { fill: #EDE7D6; }
+    .night .name-out{ fill: #9B968A; opacity: .75; }
+    .night .pill    { fill: #232A36; opacity: .95; }
+    .night .t-going { fill: #8FD08F; }
+    .night .t-out   { fill: #F08A9B; }
+    .night .t-none  { fill: #A9A292; }
+  </style>
+
+  <rect width="880" height="640" fill="#FAF3E3"/>
+  <text x="30" y="36" class="h" fill="#1E2A4A">THE DIAMOND, REDRAWN</text>
+  <text x="30" y="56" class="cap" fill="#4C4A40">Same 400×520 viewBox, same POSITION_COORDS — the field art just finally shows up. Left: day game (light). Right: night game (dark).</text>
+
+  <defs>
+    <clipPath id="wedge">
+      <path d="M200,420 L400,198 L400,0 L0,0 L0,198 Z"/>
+    </clipPath>
+  </defs>
+
+  <!-- ================= DAY FIELD ================= -->
+  <g class="day" transform="translate(20,80)">
+    <rect width="400" height="520" class="sky" rx="12"/>
+    <g clip-path="url(#wedge)">
+      <rect width="400" height="440" class="grass"/>
+      <g fill="none" stroke-width="40">
+        <circle cx="200" cy="420" r="90"  class="stripe"/>
+        <circle cx="200" cy="420" r="170" class="stripe"/>
+        <circle cx="200" cy="420" r="250" class="stripe"/>
+        <circle cx="200" cy="420" r="330" class="stripe"/>
+      </g>
+      <circle cx="200" cy="420" r="377" fill="none" stroke-width="36" class="track"/>
+      <circle cx="200" cy="420" r="395" fill="none" stroke-width="5" class="fence"/>
+    </g>
+
+    <!-- infield dirt, home circle, mound -->
+    <path d="M200,444 L316,318 Q200,90 84,318 Z" class="dirt"/>
+    <circle cx="200" cy="420" r="42" class="dirt"/>
+    <path d="M200,398 L272,322 L200,246 L128,322 Z" class="ingrass"/>
+    <circle cx="200" cy="330" r="18" class="dirt"/>
+
+    <!-- chalk -->
+    <g fill="none" stroke-width="3" stroke-linecap="round" class="chalk">
+      <path d="M200,420 L14,213"/>
+      <path d="M200,420 L386,213"/>
+    </g>
+    <g fill="none" stroke-width="2.5" stroke-linecap="round" class="chalk" opacity=".9">
+      <path d="M200,420 L290,320 L200,230 L110,320 Z"/>
+    </g>
+
+    <!-- bases + plate + rubber -->
+    <g stroke-width="1">
+      <rect x="-7" y="-7" width="14" height="14" transform="translate(290,320) rotate(45)" class="base"/>
+      <rect x="-7" y="-7" width="14" height="14" transform="translate(200,230) rotate(45)" class="base"/>
+      <rect x="-7" y="-7" width="14" height="14" transform="translate(110,320) rotate(45)" class="base"/>
+      <path d="M193,413 L207,413 L207,420 L200,427 L193,420 Z" class="base"/>
+      <rect x="193" y="327" width="14" height="4" rx="1" class="rubber"/>
+    </g>
+
+    <!-- markers: sample chart with the three RSVP states -->
+    <!-- CF Rio, no response -->
+    <g transform="translate(200,75)">
+      <circle r="20" class="m-none" stroke-width="2" stroke-dasharray="4 3"/>
+      <text dy="4" text-anchor="middle" class="abbr">CF</text>
+      <text y="34" text-anchor="middle" class="name">Rio</text>
+      <rect x="-26" y="40" width="52" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-none">NO RESPONSE</text>
+    </g>
+    <!-- LF Ozzy, going -->
+    <g transform="translate(75,130)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">LF</text>
+      <text y="34" text-anchor="middle" class="name">Ozzy</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <!-- RF Nell, going -->
+    <g transform="translate(325,130)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">RF</text>
+      <text y="34" text-anchor="middle" class="name">Nell</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <!-- SS Theo, declined -->
+    <g transform="translate(168,252)">
+      <circle r="20" class="m-out" stroke-width="1.5"/>
+      <text dy="4" text-anchor="middle" class="abbr-out abbr">SS</text>
+      <text y="34" text-anchor="middle" class="name name-out">Theo</text>
+      <rect x="-24" y="40" width="48" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-out">NOT GOING</text>
+    </g>
+    <!-- 2B Ava, going -->
+    <g transform="translate(232,252)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">2B</text>
+      <text y="34" text-anchor="middle" class="name">Ava</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <!-- 3B June, going -->
+    <g transform="translate(108,300)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">3B</text>
+      <text y="34" text-anchor="middle" class="name">June</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <!-- 1B Sam, no response -->
+    <g transform="translate(292,300)">
+      <circle r="20" class="m-none" stroke-width="2" stroke-dasharray="4 3"/>
+      <text dy="4" text-anchor="middle" class="abbr">1B</text>
+      <text y="34" text-anchor="middle" class="name">Sam</text>
+      <rect x="-26" y="40" width="52" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-none">NO RESPONSE</text>
+    </g>
+    <!-- P Maya, going -->
+    <g transform="translate(200,338)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">P</text>
+      <text y="34" text-anchor="middle" class="name">Maya</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <!-- C Leo, going -->
+    <g transform="translate(200,452)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">C</text>
+      <text y="34" text-anchor="middle" class="name">Leo</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+  </g>
+
+  <!-- ================= NIGHT FIELD ================= -->
+  <g class="night" transform="translate(460,80)">
+    <rect width="400" height="520" class="sky" rx="12"/>
+    <g clip-path="url(#wedge)">
+      <rect width="400" height="440" class="grass"/>
+      <g fill="none" stroke-width="40">
+        <circle cx="200" cy="420" r="90"  class="stripe"/>
+        <circle cx="200" cy="420" r="170" class="stripe"/>
+        <circle cx="200" cy="420" r="250" class="stripe"/>
+        <circle cx="200" cy="420" r="330" class="stripe"/>
+      </g>
+      <circle cx="200" cy="420" r="377" fill="none" stroke-width="36" class="track"/>
+      <circle cx="200" cy="420" r="395" fill="none" stroke-width="5" class="fence"/>
+    </g>
+
+    <path d="M200,444 L316,318 Q200,90 84,318 Z" class="dirt"/>
+    <circle cx="200" cy="420" r="42" class="dirt"/>
+    <path d="M200,398 L272,322 L200,246 L128,322 Z" class="ingrass"/>
+    <circle cx="200" cy="330" r="18" class="dirt"/>
+
+    <g fill="none" stroke-width="3" stroke-linecap="round" class="chalk">
+      <path d="M200,420 L14,213"/>
+      <path d="M200,420 L386,213"/>
+    </g>
+    <g fill="none" stroke-width="2.5" stroke-linecap="round" class="chalk" opacity=".9">
+      <path d="M200,420 L290,320 L200,230 L110,320 Z"/>
+    </g>
+
+    <g stroke-width="1">
+      <rect x="-7" y="-7" width="14" height="14" transform="translate(290,320) rotate(45)" class="base"/>
+      <rect x="-7" y="-7" width="14" height="14" transform="translate(200,230) rotate(45)" class="base"/>
+      <rect x="-7" y="-7" width="14" height="14" transform="translate(110,320) rotate(45)" class="base"/>
+      <path d="M193,413 L207,413 L207,420 L200,427 L193,420 Z" class="base"/>
+      <rect x="193" y="327" width="14" height="4" rx="1" class="rubber"/>
+    </g>
+
+    <g transform="translate(200,75)">
+      <circle r="20" class="m-none" stroke-width="2" stroke-dasharray="4 3"/>
+      <text dy="4" text-anchor="middle" class="abbr">CF</text>
+      <text y="34" text-anchor="middle" class="name">Rio</text>
+      <rect x="-26" y="40" width="52" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-none">NO RESPONSE</text>
+    </g>
+    <g transform="translate(75,130)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">LF</text>
+      <text y="34" text-anchor="middle" class="name">Ozzy</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <g transform="translate(325,130)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">RF</text>
+      <text y="34" text-anchor="middle" class="name">Nell</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <g transform="translate(168,252)">
+      <circle r="20" class="m-out" stroke-width="1.5"/>
+      <text dy="4" text-anchor="middle" class="abbr-out abbr">SS</text>
+      <text y="34" text-anchor="middle" class="name name-out">Theo</text>
+      <rect x="-24" y="40" width="48" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-out">NOT GOING</text>
+    </g>
+    <g transform="translate(232,252)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">2B</text>
+      <text y="34" text-anchor="middle" class="name">Ava</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <g transform="translate(108,300)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">3B</text>
+      <text y="34" text-anchor="middle" class="name">June</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <g transform="translate(292,300)">
+      <circle r="20" class="m-none" stroke-width="2" stroke-dasharray="4 3"/>
+      <text dy="4" text-anchor="middle" class="abbr">1B</text>
+      <text y="34" text-anchor="middle" class="name">Sam</text>
+      <rect x="-26" y="40" width="52" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-none">NO RESPONSE</text>
+    </g>
+    <g transform="translate(200,338)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">P</text>
+      <text y="34" text-anchor="middle" class="name">Maya</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+    <g transform="translate(200,452)">
+      <circle r="20" class="m-going" stroke-width="3"/>
+      <text dy="4" text-anchor="middle" class="abbr">C</text>
+      <text y="34" text-anchor="middle" class="name">Leo</text>
+      <rect x="-17" y="40" width="34" height="12" rx="6" class="pill"/>
+      <text y="49" text-anchor="middle" class="tag t-going">GOING</text>
+    </g>
+  </g>
+
+  <text x="220" y="622" text-anchor="middle" class="cap" fill="#4C4A40">Day game — Vintage Cream page, mowed-stripe grass, banana-yellow fence</text>
+  <text x="660" y="622" text-anchor="middle" class="cap" fill="#4C4A40">Night game — dugout charcoal, floodlit chalk, the fence still glows</text>
+</svg>

--- a/docs/design/assets/palette.svg
+++ b/docs/design/assets/palette.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" font-family="Helvetica, Arial, sans-serif">
+  <style>
+    .h    { font: 800 20px 'Arial Black', Arial, sans-serif; letter-spacing: 1px; fill: #1E2A4A; }
+    .name { font: 800 13px 'Arial Black', Arial, sans-serif; fill: #1E2A4A; }
+    .hex  { font: 600 11px 'Courier New', monospace; fill: #6B665A; }
+    .use  { font: 11px Helvetica, Arial, sans-serif; fill: #4C4A40; }
+    .dk   { fill: #EDE7D6; }
+  </style>
+  <rect width="960" height="400" fill="#FAF3E3"/>
+  <text x="30" y="40" class="h">PASTORAL BANANA BALL — PALETTE</text>
+
+  <!-- core swatches -->
+  <g transform="translate(30,64)">
+    <g>
+      <rect width="135" height="90" rx="10" fill="#FAF3E3" stroke="#C9793F" stroke-width="2"/>
+      <text y="112" class="name">Vintage Cream</text>
+      <text y="128" class="hex">#FAF3E3 · 42 70% 94%</text>
+      <text y="144" class="use">Page background, cards.</text>
+      <text y="158" class="use">Kills the white-on-white.</text>
+    </g>
+    <g transform="translate(155,0)">
+      <rect width="135" height="90" rx="10" fill="#2F6B3A"/>
+      <text y="112" class="name">Field Green</text>
+      <text y="128" class="hex">#2F6B3A · 131 39% 30%</text>
+      <text y="144" class="use">Primary buttons, links,</text>
+      <text y="158" class="use">"Going", the grass.</text>
+    </g>
+    <g transform="translate(310,0)">
+      <rect width="135" height="90" rx="10" fill="#C9793F"/>
+      <text y="112" class="name">Infield Clay</text>
+      <text y="128" class="hex">#C9793F · 25 56% 52%</text>
+      <text y="144" class="use">Secondary accents, borders,</text>
+      <text y="158" class="use">the dirt, ticket stubs.</text>
+    </g>
+    <g transform="translate(465,0)">
+      <rect width="135" height="90" rx="10" fill="#FFC72C"/>
+      <text y="112" class="name">Banana Yellow</text>
+      <text y="128" class="hex">#FFC72C · 44 100% 59%</text>
+      <text y="144" class="use">The wow: CTAs, highlights,</text>
+      <text y="158" class="use">drop targets, the fence.</text>
+    </g>
+    <g transform="translate(620,0)">
+      <rect width="135" height="90" rx="10" fill="#1E2A4A"/>
+      <text y="112" class="name">Midnight Navy</text>
+      <text y="128" class="hex">#1E2A4A · 224 42% 20%</text>
+      <text y="144" class="use">Text, headings, jersey</text>
+      <text y="158" class="use">numbers. Replaces black.</text>
+    </g>
+    <g transform="translate(775,0)">
+      <rect width="135" height="90" rx="10" fill="#C8102E"/>
+      <text y="112" class="name">Stitch Red</text>
+      <text y="128" class="hex">#C8102E · 350 85% 42%</text>
+      <text y="144" class="use">Destructive, "Not going",</text>
+      <text y="158" class="use">stitch dividers. Sparingly.</text>
+    </g>
+  </g>
+
+  <!-- night game strip -->
+  <g transform="translate(30,250)">
+    <rect width="900" height="110" rx="12" fill="#14181F"/>
+    <text x="20" y="30" class="name dk">NIGHT GAME (dark mode)</text>
+    <g transform="translate(20,44)">
+      <rect width="120" height="26" rx="6" fill="#14181F" stroke="#3A4150"/>
+      <text x="8" y="17" class="hex dk">#14181F bg</text>
+      <g transform="translate(134,0)">
+        <rect width="120" height="26" rx="6" fill="#1E2530"/>
+        <text x="8" y="17" class="hex dk">#1E2530 card</text>
+      </g>
+      <g transform="translate(268,0)">
+        <rect width="120" height="26" rx="6" fill="#234230"/>
+        <text x="8" y="17" class="hex dk">#234230 grass</text>
+      </g>
+      <g transform="translate(402,0)">
+        <rect width="120" height="26" rx="6" fill="#FFD24D"/>
+        <text x="8" y="17" class="hex" fill="#1E2A4A">#FFD24D floodlight</text>
+      </g>
+      <g transform="translate(536,0)">
+        <rect width="120" height="26" rx="6" fill="#EDE7D6"/>
+        <text x="8" y="17" class="hex" fill="#1E2A4A">#EDE7D6 chalk text</text>
+      </g>
+      <g transform="translate(670,0)">
+        <rect width="120" height="26" rx="6" fill="#7A563A"/>
+        <text x="8" y="17" class="hex dk">#7A563A night dirt</text>
+      </g>
+    </g>
+    <text x="20" y="96" class="use" fill="#A9A292">Dark mode is a night game under the lights, not an inverted spreadsheet — same field, floodlit.</text>
+  </g>
+</svg>

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -15,7 +15,8 @@ the view page) so each phase can be picked up and built without re-deriving anyt
 > intent. Three things named below were deliberately **not** built: the save-success
 > confetti and the RSVP ⚾ micro-pop (§8), and the sign-in field illustration (§7). They
 > need a confetti dependency and new client components respectively, and were left for a
-> follow-up rather than half-done.
+> follow-up rather than half-done. §13 explains how this document is kept from drifting
+> again.
 
 ![Palette](assets/palette.svg)
 
@@ -69,14 +70,36 @@ The full palette with hex/HSL and usage is in the image above. Token changes lan
 |---|---|---|---|
 | `--background` | `42 70% 94%` Vintage Cream | `218 22% 10%` Dugout Charcoal | The single biggest de-black-and-whitening move |
 | `--foreground` | `224 42% 20%` Midnight Navy | `45 36% 88%` Chalk | Navy replaces near-black everywhere |
-| `--primary` | `131 39% 30%` Field Green | `120 41% 69%` night grass-glow | Buttons/links become *green*, not black |
-| `--secondary` | `25 56% 52%` Infield Clay at 15% | clay-dark surface | Warm secondary surfaces |
+| `--primary` | `131 39% 30%` Field Green | `120 41% 69%` grass-glow | Buttons/links become *green*, not black |
+| `--secondary` | `30 40% 87%` clay tint | `219 14% 20%` | Warm secondary surfaces — a tint, not full-strength clay |
 | `--accent` | `44 85% 86%` soft banana tint | `45 40% 24%` | Hover/ghost surfaces only — the *quiet* member of the banana family |
 | `--banana` | `44 100% 59%` Banana Yellow | `45 100% 65%` Floodlight | The one-per-screen wow. Separate from `--accent` so the loud value can't leak into every hover |
-| `--destructive` | `350 85% 42%` Stitch Red | lightened stitch | Also the seam-divider color |
+| `--destructive` | `350 85% 42%` Stitch Red | `352 70% 55%` | Also the seam-divider colour |
+| `--muted` | `40 32% 86%` | `219 14% 22%` | Quiet surfaces |
+| `--muted-foreground` | `30 12% 38%` | `40 15% 68%` | Secondary text, and the declined name *on the field* |
 | `--card` | `45 60% 98%` warm white | `220 19% 15%` | Cards stay lighter than the page → depth for free |
-| `--border` | `35 30% 82%` warm sand | `219 14% 24%` | Borders get warm, stop disappearing |
-| `--baseball-*` | retire or re-point at the above | — | One palette, not two competing ones |
+| `--border` | `35 30% 80%` warm sand | `219 14% 24%` | Borders get warm, stop disappearing |
+| `--ring` | `131 39% 30%` Field Green | `45 100% 65%` Floodlight | Focus rings — yellow at night, where green would vanish |
+
+The field's own palette, consumed by `FieldArt` in both diamonds:
+
+| Token | Light ("day game") | Dark ("night game") | Notes |
+|---|---|---|---|
+| `--grass` | `104 31% 55%` | `145 31% 20%` | Fair territory |
+| `--grass-stripe` | `104 33% 60%` | `145 29% 23%` | Mow rings, a shade up from the grass |
+| `--infield-grass` | `104 27% 50%` | `144 30% 17%` | The diamond inside the basepaths |
+| `--dirt` | `31 56% 57%` | `26 36% 35%` | Infield, home circle, mound |
+| `--track` | `33 62% 60%` | `25 36% 31%` | Warning track |
+| `--chalk` | `0 0% 100%` | `45 36% 88%` | Foul lines, basepaths, bases, plate |
+
+And the scoreboard, which is charcoal in **both** themes — a scoreboard is dark; light mode
+just means it is daytime around it:
+
+| Token | Light ("day game") | Dark ("night game") | Notes |
+|---|---|---|---|
+| `--scoreboard` | `218 22% 10%` | `218 22% 8%` | Panel ground |
+| `--scoreboard-foreground` | `45 36% 88%` | `45 36% 88%` | Readout text |
+| `--scoreboard-accent` | `45 100% 65%` | `45 100% 65%` | The lit figures |
 
 Dark mode is a **night game**: same field under floodlights — charcoal sky, deeper grass,
 glowing chalk, and the yellow gets *brighter*, not muted. It already keys off
@@ -126,24 +149,29 @@ The centerpiece, and the explicit second half of the brief. Full mockup, day and
 
 ### What gets drawn (back to front)
 
-All inside the existing `400 × 520` viewBox, behind the existing markers:
+All inside the existing viewBox — `DIAMOND_GEOMETRY.width = 400`,
+`DIAMOND_GEOMETRY.height = 520` — behind the existing markers:
 
 1. **Grass wedge** — fills the fair-territory fan from home plate `(200,420)` out along
-   both foul lines, clipped a second time to the fence arc (`parkRadius`) so the park
+   both foul lines, clipped a second time to the fence arc
+   (`FIELD_ART.parkRadius = 411`) so the park
    ends at the wall instead of running green out to the corners of the box; page-cream
    shows through in foul ground and beyond the fence, keeping the poster-illustration
    feel.
-2. **Mow stripes** — concentric rings centered on home (r 90/170/250/330, 40 wide) in a
-   slightly lighter green. This is 90% of the "real field" feeling for four circles of
-   effort.
-3. **Warning track + fence** — a tan arc band centred at r=392 (36 wide) and a 5px
-   **Banana Yellow fence line** at r=408. The fence is that screen's one banana. Both
-   sit far enough out that the deepest outfielder — CENTER_FIELD at y=75, so a marker
-   edge at y=55 — stands on grass rather than straddling the track.
+2. **Mow stripes** — concentric rings centred on home, `FIELD_ART.stripeWidth = 40` wide,
+   in a slightly lighter green. This is 90% of the "real field" feeling for four circles
+   of effort.
+3. **Warning track + fence** — a tan arc band at `FIELD_ART.trackRadius = 392`,
+   `FIELD_ART.trackWidth = 36` wide, and a **Banana Yellow fence line** at
+   `FIELD_ART.fenceRadius = 408`, `FIELD_ART.fenceWidth = 5`. The fence is that screen's
+   one banana. Both sit far enough out that the deepest outfielder — CENTER_FIELD at
+   y=75, so a marker edge at y=55 — stands on grass rather than straddling the track,
+   which `diamond-geometry.test.ts` pins.
 4. **Infield dirt** — `M200,444 L316,318 Q200,90 84,318 Z` (a diamond with an arced back
-   edge behind second), plus the home-plate circle (r 54 — big enough that the catcher
-   marker at y=452, and the `NoCatcherMarker` disc that replaces it on an allPlay board,
-   sit fully *on* dirt rather than hanging off its edge) and mound (r 18 at `(200,330)`).
+   edge behind second), plus the home-plate circle — big enough that the catcher marker
+   at y=452, and the `NoCatcherMarker` disc that replaces it on an allPlay board, sit
+   fully *on* dirt rather than hanging off its edge — and the mound at `(200,330)`.
+   `FIELD_ART.mound.r = 18`.
 5. **Infield grass** — the inset diamond `(200,398) (272,322) (200,246) (128,322)`.
    SS/2B markers at y=252 land on the dirt behind it, exactly where they stand in life.
 6. **Chalk** — white foul lines home→`(14,213)`/`(386,213)` and the basepath diamond;
@@ -221,11 +249,20 @@ Every dynasty starts somewhere." Copy stays informative first, funny second; par
 
 Via the existing `LazyMotion`/`m` setup only:
 
-- Page-level: 150–200ms fade-up on card mount; stagger lists (lineup, schedule) ~40ms.
-- Micro: RSVP pop, save-success tick, pennant hover tilt (±2°).
+- Page-level: the existing `Reveal` rise on card mount; lineup rows stagger in at ~40ms
+  intervals via the `animate-rise` utility, an inline `animation-delay` per row.
+- `animate-rise` is CSS, not Motion, and **translate-only** — no opacity, for the same
+  reason `Reveal` has none: Motion serialises `initial` into the server-rendered markup,
+  so a fade ships `opacity: 0` in the HTML and the lineup stays blank until the bundle
+  hydrates. At a field on one bar of signal the content has to be legible from the raw
+  HTML, with the animation as polish on top.
+- Micro: RSVP pop, save-success tick, pennant hover tilt (±2°). **Not built** — see the
+  status note at the top.
 - Celebration: one confetti burst (green/yellow/cream, ~1.2s) on chart save success only.
-- Hard rules: nothing dnd-kit touches gets Motion (documented collision); every
-  non-essential animation respects `prefers-reduced-motion`; nothing loops forever.
+  **Not built** — needs a dependency, deferred rather than half-done.
+- Hard rules: nothing dnd-kit touches gets Motion or `animate-rise` (documented
+  collision); every non-essential animation respects `prefers-reduced-motion`, which
+  `animate-rise` does in its own `@utility` block; nothing loops forever.
 
 ## 9. Voice
 
@@ -273,3 +310,37 @@ wow-per-effort.
   standing; Decision 16).
 - Dates through `calendar.ts` helpers only.
 - One banana per screen.
+
+## 13. Keeping this document honest
+
+This document ships in the same repository as the code it describes, which makes it a
+second source of truth — and a second source of truth rots. In this document's first week
+it rotted four times: the colour table named one `--accent` where the code had split
+`--accent` and `--banana`; `--secondary` and `--border` carried values that were never
+shipped; §6 specified a `<rect>` pill that was replaced by `text-halo` during
+implementation; and the field radii were the ones from before the visual-review fixes
+moved them. Three were caught by a reviewer reading the diff. That is expensive attention
+to spend on stale numbers.
+
+So `src/design-plan-drift.test.ts` now checks this file against the code on every
+`pnpm check`, and the sections above are written in a shape it can read:
+
+- **Colour tables.** A row of the form ``| `--token` | `H S% L%` … | `H S% L%` … |`` is a
+  claim. The test asserts the token exists in `globals.css` and that both values match.
+  Describing a token in words instead of an HSL triple is allowed — the cell is simply
+  not checked — so the guard only ever fires on a stated value that is *wrong*.
+- **Geometry.** Numbers are written as ``FIELD_ART.trackRadius = 392`` or
+  ``DIAMOND_GEOMETRY.height = 520``, one level of nesting allowed
+  (``FIELD_ART.mound.r = 18``). The test reads every such claim and compares it to the
+  real constant. Prose may still say "roughly a third of the way out" — only the
+  `Object.key = number` form is binding.
+- **Utilities.** Utilities named as part of the texture vocabulary must exist as
+  `@utility` blocks in `globals.css`.
+
+Everything else — rationale, principles, the screen-by-screen pass, voice — stays
+free-form on purpose. The goal is to catch stale *facts*, not to turn a design document
+into a schema.
+
+**When the test fails, fix whichever side is wrong** — usually this document, because the
+code moved and the prose did not. Deleting the claim to quiet the test throws away the
+only thing keeping the two in step.

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -1,0 +1,255 @@
+# Pastoral Banana Ball — the design plan
+
+> Old-school pastoral baseball — cream scorecards, chalk lines, mowed grass, felt pennants —
+> crashed into by Savannah-Bananas-grade showmanship: one loud banana yellow, chunky slab
+> type, tickets, scoreboards, and a little confetti when the coach ships a lineup.
+
+This is the visual overhaul plan for the Youth Baseball Team Manager. It is a **plan, not a
+diff** — nothing in `src/` changes until phases start landing — but every spec here was
+written against the real code (`globals.css`, `diamond-geometry.ts`, the two chart editors,
+the view page) so each phase can be picked up and built without re-deriving anything.
+
+![Palette](assets/palette.svg)
+
+---
+
+## 1. Where we are (the honest audit)
+
+The app is structurally excellent and visually mute:
+
+- **Everything is white, off-white, and near-black.** `--background` is pure white,
+  `--primary` is a nearly-black brown (`24 100% 10%`), and the four `--baseball-*` tokens
+  (green, brown, blue, red) that were clearly meant to carry the theme are defined in
+  `globals.css` but almost nowhere used. The theme exists as unpaid potential.
+- **The diamond is a hollow polygon.** `DIAMOND_POLYGON` draws four `stroke-border` lines
+  on a blank card. No grass, no dirt, no bases, no foul lines. A parent squinting at a
+  phone at the field sees a kite, not a ballfield.
+- **Every surface is the same surface.** Games, practices, rosters, settings — identical
+  white cards with identical gray borders. Nothing signals "this is the fun page" (the
+  lineup) vs. "this is the admin page" (settings).
+- **Typography is one voice.** Geist everywhere, at polite sizes. Nothing shouts
+  "GAME DAY."
+
+What's already *right* and must not be lost: the RSVP visual vocabulary is centralized
+(`rsvp-style.ts`), state is never color-alone, the diamond geometry is shared between
+viewer and editor, and the dnd-kit/Motion separation is documented and respected. The
+redesign works **through** those systems, not around them.
+
+## 2. Design principles
+
+1. **Day at the ballpark, not a SaaS dashboard.** Warm cream paper, real green, real clay.
+   The default screen temperature goes from "hospital" to "July."
+2. **One banana per screen.** Banana Yellow is the wow — and it only wows if it's scarce.
+   Exactly one big yellow element per screen (the CTA, the fence, the drop highlight).
+   Two bananas is a fruit stand.
+3. **Crunchy = texture + chunk + snap.** Grain of paper (subtle pinstripes, chalk-dash
+   borders, stitch dividers), chunky slab display type, and snappy micro-motion. Never
+   gradients-and-glassmorphism modern; this is felt-and-cardstock modern.
+4. **Sunlight-first.** This app is read outdoors on a phone at 9 AM. Every color pairing
+   in this plan clears WCAG AA at its size; state always keeps its text label. Fun that
+   hurts legibility loses.
+5. **The data model is the personality.** The standing chart, the three RSVP states, the
+   "declined fades but never leaves" rule — the design amplifies existing semantics and
+   invents zero new ones.
+
+## 3. Color system
+
+The full palette with hex/HSL and usage is in the image above. Token changes land in
+`globals.css` (Tailwind 4 `@theme inline` picks them up automatically — no config file):
+
+| Token | Light ("day game") | Dark ("night game") | Notes |
+|---|---|---|---|
+| `--background` | `42 70% 94%` Vintage Cream | `218 22% 10%` Dugout Charcoal | The single biggest de-black-and-whitening move |
+| `--foreground` | `224 42% 20%` Midnight Navy | `45 36% 88%` Chalk | Navy replaces near-black everywhere |
+| `--primary` | `131 39% 30%` Field Green | `120 41% 69%` night grass-glow | Buttons/links become *green*, not black |
+| `--secondary` | `25 56% 52%` Infield Clay at 15% | clay-dark surface | Warm secondary surfaces |
+| `--accent` | `44 100% 59%` Banana Yellow | `45 100% 65%` Floodlight | New meaning: the one-per-screen wow |
+| `--destructive` | `350 85% 42%` Stitch Red | lightened stitch | Also the seam-divider color |
+| `--card` | `45 60% 98%` warm white | `220 19% 15%` | Cards stay lighter than the page → depth for free |
+| `--border` | `35 30% 82%` warm sand | `219 14% 24%` | Borders get warm, stop disappearing |
+| `--baseball-*` | retire or re-point at the above | — | One palette, not two competing ones |
+
+Dark mode is a **night game**: same field under floodlights — charcoal sky, deeper grass,
+glowing chalk, and the yellow gets *brighter*, not muted. It already keys off
+`prefers-color-scheme`; only the values change.
+
+Contrast spot-checks (must re-verify in review): navy on cream 11.9:1 ✓ · Field Green on
+cream 5.6:1 ✓ · navy on Banana Yellow 7.5:1 ✓ · white on Field Green 5.9:1 ✓. Banana
+Yellow never carries white text, ever.
+
+## 4. Typography
+
+| Role | Face | How |
+|---|---|---|
+| Display / page titles / "GAME DAY" | **Alfa Slab One** (Google) | `next/font/google`, exposed as `--font-display`, new `font-display` utility via `@theme` |
+| Body / UI | **Geist** (keep) | Already loaded; it's a good body face |
+| Scoreboard numbers, dates, jersey numbers | **Geist Mono** (keep, promote) | Tabular numerals for the readiness scoreboard and ticket stubs |
+
+Rules: Alfa Slab only at 20px+, only for headings and hero numbers, often uppercase with
+`tracking-wide`. Body stays Geist — slab body text is a ransom note. (If Alfa Slab feels
+too heavy in situ, **Graduate** is the collegiate-athletic fallback; decide once, in
+Phase 1, on a real phone.)
+
+## 5. Texture vocabulary
+
+Five reusable motifs — each one a tiny component or utility class, built once in Phase 1
+and then spent everywhere (see sketches):
+
+![Components](assets/components.svg)
+
+1. **Stitch divider** — `<StitchDivider/>`: two shallow dashed red arcs (SVG), the seam of
+   a baseball. Replaces plain `<hr>`/border-t section breaks.
+2. **Pinstripes** — a `bg-pinstripe` utility (CSS `repeating-linear-gradient`, 6% navy on
+   transparent, 24px period). Header bands and hero surfaces only, never behind body text.
+3. **Chalk box** — dashed 2px warm border + slightly-inset fill; the style for every empty
+   state and every drop zone. Already half-exists in the editors' dashed borders — this
+   names it and warms it up.
+4. **Ticket perforation** — vertical dashed rule with punched-notch circles; marks
+   anything RSVP-able (game cards, the event page header).
+5. **Jersey dot** — navy circle, cream number, Geist Mono. Batting slot numbers, roster
+   jersey numbers.
+
+## 6. The diamond finally looks like a diamond ⚾
+
+The centerpiece, and the explicit second half of the brief. Full mockup, day and night:
+
+![Diamond redesign](assets/diamond-field.svg)
+
+### What gets drawn (back to front)
+
+All inside the existing `400 × 520` viewBox, behind the existing markers:
+
+1. **Grass wedge** — fills the fair-territory fan from home plate `(200,420)` out along
+   both foul lines to the top corners; page-cream shows through in foul ground, keeping
+   the poster-illustration feel.
+2. **Mow stripes** — concentric rings centered on home (r 90/170/250/330, 40 wide) in a
+   slightly lighter green. This is 90% of the "real field" feeling for four circles of
+   effort.
+3. **Warning track + fence** — a tan arc band at r≈360–395 and a 5px **Banana Yellow
+   fence line** at r=395. The fence is that screen's one banana.
+4. **Infield dirt** — `M200,444 L316,318 Q200,90 84,318 Z` (a diamond with an arced back
+   edge behind second), plus the home-plate circle (r 42 — big enough that the catcher
+   marker at y=452 stands on dirt) and mound (r 18 at `(200,330)`).
+5. **Infield grass** — the inset diamond `(200,398) (272,322) (200,246) (128,322)`.
+   SS/2B markers at y=252 land on the dirt behind it, exactly where they stand in life.
+6. **Chalk** — white foul lines home→`(14,213)`/`(386,213)` and the basepath diamond;
+   white bases (rotated squares), home plate pentagon, pitching rubber.
+
+### How it lands in code
+
+- **New `FieldArt` server component** (`src/components/FieldArt.tsx`), pure SVG `<g>`,
+  rendered by *both* `view/Diamond.tsx` and `PositionsEditor.tsx`'s `Field` before their
+  markers/targets — same sharing rule that already governs `diamond-geometry.ts`, and the
+  geometry constants for the art live in that same file so viewer and editor can never
+  drift.
+- **Nothing moves.** `POSITION_COORDS`, the 520 height, marker radius, name/tag offsets
+  all stay. The catcher's name at y+47 stays inside the viewBox (the documented clipping
+  trap). In the editor the art is inside the existing absolutely-positioned SVG; the HTML
+  drop targets and dnd-kit measurement are untouched.
+- **Theme-aware** via the CSS tokens (`fill-[hsl(var(--…))]`-style classes), so the night
+  game falls out of dark mode for free.
+- **Markers restyle, semantics frozen.** Cream-filled circles; `RSVP_STYLE` keeps its
+  three entries and label-plus-color rule — attending gets a thick Field Green ring,
+  declined fades, no-response stays dashed. New: a small cream **pill behind the
+  name/RSVP tag** (a `rx`-rounded `<rect>` under the existing `<text>`), because navy
+  text needs backing to stay readable on grass. The `NoCatcherMarker` disc survives
+  unchanged on the home-circle dirt.
+- **allPlay outfield** markers already arc across exactly this grass
+  (`outfieldZoneCoords`); they inherit the pills and need nothing else.
+
+## 7. Screen-by-screen pass
+
+**Sign-in** — first impression, currently a form. Cream page, pinstripe band, slab
+wordmark, one banana button ("Email me a magic link"), and a tiny flat field illustration
+(a cropped reuse of `FieldArt`). Empty-state copy: "The gate's open."
+
+**Team home + `TeamCard`** — cards become **pennant cards**: small felt-green pennant
+glyph, slab team name, warm card stock. Archived teams go sepia ("retired jersey") with a
+`RETIRED` tag instead of just being text-muted.
+
+**Schedule** — games become **ticket stubs** (sketch A): perforated edge, slab opponent
+name, Geist Mono date, RSVP tallies on the stub end. Practices print on plain cream stock
+with a clay dashed border — games must feel like the main event. Month grid keeps using
+`calendar.ts` helpers exclusively (the `APP_TIMEZONE` rule).
+
+**Event page** — RSVP buttons get real weight: Going = Field Green fill, Not going =
+stitch-red outline, current selection ringed. One moment of delight: RSVPing "Going" pops
+a ⚾ micro-animation (Motion, `prefers-reduced-motion`-gated).
+
+**Lineup view (`/view`)** — the payoff page. The full-field diamond above; batting order
+as **dugout roster rows** (sketch B): jersey-dot slot number, name, RSVP pill. The
+existing `Reveal` staggers rows in like a lineup being announced.
+
+**Chart editors** — restraint zone; dnd-kit owns every dragged element (the AGENTS.md
+rule), so flair goes only into *static* styling: field art behind the position targets,
+chalk-box drop zones, warmer chips with jersey dots. The drop-target hover state
+(`isOver`) becomes a Banana Yellow chalk glow — that screen's one banana. **No Motion
+anywhere near a chip.** Save button: "Post the lineup"; success confirmation (after
+dnd-kit is done and the action returns) may confetti, once, briefly.
+
+**Readiness** — becomes **The Scoreboard** (sketch D): charcoal panel even in light mode,
+floodlight-yellow Geist Mono figures, uncovered positions in red. It's read-only math
+(`readiness.ts` stays pure); this is purely a costume change.
+
+**Roster/members/directory/settings** — calm pages: warm tokens, stitch dividers, jersey
+dots on roster rows, no bananas. Admin should feel tidy, not loud.
+
+**Empty states everywhere** — chalk box + one line of voice: "Nobody on the roster yet.
+Every dynasty starts somewhere." Copy stays informative first, funny second; parents skim.
+
+## 8. Motion (the Savannah swagger, safely)
+
+Via the existing `LazyMotion`/`m` setup only:
+
+- Page-level: 150–200ms fade-up on card mount; stagger lists (lineup, schedule) ~40ms.
+- Micro: RSVP pop, save-success tick, pennant hover tilt (±2°).
+- Celebration: one confetti burst (green/yellow/cream, ~1.2s) on chart save success only.
+- Hard rules: nothing dnd-kit touches gets Motion (documented collision); every
+  non-essential animation respects `prefers-reduced-motion`; nothing loops forever.
+
+## 9. Voice
+
+Current copy is fine and stays fine; it gets one seasoning pass. Headlines may play
+("Game day," "The gate's open"); data and instructions never do. RSVP labels
+Going / Not going / No response are **frozen** — they're shared vocabulary across two
+pages and a legend, and clarity outranks comedy on the thing parents check from a car.
+
+## 10. Accessibility & field-readability checklist
+
+- AA contrast for all text; large-text-AA minimum for text-on-illustration (with pill
+  backing on the diamond).
+- State = color **+ label** always (already policy in `rsvp-style.ts`; extends to tickets
+  and the scoreboard).
+- The diamond keeps its `aria-hidden` + `sr-only` list pattern; `FieldArt` is decoration
+  and adds no announced content.
+- Focus rings: 2px Banana Yellow outer ring on navy/green, navy on yellow — visible in
+  sunlight.
+- Touch targets ≥44px in editors and RSVP buttons (drag activation constraints already
+  tuned in `drag-activation.ts` — don't fight them).
+
+## 11. Build phases
+
+Each phase ships independently and `pnpm check` gates each one.
+
+| Phase | What | Where | Size |
+|---|---|---|---|
+| **1. Repaint** | New tokens light+dark, Alfa Slab via `next/font`, `bg-pinstripe` utility, `StitchDivider`, chalk-box classes, jersey dot | `globals.css`, `layout.tsx`, `src/components/` | S–M |
+| **2. The field** | `FieldArt` + geometry constants, wire into `Diamond.tsx` and `PositionsEditor`, marker pills | `diamond-geometry.ts`, `FieldArt.tsx`, both diamonds | M |
+| **3. Paper goods** | Ticket-stub game cards, pennant team cards, dugout batting rows, scoreboard readiness | schedule, team home, view, readiness pages | M–L |
+| **4. Showtime** | Reveal/stagger polish, RSVP pop, save confetti, empty-state voice pass | scattered, small | S |
+
+Phase 1 alone already answers "horribly black and white." Phases are ordered by
+wow-per-effort.
+
+## 12. Guardrails (read before building any phase)
+
+- dnd-kit and Motion never touch the same element. Editors get static flair only.
+- `POSITION_LABELS` is the only source of position abbreviations.
+- Diamond geometry: check the lowest marker's y+47 against the viewBox before moving
+  anything; viewer and editor share every drawn coordinate through `diamond-geometry.ts`.
+- `RSVP_STYLE` stays the single RSVP vocabulary; three states, label + color, declined
+  fades the name and never the slot.
+- No per-game anything sneaks in via design (no "today's lineup" variants — the chart is
+  standing; Decision 16).
+- Dates through `calendar.ts` helpers only.
+- One banana per screen.

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -9,6 +9,14 @@ diff** — nothing in `src/` changes until phases start landing — but every sp
 written against the real code (`globals.css`, `diamond-geometry.ts`, the two chart editors,
 the view page) so each phase can be picked up and built without re-deriving anything.
 
+> **Status.** All four phases in §11 have since shipped, in the same pull request as this
+> document. Where the two disagreed, this document has been corrected to describe what was
+> actually built — it is the plan *and* the as-built record, not a snapshot of the original
+> intent. Three things named below were deliberately **not** built: the save-success
+> confetti and the RSVP ⚾ micro-pop (§8), and the sign-in field illustration (§7). They
+> need a confetti dependency and new client components respectively, and were left for a
+> follow-up rather than half-done.
+
 ![Palette](assets/palette.svg)
 
 ---
@@ -63,7 +71,8 @@ The full palette with hex/HSL and usage is in the image above. Token changes lan
 | `--foreground` | `224 42% 20%` Midnight Navy | `45 36% 88%` Chalk | Navy replaces near-black everywhere |
 | `--primary` | `131 39% 30%` Field Green | `120 41% 69%` night grass-glow | Buttons/links become *green*, not black |
 | `--secondary` | `25 56% 52%` Infield Clay at 15% | clay-dark surface | Warm secondary surfaces |
-| `--accent` | `44 100% 59%` Banana Yellow | `45 100% 65%` Floodlight | New meaning: the one-per-screen wow |
+| `--accent` | `44 85% 86%` soft banana tint | `45 40% 24%` | Hover/ghost surfaces only — the *quiet* member of the banana family |
+| `--banana` | `44 100% 59%` Banana Yellow | `45 100% 65%` Floodlight | The one-per-screen wow. Separate from `--accent` so the loud value can't leak into every hover |
 | `--destructive` | `350 85% 42%` Stitch Red | lightened stitch | Also the seam-divider color |
 | `--card` | `45 60% 98%` warm white | `220 19% 15%` | Cards stay lighter than the page → depth for free |
 | `--border` | `35 30% 82%` warm sand | `219 14% 24%` | Borders get warm, stop disappearing |
@@ -120,16 +129,21 @@ The centerpiece, and the explicit second half of the brief. Full mockup, day and
 All inside the existing `400 × 520` viewBox, behind the existing markers:
 
 1. **Grass wedge** — fills the fair-territory fan from home plate `(200,420)` out along
-   both foul lines to the top corners; page-cream shows through in foul ground, keeping
-   the poster-illustration feel.
+   both foul lines, clipped a second time to the fence arc (`parkRadius`) so the park
+   ends at the wall instead of running green out to the corners of the box; page-cream
+   shows through in foul ground and beyond the fence, keeping the poster-illustration
+   feel.
 2. **Mow stripes** — concentric rings centered on home (r 90/170/250/330, 40 wide) in a
    slightly lighter green. This is 90% of the "real field" feeling for four circles of
    effort.
-3. **Warning track + fence** — a tan arc band at r≈360–395 and a 5px **Banana Yellow
-   fence line** at r=395. The fence is that screen's one banana.
+3. **Warning track + fence** — a tan arc band centred at r=392 (36 wide) and a 5px
+   **Banana Yellow fence line** at r=408. The fence is that screen's one banana. Both
+   sit far enough out that the deepest outfielder — CENTER_FIELD at y=75, so a marker
+   edge at y=55 — stands on grass rather than straddling the track.
 4. **Infield dirt** — `M200,444 L316,318 Q200,90 84,318 Z` (a diamond with an arced back
-   edge behind second), plus the home-plate circle (r 42 — big enough that the catcher
-   marker at y=452 stands on dirt) and mound (r 18 at `(200,330)`).
+   edge behind second), plus the home-plate circle (r 54 — big enough that the catcher
+   marker at y=452, and the `NoCatcherMarker` disc that replaces it on an allPlay board,
+   sit fully *on* dirt rather than hanging off its edge) and mound (r 18 at `(200,330)`).
 5. **Infield grass** — the inset diamond `(200,398) (272,322) (200,246) (128,322)`.
    SS/2B markers at y=252 land on the dirt behind it, exactly where they stand in life.
 6. **Chalk** — white foul lines home→`(14,213)`/`(386,213)` and the basepath diamond;
@@ -150,12 +164,15 @@ All inside the existing `400 × 520` viewBox, behind the existing markers:
   game falls out of dark mode for free.
 - **Markers restyle, semantics frozen.** Cream-filled circles; `RSVP_STYLE` keeps its
   three entries and label-plus-color rule — attending gets a thick Field Green ring,
-  declined fades, no-response stays dashed. New: a small cream **pill behind the
-  name/RSVP tag** (a `rx`-rounded `<rect>` under the existing `<text>`), because navy
-  text needs backing to stay readable on grass. The `NoCatcherMarker` disc survives
-  unchanged on the home-circle dirt.
+  declined fades, no-response stays dashed. New: a **`text-halo` utility**
+  (`paint-order: stroke` with a background-colored stroke) behind the name and RSVP
+  tag, because navy text needs backing to stay readable on grass. A halo rather than a
+  `<rect>` pill: the pill has to be measured against the text it sits behind, and SVG
+  gives no layout pass to measure with, so a fixed-width rect either clips a long name
+  or floats around a short one. The `NoCatcherMarker` disc survives unchanged on the
+  home-circle dirt.
 - **allPlay outfield** markers already arc across exactly this grass
-  (`outfieldZoneCoords`); they inherit the pills and need nothing else.
+  (`outfieldZoneCoords`); they inherit the halo and need nothing else.
 
 ## 7. Screen-by-screen pass
 
@@ -164,8 +181,11 @@ wordmark, one banana button ("Email me a magic link"), and a tiny flat field ill
 (a cropped reuse of `FieldArt`). Empty-state copy: "The gate's open."
 
 **Team home + `TeamCard`** — cards become **pennant cards**: small felt-green pennant
-glyph, slab team name, warm card stock. Archived teams go sepia ("retired jersey") with a
-`RETIRED` tag instead of just being text-muted.
+glyph, slab team name, warm card stock. Archived teams go sepia and desaturated — a
+retired jersey — instead of just being text-muted. The badge keeps the word **Archived**:
+that is the app's existing vocabulary for this state, shared with the "Archived Teams"
+section heading it sits under, the settings Archive/Unarchive controls, and the team
+header. A second word for one state is a worse card, however good the flourish.
 
 **Schedule** — games become **ticket stubs** (sketch A): perforated edge, slab opponent
 name, Geist Mono date, RSVP tallies on the stub end. Practices print on plain cream stock

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,89 +1,119 @@
 @import "tailwindcss";
 
+/* "Pastoral Banana Ball" — see docs/design/design-plan.md. Old-school pastoral
+   baseball (cream paper, field green, infield clay, midnight navy) with one
+   loud Banana Yellow accent per screen. Dark mode is a night game under
+   floodlights, not an inverted spreadsheet. */
 :root {
   /* Background & foreground in HSL */
-  --background: 0 0% 100%;
-  --foreground: 217 33% 16%;
-
-  /* Baseball theme (hex → HSL). Overridden in the dark block below — these
-     are tuned for light surfaces and wash out on a dark card. */
-  --baseball-green: 104 48% 24%;
-  --baseball-brown: 43 60% 33%;
-  --baseball-blue: 217 100% 29%;
-  --baseball-red: 0 90% 56%;
+  --background: 42 70% 94%;
+  --foreground: 224 42% 20%;
 
   /* shadcn/ui design tokens.
      `--primary` is the brand SURFACE and `--primary-foreground` is the text
      that sits on it — `bg-primary text-primary-foreground`. Keep primary dark
      here and light in the dark block; transposing the pair makes `text-primary`
      near-invisible and turns the default Button into a white-on-white slab. */
-  --primary: 24 100% 10%;
-  --primary-foreground: 24 9% 98%;
+  --primary: 131 39% 30%;
+  --primary-foreground: 42 70% 96%;
 
-  --secondary: 24 5% 90%;
-  --secondary-foreground: 24 9% 10%;
+  --secondary: 30 40% 87%;
+  --secondary-foreground: 25 50% 25%;
 
-  --destructive: 0 84% 60%;
+  --destructive: 350 85% 42%;
   --destructive-foreground: 0 0% 98%;
 
-  --muted: 24 5% 74%;
-  --muted-foreground: 15 4% 36%;
+  --muted: 40 32% 86%;
+  --muted-foreground: 30 12% 38%;
 
-  --accent: 24 9% 98%;
-  --accent-foreground: 24 100% 10%;
+  /* Accent is the *hover-tint* member of the banana family — soft enough for
+     outline/ghost button hovers. The full-strength banana lives in --banana
+     below and is rationed: one big yellow thing per screen. */
+  --accent: 44 85% 86%;
+  --accent-foreground: 224 42% 20%;
 
-  --popover: 0 0% 100%;
-  --popover-foreground: 15 23% 10%;
+  --banana: 44 100% 59%;
+  --banana-foreground: 224 42% 20%;
 
-  --card: 0 0% 100%;
-  --card-foreground: 15 23% 10%;
+  --popover: 45 60% 98%;
+  --popover-foreground: 224 42% 20%;
 
-  --border: 24 6% 93%;
-  --input: 24 6% 93%;
-  --ring: 24 100% 10%;
+  --card: 45 60% 98%;
+  --card-foreground: 224 42% 20%;
+
+  --border: 35 30% 80%;
+  --input: 35 30% 80%;
+  --ring: 131 39% 30%;
+
+  /* The field itself — consumed by FieldArt (both diamonds). Tuned as a flat
+     poster illustration: markers and text must stay readable on top. */
+  --grass: 104 31% 55%;
+  --grass-stripe: 104 33% 60%;
+  --infield-grass: 104 27% 50%;
+  --dirt: 31 56% 57%;
+  --track: 33 62% 60%;
+  --chalk: 0 0% 100%;
+
+  /* The readiness scoreboard is charcoal in BOTH themes — a scoreboard is
+     dark; light mode just means it's daytime around it. */
+  --scoreboard: 218 22% 10%;
+  --scoreboard-foreground: 45 36% 88%;
+  --scoreboard-accent: 45 100% 65%;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: 217 33% 6%;
-    --foreground: 200 10% 98%;
+    --background: 218 22% 10%;
+    --foreground: 45 36% 88%;
 
-    /* Lightened so they keep contrast against --card (15 23% 12%). */
-    --baseball-green: 104 40% 65%;
-    --baseball-brown: 43 50% 65%;
-    --baseball-blue: 217 80% 72%;
-    --baseball-red: 0 85% 70%;
+    --primary: 120 41% 69%;
+    --primary-foreground: 218 22% 10%;
 
-    --primary: 24 9% 98%;
-    --primary-foreground: 24 100% 10%;
+    --secondary: 219 14% 20%;
+    --secondary-foreground: 45 36% 88%;
 
-    --secondary: 24 9% 20%;
-    --secondary-foreground: 24 9% 98%;
-
-    --destructive: 0 84% 60%;
+    --destructive: 352 70% 55%;
     --destructive-foreground: 0 0% 98%;
 
-    --muted: 15 10% 40%;
-    --muted-foreground: 15 4% 74%;
+    --muted: 219 14% 22%;
+    --muted-foreground: 40 15% 68%;
 
-    --accent: 24 100% 10%;
-    --accent-foreground: 24 9% 98%;
+    --accent: 45 40% 24%;
+    --accent-foreground: 45 36% 88%;
 
-    --popover: 15 23% 10%;
-    --popover-foreground: 15 23% 98%;
+    /* Floodlight: the banana gets brighter at night, never muted. */
+    --banana: 45 100% 65%;
+    --banana-foreground: 218 22% 10%;
 
-    --card: 15 23% 12%;
-    --card-foreground: 15 23% 98%;
+    --popover: 220 19% 15%;
+    --popover-foreground: 45 36% 88%;
 
-    --border: 15 13% 22%;
-    --input: 15 13% 22%;
-    --ring: 24 100% 10%;
+    --card: 220 19% 15%;
+    --card-foreground: 45 36% 88%;
+
+    --border: 219 14% 24%;
+    --input: 219 14% 24%;
+    --ring: 45 100% 65%;
+
+    --grass: 145 31% 20%;
+    --grass-stripe: 145 29% 23%;
+    --infield-grass: 144 30% 17%;
+    --dirt: 26 36% 35%;
+    --track: 25 36% 31%;
+    --chalk: 45 36% 88%;
+
+    --scoreboard: 218 22% 8%;
+    --scoreboard-foreground: 45 36% 88%;
+    --scoreboard-accent: 45 100% 65%;
   }
 }
 
 @theme inline {
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  /* Display slab for headings and hero numbers only, 20px+ — slab body text is
+     a ransom note. Loaded in layout.tsx via next/font. */
+  --font-display: var(--font-alfa-slab);
 
   --color-background: hsl(var(--background));
   --color-foreground: hsl(var(--foreground));
@@ -105,12 +135,62 @@
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
   /* hsl() wrappers, like every token above. Without them these expand to a
-     bare `104 48% 24%`, which is not a color value — any `text-baseball-green`
-     or `fill-baseball-green` utility silently produces an invalid declaration. */
-  --color-baseball-green: hsl(var(--baseball-green));
-  --color-baseball-brown: hsl(var(--baseball-brown));
-  --color-baseball-blue: hsl(var(--baseball-blue));
-  --color-baseball-red: hsl(var(--baseball-red));
+     bare `44 100% 59%`, which is not a color value — any `text-banana` or
+     `fill-grass` utility silently produces an invalid declaration. */
+  --color-banana: hsl(var(--banana));
+  --color-banana-foreground: hsl(var(--banana-foreground));
+  --color-grass: hsl(var(--grass));
+  --color-grass-stripe: hsl(var(--grass-stripe));
+  --color-infield-grass: hsl(var(--infield-grass));
+  --color-dirt: hsl(var(--dirt));
+  --color-track: hsl(var(--track));
+  --color-chalk: hsl(var(--chalk));
+  --color-scoreboard: hsl(var(--scoreboard));
+  --color-scoreboard-foreground: hsl(var(--scoreboard-foreground));
+  --color-scoreboard-accent: hsl(var(--scoreboard-accent));
+}
+
+/* Vertical pinstripes for header bands and hero surfaces only — never behind
+   body text. Foreground-derived so it survives both themes. */
+@utility bg-pinstripe {
+  background-image: repeating-linear-gradient(
+    90deg,
+    hsl(var(--foreground) / 0.05) 0,
+    hsl(var(--foreground) / 0.05) 1px,
+    transparent 1px,
+    transparent 24px
+  );
+}
+
+/* Halo for SVG <text> sitting on the field art: paints the stroke *behind*
+   the glyph fill, so navy names stay readable on grass without needing a
+   measured pill rect behind every label. */
+@utility text-halo {
+  paint-order: stroke;
+  stroke: hsl(var(--background));
+  stroke-width: 3px;
+  stroke-linejoin: round;
+}
+
+/* A lineup-announcement rise for list rows, staggered per row with an inline
+   animation-delay. Translate-only, same reasoning as Reveal.tsx: no opacity,
+   so the raw HTML is legible before (and without) any animation. CSS-only —
+   never attach to anything dnd-kit drags. */
+@utility animate-rise {
+  animation: rise 0.35s ease-out both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+@keyframes rise {
+  from {
+    transform: translateY(8px);
+  }
+  to {
+    transform: translateY(0);
+  }
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { LazyMotion, domAnimation } from "motion/react";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Alfa_Slab_One, Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -10,6 +10,14 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+/// Display slab for headings and hero numbers only (design-plan.md §4) —
+/// exposed as the `font-display` utility via `--font-display` in globals.css.
+const alfaSlab = Alfa_Slab_One({
+  variable: "--font-alfa-slab",
+  weight: "400",
   subsets: ["latin"],
 });
 
@@ -34,7 +42,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${alfaSlab.variable} h-full antialiased`}
     >
       <body className="h-full">
         <LazyMotion features={domAnimation}>{children}</LazyMotion>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export default async function Home() {
       <PageContainer>
         <div className="space-y-6 py-12 text-center">
           <div>
-            <h2 className="text-3xl font-bold text-foreground mb-2">
+            <h2 className="font-display text-3xl text-foreground mb-2">
               Welcome to Youth Baseball Team Manager
             </h2>
             <p className="text-lg text-muted-foreground">
@@ -45,7 +45,7 @@ export default async function Home() {
       <div className="space-y-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <h2 className="text-3xl font-bold text-foreground mb-2">
+            <h2 className="font-display text-3xl text-foreground mb-2">
               {user.name ? `Welcome back, ${user.name}` : "Welcome back"}
             </h2>
             <p className="text-lg text-muted-foreground">

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -89,7 +89,11 @@ export default async function SignInPage({
                 ) : null}
               </div>
 
-              <Button type="submit" className="w-full">
+              {/* This screen's one banana (design-plan.md §2). */}
+              <Button
+                type="submit"
+                className="w-full bg-banana text-banana-foreground hover:bg-banana/90"
+              >
                 Email me a sign-in link
               </Button>
             </form>

--- a/src/app/t/[teamId]/chart/BattingOrderEditor.tsx
+++ b/src/app/t/[teamId]/chart/BattingOrderEditor.tsx
@@ -20,6 +20,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
+import { JerseyDot } from "@/components/JerseyDot";
 import { Button } from "@/components/ui/button";
 import {
   buildBattingDraft,
@@ -200,15 +201,17 @@ function SlotItem({
       {...draggableProps}
       className={`flex touch-manipulation select-none items-center gap-3 rounded-md border p-3 ${
         entry !== undefined
-          ? "border-border bg-background cursor-grab"
-          : "border-dashed border-border bg-muted/30"
+          ? "border-border bg-card cursor-grab shadow-sm"
+          : "border-2 border-dashed border-border bg-muted/30"
       } ${isDragging ? "z-10 opacity-80 shadow-md cursor-grabbing" : ""} ${
-        isOver && !isDragging ? "ring-2 ring-ring" : ""
+        isOver && !isDragging ? "ring-2 ring-banana" : ""
       }`}
     >
-      <span className="w-6 shrink-0 text-right text-sm font-semibold text-muted-foreground">
-        {slotNumber}
-      </span>
+      {/* Static styling only on a dnd-kit element — no Motion, ever. */}
+      <JerseyDot
+        number={slotNumber}
+        className={entry === undefined ? "opacity-40" : ""}
+      />
       {entry !== undefined ? (
         <PlayerLabel entry={entry} />
       ) : (
@@ -234,8 +237,8 @@ function UnassignedPool({
       </h4>
       <div
         ref={setNodeRef}
-        className={`min-h-16 space-y-2 rounded-md border border-dashed p-3 ${
-          isOver ? "border-ring bg-muted/40" : "border-border"
+        className={`min-h-16 space-y-2 rounded-md border-2 border-dashed p-3 ${
+          isOver ? "border-banana bg-banana/20" : "border-border"
         }`}
       >
         {draft.unassigned.length === 0 ? (

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
@@ -74,9 +74,12 @@ describe("PositionsEditor", () => {
     );
 
     const field = screen.getByRole("region", { name: "Diamond" });
-    expect(field.querySelector("circle")).toHaveClass(
-      "fill-muted-foreground/30",
-    );
+    // Selected by its class rather than as "the circle": FieldArt paints the
+    // field with circles of its own (mow stripes, mound, fence), so the disc
+    // is no longer the only one in the SVG.
+    expect(
+      field.querySelector("circle.fill-muted-foreground\\/30"),
+    ).toBeInTheDocument();
     expect(field).toHaveTextContent("the coach pitches");
   });
 
@@ -86,7 +89,7 @@ describe("PositionsEditor", () => {
     );
 
     const field = screen.getByRole("region", { name: "Diamond" });
-    expect(field.querySelector("circle")).toBeNull();
+    expect(field.querySelector("circle.fill-muted-foreground\\/30")).toBeNull();
     expect(field).toHaveTextContent("C");
   });
 

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
@@ -21,9 +21,9 @@ import { CSS } from "@dnd-kit/utilities";
 
 import {
   DIAMOND_GEOMETRY,
-  DIAMOND_POLYGON,
   positionPercent,
 } from "@/components/diamond-geometry";
+import { FieldArt } from "@/components/FieldArt";
 import {
   NO_CATCHER_TEXT,
   NoCatcherMarker,
@@ -255,11 +255,10 @@ function Field({
           focusable="false"
           className="absolute inset-0 h-full w-full"
         >
-          <polygon
-            points={DIAMOND_POLYGON}
-            className="fill-none stroke-border"
-            strokeWidth={2}
-          />
+          {/* Same painted field as the view page — FieldArt draws the chalk
+              basepaths the bare polygon used to be. Background only: the drop
+              targets stay HTML, dnd-kit measurement is untouched. */}
+          <FieldArt />
           {noCatcher ? <NoCatcherMarker /> : null}
         </svg>
 
@@ -296,8 +295,12 @@ function PositionTarget({
       ref={setNodeRef}
       data-position={position}
       style={{ left: `${x}%`, top: `${y}%` }}
-      className={`absolute flex w-20 -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1 rounded-md border p-1 text-center ${
-        isOver ? "border-ring bg-muted/60" : "border-dashed border-border"
+      className={`absolute flex w-20 -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1 rounded-md border-2 p-1 text-center ${
+        // Chalk box on the field; the hover target is this screen's one
+        // banana (design-plan.md §7).
+        isOver
+          ? "border-banana bg-banana/25"
+          : "border-dashed border-chalk/70 bg-background/70"
       }`}
     >
       <span className="text-[11px] font-bold text-foreground">
@@ -335,8 +338,8 @@ function Zone({
       <h4 className="mb-2 text-sm font-medium text-muted-foreground">{title}</h4>
       <div
         ref={setNodeRef}
-        className={`flex min-h-16 flex-wrap gap-2 rounded-md border border-dashed p-3 ${
-          isOver ? "border-ring bg-muted/40" : "border-border"
+        className={`flex min-h-16 flex-wrap gap-2 rounded-md border-2 border-dashed p-3 ${
+          isOver ? "border-banana bg-banana/20" : "border-border"
         }`}
       >
         {draft.pool.length === 0 ? (
@@ -381,7 +384,7 @@ function Chip({
       style={{ transform: CSS.Translate.toString(transform) }}
       {...attributes}
       {...listeners}
-      className={`inline-flex cursor-grab touch-manipulation select-none items-center gap-1 rounded border border-border bg-background px-2 py-1 text-xs font-medium text-foreground ${
+      className={`inline-flex cursor-grab touch-manipulation select-none items-center gap-1 rounded-md border border-border bg-card px-2 py-1 text-xs font-medium text-foreground shadow-sm ${
         isDragging ? "z-10 cursor-grabbing opacity-80 shadow-md" : ""
       }`}
     >

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
@@ -296,20 +296,25 @@ function PositionTarget({
       data-position={position}
       style={{ left: `${x}%`, top: `${y}%` }}
       className={`absolute flex w-20 -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1 rounded-md border-2 p-1 text-center ${
-        // Chalk box on the field; the hover target is this screen's one
-        // banana (design-plan.md §7).
+        // A chalk box on the grass. The box itself stays unfilled: targets are
+        // 80px wide but neighbours like SS and 2B stand only 64px apart, so a
+        // filled box turns that overlap into two visibly stacked slabs. The
+        // label carries its own backing instead, which is also what keeps it
+        // readable over grass and dirt.
         isOver
           ? "border-banana bg-banana/25"
-          : "border-dashed border-chalk/70 bg-background/70"
+          : "border-dashed border-chalk/80"
       }`}
     >
-      <span className="text-[11px] font-bold text-foreground">
+      <span className="rounded bg-background/85 px-1 text-[11px] font-bold text-foreground">
         {POSITION_LABELS[position]}
       </span>
       {entry !== undefined ? (
         <Chip entry={entry} label={shortName(entry.playerName)} />
       ) : (
-        <span className="text-[11px] italic text-muted-foreground">Open</span>
+        <span className="rounded bg-background/85 px-1 text-[11px] italic text-muted-foreground">
+          Open
+        </span>
       )}
     </div>
   );

--- a/src/app/t/[teamId]/layout.tsx
+++ b/src/app/t/[teamId]/layout.tsx
@@ -58,7 +58,7 @@ export default async function TeamLayout({
   return (
     <PageContainer>
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4 border-b border-border pb-4">
-        <h2 className="text-2xl font-bold text-foreground">{team.name}</h2>
+        <h2 className="font-display text-2xl text-foreground">{team.name}</h2>
         <TeamSwitcher teams={switcherTeams} currentTeamId={teamId} />
       </div>
       {children}

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -52,7 +52,11 @@ export default async function TeamHomePage({
           <Link href={`/t/${teamId}/schedule`}>Schedule</Link>
         </Button>
 
-        <Button asChild variant="outline">
+        {/* The payoff page gets this screen's one banana (design-plan.md §2). */}
+        <Button
+          asChild
+          className="bg-banana text-banana-foreground hover:bg-banana/90"
+        >
           <Link href={`/t/${teamId}/view`}>Lineup</Link>
         </Button>
 

--- a/src/app/t/[teamId]/readiness/page.tsx
+++ b/src/app/t/[teamId]/readiness/page.tsx
@@ -223,12 +223,15 @@ export default async function ReadinessPage({
         </Card>
       ) : (
         <>
-          <Card>
+          {/* The scoreboard (design-plan.md §7): charcoal in both themes — a
+              scoreboard is dark; light mode just means it's daytime around
+              it. Mono type overrides the card's slab title via cn/twMerge. */}
+          <Card className="border-2 border-scoreboard-accent/40 bg-scoreboard text-scoreboard-foreground shadow-md">
             <CardHeader>
-              <CardTitle>
+              <CardTitle className="font-mono text-lg font-bold uppercase tracking-widest text-scoreboard-accent">
                 {readiness.ready ? "Ready for game day" : "Needs attention"}
               </CardTitle>
-              <CardDescription>
+              <CardDescription className="font-mono text-scoreboard-foreground/85">
                 {readiness.ready
                   ? "Nobody in the chart has said they can't make it."
                   : `${readiness.declined.length} ${
@@ -274,7 +277,7 @@ export default async function ReadinessPage({
                   {readiness.uncoveredPositions.map((position) => (
                     <li
                       key={position}
-                      className="rounded-md border border-destructive px-3 py-1 text-sm font-medium text-destructive"
+                      className="rounded-md border-2 border-destructive bg-destructive/10 px-3 py-1 font-mono text-sm font-bold text-destructive"
                     >
                       {POSITION_LABELS[position]}
                     </li>

--- a/src/app/t/[teamId]/roster/page.tsx
+++ b/src/app/t/[teamId]/roster/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { JerseyDot } from "@/components/JerseyDot";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -80,7 +81,9 @@ export default async function RosterPage({
       ) : null}
 
       {roster.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No players yet.</p>
+        <p className="rounded-md border-2 border-dashed border-border p-4 text-sm text-muted-foreground">
+          No players yet. Every dynasty starts somewhere.
+        </p>
       ) : (
         <ul className="space-y-2">
           {roster.map((entry) => (
@@ -88,9 +91,13 @@ export default async function RosterPage({
               <Card>
                 <CardContent className="flex items-center justify-between gap-4 p-4">
                   <div className="flex items-center gap-3">
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground">
-                      {entry.jerseyNumber ?? "—"}
-                    </span>
+                    {entry.jerseyNumber !== null ? (
+                      <JerseyDot number={entry.jerseyNumber} />
+                    ) : (
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium text-muted-foreground">
+                        —
+                      </span>
+                    )}
                     <span className="font-medium text-foreground">
                       {entry.player.name}
                     </span>

--- a/src/app/t/[teamId]/schedule/page.tsx
+++ b/src/app/t/[teamId]/schedule/page.tsx
@@ -241,7 +241,11 @@ function MonthView({
                           <li key={event.id}>
                             <Link
                               href={`/t/${teamId}/schedule/${event.id}`}
-                              className="block truncate rounded bg-muted px-1 py-0.5 text-xs text-foreground hover:bg-accent"
+                              className={`block truncate rounded px-1 py-0.5 text-xs text-foreground hover:bg-accent ${
+                                event.type === "GAME"
+                                  ? "bg-primary/15"
+                                  : "bg-muted"
+                              }`}
                             >
                               <span className="font-medium">
                                 {formatEventTime(event.startsAt)}
@@ -298,39 +302,106 @@ function ListView({
       </div>
 
       {events.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          {showPast ? "Nothing has happened yet." : "Nothing scheduled yet."}
+        <p className="rounded-md border-2 border-dashed border-border p-4 text-sm text-muted-foreground">
+          {showPast
+            ? "Nothing has happened yet. The season's still ahead."
+            : "Nothing scheduled yet. The season's wide open."}
         </p>
       ) : (
         <ul className="space-y-2">
-          {events.map((event) => (
-            <li key={event.id}>
-              <Card>
-                <CardContent className="p-4">
-                  <Link
-                    href={`/t/${teamId}/schedule/${event.id}`}
-                    className="flex flex-wrap items-baseline justify-between gap-2"
-                  >
-                    <span className="font-medium text-foreground">
-                      {eventTitle(event)}
-                    </span>
-                    <span className="text-sm text-muted-foreground">
-                      {formatEventDayLabel(event.startsAt)} ·{" "}
-                      {formatEventTime(event.startsAt)}
-                    </span>
-                  </Link>
-                  {event.location ? (
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      {event.location}
-                    </p>
-                  ) : null}
-                </CardContent>
-              </Card>
-            </li>
-          ))}
+          {events.map((event) =>
+            event.type === "GAME" ? (
+              <GameTicket key={event.id} teamId={teamId} event={event} />
+            ) : (
+              <PracticeCard key={event.id} teamId={teamId} event={event} />
+            ),
+          )}
         </ul>
       )}
     </div>
+  );
+}
+
+/// A game prints as a ticket stub (design-plan.md §7): clay border, slab
+/// opponent, and a perforated stub end. Games are the main event, so only
+/// they get ticket stock — practices print plain below.
+function GameTicket({
+  teamId,
+  event,
+}: {
+  teamId: string;
+  event: ScheduleEvent;
+}) {
+  return (
+    <li>
+      <Card className="overflow-hidden border-2 border-dirt/60 p-0">
+        <div className="flex items-stretch">
+          <Link
+            href={`/t/${teamId}/schedule/${event.id}`}
+            className="min-w-0 flex-1 p-4"
+          >
+            <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-destructive">
+              Game
+            </p>
+            <p className="truncate font-display text-lg text-foreground">
+              {eventTitle(event)}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {formatEventDayLabel(event.startsAt)} ·{" "}
+              {formatEventTime(event.startsAt)}
+            </p>
+            {event.location ? (
+              <p className="mt-1 truncate text-sm text-muted-foreground">
+                {event.location}
+              </p>
+            ) : null}
+          </Link>
+          {/* The stub: decorative, so it lives outside the link. */}
+          <div
+            aria-hidden="true"
+            className="flex w-16 shrink-0 items-center justify-center border-l-2 border-dashed border-dirt/60 bg-secondary"
+          >
+            <span className="rotate-90 whitespace-nowrap font-mono text-[10px] font-bold uppercase tracking-[0.3em] text-secondary-foreground">
+              Admit one
+            </span>
+          </div>
+        </div>
+      </Card>
+    </li>
+  );
+}
+
+/// Practices print on plain stock — a chalk-dashed border, no stub — so the
+/// list reads games-first at a glance.
+function PracticeCard({
+  teamId,
+  event,
+}: {
+  teamId: string;
+  event: ScheduleEvent;
+}) {
+  return (
+    <li>
+      <Card className="border-dashed shadow-none">
+        <CardContent className="p-4">
+          <Link
+            href={`/t/${teamId}/schedule/${event.id}`}
+            className="flex flex-wrap items-baseline justify-between gap-2"
+          >
+            <span className="font-medium text-foreground">
+              {eventTitle(event)}
+            </span>
+            <span className="text-sm text-muted-foreground">
+              {formatEventDayLabel(event.startsAt)} ·{" "}
+              {formatEventTime(event.startsAt)}
+            </span>
+          </Link>
+          {event.location ? (
+            <p className="mt-1 text-sm text-muted-foreground">{event.location}</p>
+          ) : null}
+        </CardContent>
+      </Card>
+    </li>
   );
 }
 

--- a/src/app/t/[teamId]/view/Diamond.tsx
+++ b/src/app/t/[teamId]/view/Diamond.tsx
@@ -83,7 +83,7 @@ function Marker({
         fill="currentColor"
         className={
           style
-            ? `text-halo text-[11px] font-medium ${style.nameClassName}`
+            ? `text-halo text-[11px] font-medium ${style.markerNameClassName}`
             : "text-halo fill-muted-foreground text-[11px] italic"
         }
       >

--- a/src/app/t/[teamId]/view/Diamond.tsx
+++ b/src/app/t/[teamId]/view/Diamond.tsx
@@ -1,9 +1,9 @@
 import {
   DIAMOND_GEOMETRY,
-  DIAMOND_POLYGON,
   POSITION_COORDS,
   outfieldZoneCoords,
 } from "@/components/diamond-geometry";
+import { FieldArt } from "@/components/FieldArt";
 import {
   NO_CATCHER_TEXT,
   NoCatcherMarker,
@@ -55,7 +55,12 @@ function Marker({
     <g transform={`translate(${x} ${y})`}>
       <circle
         r={MARKER_RADIUS}
-        className={style ? style.markerClassName : "fill-card stroke-border"}
+        className={
+          // Markers now sit on grass and dirt, so every circle carries an
+          // opaque card fill — a tinted or transparent fill reads as a hole
+          // in the field instead of a badge on it.
+          style ? style.markerClassName : "fill-card/80 stroke-muted-foreground"
+        }
         strokeWidth={style ? style.markerStrokeWidth : 1.5}
         strokeDasharray={player ? undefined : "4 3"}
       />
@@ -70,14 +75,16 @@ function Marker({
         {label}
       </text>
 
+      {/* text-halo paints a background-colored stroke behind the glyphs so
+          names and tags stay readable on the grass (design-plan.md §6). */}
       <text
         y={NAME_OFFSET}
         textAnchor="middle"
         fill="currentColor"
         className={
           style
-            ? `text-[11px] font-medium ${style.nameClassName}`
-            : "fill-muted-foreground text-[11px] italic"
+            ? `text-halo text-[11px] font-medium ${style.nameClassName}`
+            : "text-halo fill-muted-foreground text-[11px] italic"
         }
       >
         {player ? shortName(player.playerName) : "Open"}
@@ -88,7 +95,7 @@ function Marker({
           y={TAG_OFFSET}
           textAnchor="middle"
           fill="currentColor"
-          className={`text-[9px] ${style.tagClassName}`}
+          className={`text-halo text-[9px] font-semibold ${style.tagClassName}`}
         >
           {style.label}
         </text>
@@ -132,11 +139,9 @@ export function Diamond({
         focusable="false"
         className="mx-auto w-full max-w-sm"
       >
-        <polygon
-          points={DIAMOND_POLYGON}
-          className="fill-none stroke-border"
-          strokeWidth={2}
-        />
+        {/* The painted field sits under every marker — FieldArt draws the
+            chalk basepaths that the bare polygon used to be. */}
+        <FieldArt />
 
         {allPlay ? <NoCatcherMarker /> : null}
 

--- a/src/app/t/[teamId]/view/page.tsx
+++ b/src/app/t/[teamId]/view/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { JerseyDot } from "@/components/JerseyDot";
 import { RSVP_STYLE } from "@/components/rsvp-style";
+import { StitchDivider } from "@/components/StitchDivider";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -61,7 +63,8 @@ export default async function ViewPage({
           <CardHeader>
             <CardTitle>No upcoming game</CardTitle>
             <CardDescription>
-              The lineup shows up here once a game is on the schedule.
+              The lineup shows up here once a game is on the schedule. Enjoy
+              the day off.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -143,22 +146,30 @@ export default async function ViewPage({
                   </p>
                 ) : (
                   <ol className="space-y-2">
-                    {chart.lineup.map((player) => {
+                    {chart.lineup.map((player, index) => {
                       const style = RSVP_STYLE[player.rsvpState];
                       return (
                         <li
                           key={player.playerId}
-                          className="flex items-center justify-between gap-4 rounded-md border border-border p-3"
+                          className="animate-rise flex items-center justify-between gap-4 rounded-md border border-border bg-background/60 p-3"
+                          // Rows rise in batting order, like a lineup being
+                          // announced. Translate-only and reduced-motion-gated
+                          // (see animate-rise in globals.css).
+                          style={{ animationDelay: `${index * 40}ms` }}
                         >
-                          <div className="flex items-center gap-3">
-                            <span className="text-sm font-semibold text-muted-foreground">
-                              {player.battingOrder}
-                            </span>
-                            <span className={`text-sm font-medium ${style.nameClassName}`}>
+                          <div className="flex min-w-0 items-center gap-3">
+                            {/* The slot number wears a jersey (design-plan.md
+                                §7); the shirt number rides along in mono. */}
+                            <JerseyDot number={player.battingOrder ?? ""} />
+                            <span
+                              className={`truncate text-sm font-medium ${style.nameClassName}`}
+                            >
                               {player.playerName}
-                              {player.jerseyNumber !== null
-                                ? ` #${player.jerseyNumber}`
-                                : ""}
+                              {player.jerseyNumber !== null ? (
+                                <span className="ml-1 font-mono text-xs text-muted-foreground">
+                                  #{player.jerseyNumber}
+                                </span>
+                              ) : null}
                             </span>
                           </div>
                           <span className={`text-xs ${style.tagClassName}`}>
@@ -173,7 +184,9 @@ export default async function ViewPage({
             </Card>
           </div>
 
-          <p className="mt-6 text-xs text-muted-foreground">
+          <StitchDivider className="mt-6" />
+
+          <p className="mt-3 text-xs text-muted-foreground">
             <span className={RSVP_STYLE.attending.tagClassName}>
               {RSVP_STYLE.attending.label}
             </span>{" "}

--- a/src/components/FieldArt.tsx
+++ b/src/components/FieldArt.tsx
@@ -21,46 +21,60 @@ import { DIAMOND_POLYGON, FIELD_ART } from "@/components/diamond-geometry";
  * sr-only list, both owned by the callers — nothing here may grow a label.
  */
 export function FieldArt() {
-  // Both diamonds can never be on one page today, but the clip id must still
+  // Both diamonds can never be on one page today, but the clip ids must still
   // be unique per render tree — useId works in server and client components.
-  const clipId = useId();
+  // Two clips, nested, because the park is the *intersection* of fair
+  // territory and the fence arc: the wedge alone runs grass out to the corners
+  // of the box, which reads as a field with no outfield wall.
+  const id = useId();
+  const wedgeId = `${id}-wedge`;
+  const parkId = `${id}-park`;
 
   return (
     <g aria-hidden="true">
       <defs>
-        <clipPath id={clipId}>
+        <clipPath id={wedgeId}>
           <path d={FIELD_ART.fairTerritory} />
+        </clipPath>
+        <clipPath id={parkId}>
+          <circle
+            cx={FIELD_ART.homeCircle.x}
+            cy={FIELD_ART.homeCircle.y}
+            r={FIELD_ART.parkRadius}
+          />
         </clipPath>
       </defs>
 
-      <g clipPath={`url(#${clipId})`}>
-        <path d={FIELD_ART.fairTerritory} className="fill-grass" />
+      <g clipPath={`url(#${wedgeId})`}>
+        <g clipPath={`url(#${parkId})`}>
+          <path d={FIELD_ART.fairTerritory} className="fill-grass" />
 
-        {FIELD_ART.stripes.map((radius) => (
+          {FIELD_ART.stripes.map((radius) => (
+            <circle
+              key={radius}
+              cx={FIELD_ART.homeCircle.x}
+              cy={FIELD_ART.homeCircle.y}
+              r={radius}
+              className="fill-none stroke-grass-stripe"
+              strokeWidth={FIELD_ART.stripeWidth}
+            />
+          ))}
+
           <circle
-            key={radius}
             cx={FIELD_ART.homeCircle.x}
             cy={FIELD_ART.homeCircle.y}
-            r={radius}
-            className="fill-none stroke-grass-stripe"
-            strokeWidth={FIELD_ART.stripeWidth}
+            r={FIELD_ART.trackRadius}
+            className="fill-none stroke-track"
+            strokeWidth={FIELD_ART.trackWidth}
           />
-        ))}
-
-        <circle
-          cx={FIELD_ART.homeCircle.x}
-          cy={FIELD_ART.homeCircle.y}
-          r={FIELD_ART.trackRadius}
-          className="fill-none stroke-track"
-          strokeWidth={FIELD_ART.trackWidth}
-        />
-        <circle
-          cx={FIELD_ART.homeCircle.x}
-          cy={FIELD_ART.homeCircle.y}
-          r={FIELD_ART.fenceRadius}
-          className="fill-none stroke-banana"
-          strokeWidth={FIELD_ART.fenceWidth}
-        />
+          <circle
+            cx={FIELD_ART.homeCircle.x}
+            cy={FIELD_ART.homeCircle.y}
+            r={FIELD_ART.fenceRadius}
+            className="fill-none stroke-banana"
+            strokeWidth={FIELD_ART.fenceWidth}
+          />
+        </g>
       </g>
 
       <path d={FIELD_ART.infieldDirt} className="fill-dirt" />

--- a/src/components/FieldArt.tsx
+++ b/src/components/FieldArt.tsx
@@ -1,0 +1,122 @@
+import { useId } from "react";
+
+import { DIAMOND_POLYGON, FIELD_ART } from "@/components/diamond-geometry";
+
+/**
+ * The painted ballfield (design-plan.md §6): grass wedge with mowed stripes,
+ * warning track, banana-yellow fence, dirt infield with a grass diamond inside
+ * the basepaths, chalk lines, bases, home plate, and the mound.
+ *
+ * Rendered by BOTH diamonds — the view page's and the drag editor's — inside
+ * their existing 400×520 SVG, *before* the markers/targets, so it is pure
+ * background. It draws no positions and no players: every coordinate that
+ * means something lives in POSITION_COORDS, and this component only paints
+ * underneath them.
+ *
+ * All colors go through the field tokens in globals.css (`--grass`, `--dirt`,
+ * `--chalk`, …), so dark mode renders the same field as a night game with no
+ * extra code here.
+ *
+ * Decoration only: parents get the real content from the markers and the
+ * sr-only list, both owned by the callers — nothing here may grow a label.
+ */
+export function FieldArt() {
+  // Both diamonds can never be on one page today, but the clip id must still
+  // be unique per render tree — useId works in server and client components.
+  const clipId = useId();
+
+  return (
+    <g aria-hidden="true">
+      <defs>
+        <clipPath id={clipId}>
+          <path d={FIELD_ART.fairTerritory} />
+        </clipPath>
+      </defs>
+
+      <g clipPath={`url(#${clipId})`}>
+        <path d={FIELD_ART.fairTerritory} className="fill-grass" />
+
+        {FIELD_ART.stripes.map((radius) => (
+          <circle
+            key={radius}
+            cx={FIELD_ART.homeCircle.x}
+            cy={FIELD_ART.homeCircle.y}
+            r={radius}
+            className="fill-none stroke-grass-stripe"
+            strokeWidth={FIELD_ART.stripeWidth}
+          />
+        ))}
+
+        <circle
+          cx={FIELD_ART.homeCircle.x}
+          cy={FIELD_ART.homeCircle.y}
+          r={FIELD_ART.trackRadius}
+          className="fill-none stroke-track"
+          strokeWidth={FIELD_ART.trackWidth}
+        />
+        <circle
+          cx={FIELD_ART.homeCircle.x}
+          cy={FIELD_ART.homeCircle.y}
+          r={FIELD_ART.fenceRadius}
+          className="fill-none stroke-banana"
+          strokeWidth={FIELD_ART.fenceWidth}
+        />
+      </g>
+
+      <path d={FIELD_ART.infieldDirt} className="fill-dirt" />
+      <circle
+        cx={FIELD_ART.homeCircle.x}
+        cy={FIELD_ART.homeCircle.y}
+        r={FIELD_ART.homeCircle.r}
+        className="fill-dirt"
+      />
+      <path d={FIELD_ART.infieldGrass} className="fill-infield-grass" />
+      <circle
+        cx={FIELD_ART.mound.x}
+        cy={FIELD_ART.mound.y}
+        r={FIELD_ART.mound.r}
+        className="fill-dirt"
+      />
+
+      <polygon
+        points={DIAMOND_POLYGON}
+        className="fill-none stroke-chalk"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        opacity={0.9}
+      />
+
+      {FIELD_ART.foulLines.map((line) => (
+        <path
+          key={line}
+          d={line}
+          className="fill-none stroke-chalk"
+          strokeWidth={3}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {FIELD_ART.bases.map(({ x, y }) => (
+        <rect
+          key={`${x},${y}`}
+          x={-FIELD_ART.baseSize / 2}
+          y={-FIELD_ART.baseSize / 2}
+          width={FIELD_ART.baseSize}
+          height={FIELD_ART.baseSize}
+          transform={`translate(${x} ${y}) rotate(45)`}
+          className="fill-chalk stroke-dirt"
+          strokeWidth={1}
+        />
+      ))}
+      <path d={FIELD_ART.homePlate} className="fill-chalk stroke-dirt" strokeWidth={1} />
+      <rect
+        x={FIELD_ART.pitchingRubber.x}
+        y={FIELD_ART.pitchingRubber.y}
+        width={FIELD_ART.pitchingRubber.width}
+        height={FIELD_ART.pitchingRubber.height}
+        rx={1}
+        className="fill-chalk"
+      />
+    </g>
+  );
+}

--- a/src/components/JerseyDot.tsx
+++ b/src/components/JerseyDot.tsx
@@ -1,0 +1,20 @@
+/// A jersey-style number chip: navy disc, cream numeral, tabular mono
+/// (design-plan.md §5). Used for batting-order slot numbers and roster jersey
+/// numbers so "a number on this team" always looks like the back of a shirt.
+///
+/// The number is content, not decoration — it stays real text.
+export function JerseyDot({
+  number,
+  className = "",
+}: {
+  number: number | string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-foreground font-mono text-sm font-bold text-background ${className}`}
+    >
+      {number}
+    </span>
+  );
+}

--- a/src/components/StitchDivider.tsx
+++ b/src/components/StitchDivider.tsx
@@ -1,0 +1,34 @@
+/// A baseball-seam section divider: two shallow dashed arcs in stitch red,
+/// replacing plain border-t rules between sections (design-plan.md §5).
+///
+/// Purely decorative — aria-hidden, no announced content — so it can sit
+/// between sections without adding noise for screen readers. Height is fixed
+/// and small; the arcs bow the way a seam crosses a ball.
+export function StitchDivider({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 400 16"
+      aria-hidden="true"
+      focusable="false"
+      preserveAspectRatio="none"
+      className={`h-3 w-full ${className}`}
+    >
+      <path
+        d="M0,4 Q200,14 400,4"
+        fill="none"
+        className="stroke-destructive"
+        strokeWidth={1.5}
+        strokeDasharray="6 5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M0,12 Q200,2 400,12"
+        fill="none"
+        className="stroke-destructive/60"
+        strokeWidth={1.5}
+        strokeDasharray="6 5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/TeamCard.tsx
+++ b/src/components/TeamCard.tsx
@@ -10,6 +10,30 @@ interface TeamCardProps {
   archivedAt?: Date | null;
 }
 
+/// A little felt pennant beside the team name (design-plan.md §7). Decorative
+/// only — the name itself is the content.
+function PennantGlyph() {
+  return (
+    <svg
+      viewBox="0 0 26 16"
+      aria-hidden="true"
+      focusable="false"
+      className="h-4 w-6 shrink-0"
+    >
+      <line
+        x1="2"
+        y1="1"
+        x2="2"
+        y2="15"
+        className="stroke-dirt"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+      <path d="M4,2 L24,6 L4,12 Z" className="fill-primary" />
+    </svg>
+  );
+}
+
 export function TeamCard({
   id,
   name,
@@ -20,13 +44,22 @@ export function TeamCard({
 }: TeamCardProps) {
   const content = (
     <Card
-      className={isClickable ? "cursor-pointer hover:shadow-md transition-shadow" : ""}
+      className={`${
+        isClickable ? "cursor-pointer transition-shadow hover:shadow-md" : ""
+      } ${
+        // A retired jersey, not a deleted one: archived teams go quiet but
+        // keep their pennant.
+        archivedAt ? "opacity-75 saturate-50" : ""
+      }`}
     >
       <CardHeader>
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-lg">{name}</CardTitle>
+          <div className="flex min-w-0 items-center gap-2">
+            <PennantGlyph />
+            <CardTitle className="truncate text-lg">{name}</CardTitle>
+          </div>
           {archivedAt && (
-            <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            <span className="rounded-full bg-secondary px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-secondary-foreground">
               Archived
             </span>
           )}

--- a/src/components/diamond-geometry.test.ts
+++ b/src/components/diamond-geometry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   DIAMOND_GEOMETRY,
+  FIELD_ART,
   POSITION_COORDS,
   outfieldZoneCoords,
   positionPercent,
@@ -17,6 +18,42 @@ describe("DIAMOND_GEOMETRY", () => {
     // without error and simply cannot be seen.
     expect(POSITION_COORDS.CATCHER.y + DIAMOND_GEOMETRY.tagOffset).toBeLessThan(
       DIAMOND_GEOMETRY.height,
+    );
+  });
+});
+
+describe("FIELD_ART", () => {
+  it("seats the catcher's spot on the home dirt circle", () => {
+    // The catcher stands below home plate, so the dirt has to reach past that
+    // marker's bottom edge. Undersize it and the catcher — or, on an allPlay
+    // board, the disc that stands in for one — hangs off the dirt onto bare
+    // page, where a deliberate marker reads as a rendering artefact. Nothing
+    // errors; it just looks broken.
+    const catcherBottom =
+      POSITION_COORDS.CATCHER.y +
+      DIAMOND_GEOMETRY.markerRadius -
+      FIELD_ART.homeCircle.y;
+
+    expect(FIELD_ART.homeCircle.r).toBeGreaterThanOrEqual(catcherBottom);
+  });
+
+  it("keeps the deepest outfielder on grass, off the warning track", () => {
+    // The track is a band centred on trackRadius, so its inner edge is what
+    // the centre fielder must clear.
+    const trackInnerEdge =
+      FIELD_ART.homeCircle.y -
+      (FIELD_ART.trackRadius - FIELD_ART.trackWidth / 2);
+    const centreFielderTop =
+      POSITION_COORDS.CENTER_FIELD.y - DIAMOND_GEOMETRY.markerRadius;
+
+    expect(centreFielderTop).toBeGreaterThan(trackInnerEdge);
+  });
+
+  it("clips the park past the fence rather than through it", () => {
+    // The green is clipped to parkRadius so grass stops at the wall. Clip
+    // inside the fence stroke and the fence is shaved in half.
+    expect(FIELD_ART.parkRadius).toBeGreaterThanOrEqual(
+      FIELD_ART.fenceRadius + FIELD_ART.fenceWidth / 2,
     );
   });
 });

--- a/src/components/diamond-geometry.ts
+++ b/src/components/diamond-geometry.ts
@@ -48,7 +48,7 @@ export const DIAMOND_POLYGON = "200,420 290,320 200,230 110,320";
 /// Everything is derived from the geometry above rather than re-eyeballed:
 /// home plate is the polygon's bottom vertex (200,420), the bases are its
 /// other three, the mound sits between the pitcher marker and home, and the
-/// home dirt circle's radius (42) is what keeps the catcher marker at y=452
+/// home dirt circle's radius is what keeps the catcher marker at y=452
 /// standing on dirt rather than on bare page.
 export const FIELD_ART = {
   /// Fair territory: home plate out along both foul lines to the top corners.
@@ -59,16 +59,28 @@ export const FIELD_ART = {
   stripeWidth: 40,
   /// Warning track band and fence arc, also centred on home plate. The fence
   /// is drawn in banana yellow — that screen's one banana.
-  trackRadius: 377,
+  ///
+  /// Pushed out far enough that the deepest outfielder (CENTER_FIELD at y=75,
+  /// so a marker top edge of y=55) stands on grass rather than straddling the
+  /// track. Check that gap before moving either radius.
+  trackRadius: 392,
   trackWidth: 36,
-  fenceRadius: 395,
+  fenceRadius: 408,
   fenceWidth: 5,
+  /// Everything green is clipped to this too, so the park ends at the fence
+  /// instead of grass running out to the corners of the box. Sits just past
+  /// the fence stroke (fenceRadius + fenceWidth/2) so the fence itself is not
+  /// clipped in half.
+  parkRadius: 411,
   /// Infield dirt: a diamond whose back edge bows behind second base.
   infieldDirt: "M200,444 L316,318 Q200,90 84,318 Z",
   /// The grass diamond inside the basepaths.
   infieldGrass: "M200,398 L272,322 L200,246 L128,322 Z",
-  /// Home-plate dirt circle and pitcher's mound.
-  homeCircle: { x: 200, y: 420, r: 42 },
+  /// Home-plate dirt circle and pitcher's mound. The radius is not cosmetic:
+  /// the catcher's spot sits at y=452 with a 20-radius marker, so anything
+  /// under 52 leaves the catcher — and, on an allPlay board, the disc that
+  /// stands in for the catcher — hanging off the dirt onto bare page.
+  homeCircle: { x: 200, y: 420, r: 54 },
   mound: { x: 200, y: 330, r: 18 },
   pitchingRubber: { x: 193, y: 327, width: 14, height: 4 },
   /// Chalk foul lines, home plate to where each leaves the wedge.

--- a/src/components/diamond-geometry.ts
+++ b/src/components/diamond-geometry.ts
@@ -39,6 +39,50 @@ export const POSITION_COORDS: Record<Position, { x: number; y: number }> = {
 /// The infield polygon, in the same coordinate space.
 export const DIAMOND_POLYGON = "200,420 290,320 200,230 110,320";
 
+/// The painted field behind the markers (design-plan.md §6), in the same
+/// coordinate space as POSITION_COORDS and consumed only by `FieldArt` — which
+/// both the view page's diamond and the drag editor render, under the same
+/// sharing rule as the coordinates themselves: a field one page paints and the
+/// other doesn't is its own kind of bug.
+///
+/// Everything is derived from the geometry above rather than re-eyeballed:
+/// home plate is the polygon's bottom vertex (200,420), the bases are its
+/// other three, the mound sits between the pitcher marker and home, and the
+/// home dirt circle's radius (42) is what keeps the catcher marker at y=452
+/// standing on dirt rather than on bare page.
+export const FIELD_ART = {
+  /// Fair territory: home plate out along both foul lines to the top corners.
+  /// Grass, stripes, track, and fence are all clipped to this wedge.
+  fairTerritory: "M200,420 L400,198 L400,0 L0,0 L0,198 Z",
+  /// Mowed-stripe rings, centred on home plate: radius + strokeWidth pairs.
+  stripes: [90, 170, 250, 330],
+  stripeWidth: 40,
+  /// Warning track band and fence arc, also centred on home plate. The fence
+  /// is drawn in banana yellow — that screen's one banana.
+  trackRadius: 377,
+  trackWidth: 36,
+  fenceRadius: 395,
+  fenceWidth: 5,
+  /// Infield dirt: a diamond whose back edge bows behind second base.
+  infieldDirt: "M200,444 L316,318 Q200,90 84,318 Z",
+  /// The grass diamond inside the basepaths.
+  infieldGrass: "M200,398 L272,322 L200,246 L128,322 Z",
+  /// Home-plate dirt circle and pitcher's mound.
+  homeCircle: { x: 200, y: 420, r: 42 },
+  mound: { x: 200, y: 330, r: 18 },
+  pitchingRubber: { x: 193, y: 327, width: 14, height: 4 },
+  /// Chalk foul lines, home plate to where each leaves the wedge.
+  foulLines: ["M200,420 L14,213", "M200,420 L386,213"],
+  /// Bases as rotated squares on the polygon's corners, plus the plate.
+  baseSize: 14,
+  bases: [
+    { x: 290, y: 320 },
+    { x: 200, y: 230 },
+    { x: 110, y: 320 },
+  ],
+  homePlate: "M193,413 L207,413 L207,420 L200,427 L193,420 Z",
+} as const;
+
 /// The same coordinates as percentages, for the editor — its drop targets are
 /// absolutely positioned HTML rather than SVG nodes, because dnd-kit measures
 /// with `getBoundingClientRect` and drags HTML chips by writing `transform`.

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -67,11 +67,13 @@ export function PageContainer({
 }>) {
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">
-      <header className="border-b border-border bg-card">
+      {/* Pinstriped band, per design-plan.md §5 — stripes live on header
+          surfaces only, never behind body text. */}
+      <header className="border-b-2 border-primary/30 bg-card bg-pinstripe">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex items-center">
             <BaseballCornIcon />
-            <h1 className="text-2xl font-bold text-primary">
+            <h1 className="font-display text-xl text-primary sm:text-2xl">
               Youth Baseball Team Manager
             </h1>
           </div>

--- a/src/components/rsvp-style.test.ts
+++ b/src/components/rsvp-style.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import { RSVP_STYLE } from "./rsvp-style";
+
+/// The three states must stay visually distinct, and the on-field variants
+/// must stay legible over grass. Both are things the page-level tests cannot
+/// see: they assert labels and class strings, not whether anyone could read
+/// the result outdoors.
+describe("RSVP_STYLE", () => {
+  it("gives every state a text label, never colour alone", () => {
+    for (const style of Object.values(RSVP_STYLE)) {
+      expect(style.label.trim()).not.toBe("");
+    }
+  });
+
+  it("styles no-response distinctly from declined", () => {
+    // The two mean different things — hasn't answered vs. said no — and drifted
+    // together once before.
+    expect(RSVP_STYLE["no-response"].tagClassName).not.toBe(
+      RSVP_STYLE.declined.tagClassName,
+    );
+    expect(RSVP_STYLE["no-response"].markerClassName).not.toBe(
+      RSVP_STYLE.declined.markerClassName,
+    );
+  });
+
+  it("dims the declined name on the field by colour, not opacity", () => {
+    // `nameClassName` fades declined with `opacity-60`, which works on a card
+    // and disappears over grass — the one surface this app is read on in
+    // sunlight. The field variant has to dim by colour instead, so reusing the
+    // card value here is the regression to catch.
+    expect(RSVP_STYLE.declined.markerNameClassName).not.toContain("opacity-");
+    expect(RSVP_STYLE.declined.markerNameClassName).not.toBe(
+      RSVP_STYLE.declined.nameClassName,
+    );
+  });
+
+  it("still ranks the declined name below the other two on the field", () => {
+    expect(RSVP_STYLE.declined.markerNameClassName).not.toBe(
+      RSVP_STYLE.attending.markerNameClassName,
+    );
+    expect(RSVP_STYLE.attending.markerNameClassName).toBe(
+      RSVP_STYLE["no-response"].markerNameClassName,
+    );
+  });
+});

--- a/src/components/rsvp-style.ts
+++ b/src/components/rsvp-style.ts
@@ -21,6 +21,13 @@ export const RSVP_STYLE: Record<
     /// Applied to the view page diamond's position marker circle.
     markerClassName: string;
     markerStrokeWidth: number;
+    /// The player's name *on the field*, where it sits over grass and dirt
+    /// rather than a card. Same meaning as `nameClassName` and it must keep
+    /// the same ranking — declined dimmer than the other two — but it cannot
+    /// borrow that value: `opacity-60` on a light grey is legible on white and
+    /// disappears on green, which is the one place this app is read in
+    /// sunlight. Dim it by colour here, not by opacity.
+    markerNameClassName: string;
   }
 > = {
   attending: {
@@ -32,6 +39,7 @@ export const RSVP_STYLE: Record<
     // carried by ring color and weight, never fill alone.
     markerClassName: "fill-card stroke-primary",
     markerStrokeWidth: 3,
+    markerNameClassName: "text-foreground",
   },
   declined: {
     label: "Not going",
@@ -39,6 +47,7 @@ export const RSVP_STYLE: Record<
     nameClassName: "text-muted-foreground opacity-60",
     markerClassName: "fill-muted stroke-muted-foreground",
     markerStrokeWidth: 1.5,
+    markerNameClassName: "text-muted-foreground",
   },
   "no-response": {
     label: "No response",
@@ -46,5 +55,6 @@ export const RSVP_STYLE: Record<
     nameClassName: "text-foreground",
     markerClassName: "fill-card stroke-muted-foreground",
     markerStrokeWidth: 2,
+    markerNameClassName: "text-foreground",
   },
 };

--- a/src/components/rsvp-style.ts
+++ b/src/components/rsvp-style.ts
@@ -27,14 +27,17 @@ export const RSVP_STYLE: Record<
     label: "Going",
     tagClassName: "text-primary",
     nameClassName: "text-foreground",
-    markerClassName: "fill-primary/10 stroke-primary",
-    markerStrokeWidth: 2.5,
+    // Marker fills are opaque now that the circles sit on FieldArt's grass
+    // and dirt — a translucent fill reads as a hole in the field. State is
+    // carried by ring color and weight, never fill alone.
+    markerClassName: "fill-card stroke-primary",
+    markerStrokeWidth: 3,
   },
   declined: {
     label: "Not going",
     tagClassName: "text-destructive",
     nameClassName: "text-muted-foreground opacity-60",
-    markerClassName: "fill-muted/40 stroke-muted-foreground",
+    markerClassName: "fill-muted stroke-muted-foreground",
     markerStrokeWidth: 1.5,
   },
   "no-response": {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -36,7 +36,9 @@ const CardTitle = React.forwardRef<
   <h2
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      // Alfa Slab One ships one weight — font-normal, or the browser
+      // synthesizes a fake bold on top of an already-slab face.
+      "font-display text-2xl font-normal leading-tight tracking-tight",
       className
     )}
     {...props}

--- a/src/design-plan-drift.test.ts
+++ b/src/design-plan-drift.test.ts
@@ -1,0 +1,168 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { DIAMOND_GEOMETRY, FIELD_ART } from "@/components/diamond-geometry";
+
+/**
+ * Keeps `docs/design/design-plan.md` honest about the code it describes.
+ *
+ * That document ships in the same repository as its implementation, which
+ * makes it a second source of truth — and a second source of truth rots
+ * silently. It rotted three times before this test existed: the colour table
+ * named one `--accent` where the code had split `--accent` and `--banana`, the
+ * marker section specified a `<rect>` pill that was never built, and the field
+ * geometry still quoted the radii from before the visual-review fixes moved
+ * them. Every one of those was caught by a human reading the diff, which is
+ * exactly the review attention this test is meant to buy back.
+ *
+ * So the plan states its facts in a shape a machine can check, and this asserts
+ * them. It is deliberately narrow: it verifies **claims the document makes**,
+ * never that the document mentions everything. Prose, rationale, and the
+ * screen-by-screen pass stay free-form — the point is to catch stale numbers
+ * and stale token names, not to turn a design document into a schema.
+ *
+ * Not co-located, unusually for this repo, because it guards a file in `docs/`
+ * against two sources in `src/` and belongs beside neither.
+ *
+ * **When this fails, fix whichever side is wrong.** Usually that is the
+ * document: the code moved and the prose did not. Never delete the claim to
+ * silence the test — restating it correctly is the entire job.
+ */
+
+// Vitest runs with the project root as its working directory (vitest.config.ts
+// sets no other `root`), and `import.meta.url` is not a file URL under its
+// transform, so this is the resolution that actually works here.
+const repoRoot = process.cwd();
+const plan = readFileSync(join(repoRoot, "docs/design/design-plan.md"), "utf8");
+const globalsCss = readFileSync(join(repoRoot, "src/app/globals.css"), "utf8");
+
+/// The `:root` block and the `prefers-color-scheme: dark` override, as
+/// token -> value maps.
+function cssTokens(): { light: Map<string, string>; dark: Map<string, string> } {
+  // `[\s\S]` rather than `.` with the dotAll flag: tsconfig targets below
+  // es2018, where `/s/` is a compile error.
+  const lightBlock = /:root \{([\s\S]*?)\n\}/.exec(globalsCss);
+  const darkBlock =
+    /@media \(prefers-color-scheme: dark\) \{\s*:root \{([\s\S]*?)\n {2}\}/.exec(
+      globalsCss,
+    );
+
+  if (!lightBlock || !darkBlock) {
+    throw new Error(
+      "Could not find the :root and dark :root blocks in globals.css — this " +
+        "parser, not the stylesheet, is probably what needs updating.",
+    );
+  }
+
+  const parse = (block: string) =>
+    new Map(
+      [...block.matchAll(/--([a-z-]+):\s*([^;]+);/g)].map(([, name, value]) => [
+        name,
+        value.trim(),
+      ]),
+    );
+
+  return { light: parse(lightBlock[1]), dark: parse(darkBlock[1]) };
+}
+
+/// Rows of the plan's colour tables: token name, plus the first HSL triple in
+/// each of the light and dark cells. Rows whose cells carry no triple are
+/// skipped rather than failed — a table may legitimately describe a token in
+/// words — so the check only ever fires on a stated value that is wrong.
+function documentedTokens(): {
+  name: string;
+  light: string | null;
+  dark: string | null;
+}[] {
+  const hsl = (cell: string) => /`(\d+ \d+% \d+%)`/.exec(cell)?.[1] ?? null;
+
+  return [...plan.matchAll(/^\|\s*`--([a-z-]+)`\s*\|([^|]*)\|([^|]*)\|/gm)].map(
+    ([, name, lightCell, darkCell]) => ({
+      name,
+      light: hsl(lightCell),
+      dark: hsl(darkCell),
+    }),
+  );
+}
+
+describe("design-plan.md colour tables", () => {
+  const { light, dark } = cssTokens();
+  const documented = documentedTokens();
+
+  it("documents tokens at all, so a broken parser cannot pass silently", () => {
+    // Without this, a regex that matches nothing turns every check below into
+    // a vacuous pass over an empty list — the classic way a drift guard stops
+    // guarding without anyone noticing.
+    expect(documented.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it.each(documented)("--$name exists in globals.css", ({ name }) => {
+    expect(light.has(name)).toBe(true);
+  });
+
+  it.each(documented.filter((token) => token.light !== null))(
+    "--$name has the light value the plan states",
+    ({ name, light: stated }) => {
+      expect(light.get(name)).toBe(stated);
+    },
+  );
+
+  it.each(documented.filter((token) => token.dark !== null))(
+    "--$name has the dark value the plan states",
+    ({ name, dark: stated }) => {
+      expect(dark.get(name)).toBe(stated);
+    },
+  );
+});
+
+describe("design-plan.md geometry claims", () => {
+  /// Claims written as `FIELD_ART.trackRadius = 392` or
+  /// `DIAMOND_GEOMETRY.height = 520`, including one level of nesting
+  /// (`FIELD_ART.mound.r = 18`).
+  const claims = [
+    ...plan.matchAll(
+      /`(FIELD_ART|DIAMOND_GEOMETRY)\.([a-zA-Z]+)(?:\.([a-zA-Z]+))? = (-?\d+(?:\.\d+)?)`/g,
+    ),
+  ].map(([, object, key, nested, value]) => ({
+    label: `${object}.${key}${nested ? `.${nested}` : ""}`,
+    object,
+    key,
+    nested,
+    value: Number(value),
+  }));
+
+  it("finds the claims it is meant to check", () => {
+    expect(claims.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it.each(claims)("$label is $value in the code", ({ object, key, nested, value }) => {
+    const source: Record<string, unknown> =
+      object === "FIELD_ART" ? FIELD_ART : DIAMOND_GEOMETRY;
+    const target = nested
+      ? (source[key] as Record<string, unknown>)?.[nested]
+      : source[key];
+
+    expect(target).toBe(value);
+  });
+});
+
+describe("design-plan.md utility claims", () => {
+  /// Utilities the plan names as part of the texture vocabulary. Each is
+  /// declared with Tailwind 4's `@utility`, so its absence means the plan is
+  /// describing something that was renamed or never built — the shape the
+  /// `<rect>`-pill drift took.
+  const utilities = ["bg-pinstripe", "text-halo", "animate-rise"];
+
+  it.each(utilities)("%s is declared in globals.css and named in the plan", (name) => {
+    expect(globalsCss).toContain(`@utility ${name}`);
+    expect(plan).toContain(name);
+  });
+
+  it("does not still promise the pill that `text-halo` replaced", () => {
+    // The specific stale claim a reviewer caught by hand. Cheap to pin, and it
+    // fails loudly if the paragraph is ever reverted wholesale.
+    expect(plan).not.toMatch(/pill behind the\s+name\/RSVP tag/);
+  });
+});


### PR DESCRIPTION
Closes #37.

## Summary

Ships the "Pastoral Banana Ball" visual overhaul: the design plan (`docs/design/design-plan.md` with SVG mockups) **plus the full four-phase implementation**. The app goes from black-and-white to warm pastoral baseball — cream paper, field green, midnight navy — with one rationed Banana Yellow accent per screen, and the diamond diagram now looks like an actual ballfield.

## Key Decisions

- **The diamond keeps its geometry contract.** The new `FieldArt` component (grass with mowed stripes, warning track, banana fence, dirt infield, chalk lines, bases, mound) paints *behind* the existing markers inside the same 400×520 viewBox; `POSITION_COORDS`, the catcher-clipping guard, and dnd-kit's HTML drop targets are untouched. Its path constants live in `diamond-geometry.ts` under the same viewer/editor sharing rule as the coordinates.
- **Legibility on grass via `paint-order: stroke`.** A `text-halo` utility paints a background-coloured stroke behind SVG text instead of measured pill rects — a pill has to be sized against the text it backs, and SVG offers no layout pass to measure with.
- **"One banana per screen"** is enforced structurally: `--accent` stays a soft hover tint, and the loud `--banana` token is used exactly once per screen (sign-in CTA, team-home Lineup button, editor drop-target hover, the fence).
- **Frozen semantics stay frozen.** `RSVP_STYLE`'s three states, `POSITION_LABELS`, the dnd-kit/Motion separation, `calendar.ts`-only dates, and the no-catcher disc all survive unchanged. The `--baseball-*` tokens were retired — grep confirms zero usages, including in the pages #35 added.
- **The plan is guarded against drifting from the code.** `src/design-plan-drift.test.ts` checks the document's colour values, `FIELD_ART.key = n` geometry claims, and named utilities against the source on every `pnpm check`.

## What's in Scope

- **Phase 1 — Repaint**: light ("day game") and dark ("night game") tokens; Alfa Slab One via `next/font` as `font-display`; `bg-pinstripe`, `text-halo`, `animate-rise` utilities; `StitchDivider` and `JerseyDot`.
- **Phase 2 — The field**: `FieldArt` rendered by both `view/Diamond.tsx` and the positions editor; haloed marker text; chalk-box drop targets with banana hover.
- **Phase 3 — Paper goods**: games as perforated ticket stubs (practices plain); pennant team cards with a retired-jersey archived state; batting order as dugout rows with jersey dots; readiness as a charcoal scoreboard.
- **Phase 4 — Showtime**: staggered lineup rise, empty-state voice pass.
- The design plan, three SVG mockups, and the drift guard.

### Out of Scope

- Save-success confetti and the RSVP ⚾ micro-pop — need a dependency / new client components.
- The sign-in field illustration.
- The Alfa Slab vs. Graduate on-device font decision (one line in `layout.tsx`).

## Bugs Found and Fixed During Self-Review

Rendering the diamond with real data surfaced four defects the unit tests could not see, all from putting markers on painted grass for the first time. Each now has a regression test **verified to fail against the pre-fix value**:

- Declined players' names were illegible on grass — `nameClassName` fades them with `opacity-60`, fine on a white card, invisible on green. Added `RSVP_STYLE.markerNameClassName`, which dims by colour.
- The home dirt circle was too small for the spot it holds, so the catcher marker and the `NoCatcherMarker` disc hung off the dirt and read as artefacts.
- Grass ran past the outfield fence to the corners, and the warning track reached far enough in that the centre fielder stood on it.
- Filled drop targets turned the pre-existing 80px-box/64px-spacing overlap at SS and 2B into visibly stacked slabs.

Two `PositionsEditor` tests also located the no-catcher disc via `querySelector("circle")`, which broke once `FieldArt` added circles to the same SVG — now selected by class, preserving both directions of the assertion.

## Known Gaps / Follow-ups

- Criteria 5 and 6 of #37 were verified from screenshots of the real components on temporary probe routes, since the team-scoped pages need a live database and session. **Nobody has yet seen this on a phone at a field**, which is what "legible in sunlight" ultimately means.
- `main` was merged in after #35 landed; only `AGENTS.md` conflicted (both sides appended a Gotchas entry) and both entries are kept.

## Test Plan

- [x] `pnpm check` on the merged tree — lint, typecheck, **895 tests across 62 files**.
- [x] Diamond rendered and screenshotted in both themes; day and night verified.
- [x] Confirmed #35's new pages do not use the retired `--baseball-*` tokens.
- [ ] Vercel preview deploy succeeds — this is the only gate that exercises `prisma migrate deploy && next build`, which the local gate cannot without `DATABASE_URL`.
- [ ] On a real phone at a field: the lineup diamond is readable in sunlight.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gDSJTbh6VY9eKhQoY2c8M