### PR TITLE
Make contact details staff-facing, and give people their own profile

### DIFF
--- a/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
@@ -89,6 +89,12 @@ Scoped to fit **6 weeks of evenings and weekends**.
   so excluding them from the directory would remove the convenient list without
   removing the access — while leaving an assistant coach at the field unable to call
   a parent.
+- **Your profile** — each person sees and edits their own name and phone at `/profile`
+  (added 2026-08-18). #5 logged "a parent expects to edit their own phone" as an accepted
+  risk on the assumption they could at least see the value; closing the directory to
+  parents removed the last screen that showed it, so a coach's typo became undetectable
+  by the one person who knows it is wrong. Email is not editable — it is the magic-link
+  identity, so changing it is an account migration, not a profile edit.
 - **Schedule** — coach creates games and practices with location and time; parents see a
   month calendar view and a chronological list view.
 - **RSVP** — parent toggles attending / not attending per kid per event, **only for kids

--- a/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
@@ -77,8 +77,11 @@ Scoped to fit **6 weeks of evenings and weekends**.
   short **"you've been added to <team>"** email — no magic link, since they already have an
   account; just a heads-up and a way in. Explicitly *not* a bulk "copy last year's
   roster" — it's a deliberate pick, because rosters genuinely change.
-- **Directory** — parent name, phone, email, and their kids. Visible to all signed-in
-  members.
+- **Directory** — parent name, phone, email, and their kids. Visible to **coaches and the
+  owner only** (revised 2026-08-18; it previously read "visible to all signed-in members").
+  It is the whole team's contact details in one list, and a parent has no reason to hold
+  every other family's phone number and email; a parent who needs to reach someone goes
+  through the coach. Parents still see the schedule, the lineup, the roster, and RSVP.
 - **Schedule** — coach creates games and practices with location and time; parents see a
   month calendar view and a chronological list view.
 - **RSVP** — parent toggles attending / not attending per kid per event, **only for kids

--- a/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
@@ -77,11 +77,13 @@ Scoped to fit **6 weeks of evenings and weekends**.
   short **"you've been added to <team>"** email — no magic link, since they already have an
   account; just a heads-up and a way in. Explicitly *not* a bulk "copy last year's
   roster" — it's a deliberate pick, because rosters genuinely change.
-- **Directory** — parent name, phone, email, and their kids. Visible to **coaches and the
-  owner only** (revised 2026-08-18; it previously read "visible to all signed-in members").
-  It is the whole team's contact details in one list, and a parent has no reason to hold
-  every other family's phone number and email; a parent who needs to reach someone goes
-  through the coach. Parents still see the schedule, the lineup, the roster, and RSVP.
+- **Directory** — parent name, phone, email, and their kids. Visible to the **owner only**
+  (revised 2026-08-18; it previously read "visible to all signed-in members"). It is the
+  whole team's contact details in one list, so it sits with the one person who runs the
+  team. Coaches are deliberately excluded too: a team can carry up to four, they turn over
+  season to season, and none of that churn is visible to the families whose numbers are on
+  the page — a coach who needs to reach someone asks the owner. Parents and coaches keep
+  the schedule, the lineup, the roster, and RSVP.
 - **Schedule** — coach creates games and practices with location and time; parents see a
   month calendar view and a chronological list view.
 - **RSVP** — parent toggles attending / not attending per kid per event, **only for kids

--- a/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
@@ -81,11 +81,14 @@ Scoped to fit **6 weeks of evenings and weekends**.
   owner only** (revised 2026-08-18; it previously read "visible to all signed-in members").
   It is the whole team's contact details in one list, and a parent has no reason to hold
   every other family's phone number and email; a parent who needs to reach someone goes
-  through the coach. Parents still see the schedule, the lineup, the roster, and RSVP.
-  Owner-only was considered and rejected the same day: coaches already read contact
-  details family-by-family through the roster entry pages their job requires, so
-  excluding them from the directory would remove the convenient list without removing
-  the access — while leaving an assistant coach at the field unable to call a parent.
+  through the coach. To make that path real, the team home page shows parents a
+  **coaching-staff contact card** (owner and coaches only — name, email, phone; no
+  other family's data). Parents still see the schedule, the lineup, the roster, and
+  RSVP. Owner-only was considered and rejected the same day: coaches already read
+  contact details family-by-family through the roster entry pages their job requires,
+  so excluding them from the directory would remove the convenient list without
+  removing the access — while leaving an assistant coach at the field unable to call
+  a parent.
 - **Schedule** — coach creates games and practices with location and time; parents see a
   month calendar view and a chronological list view.
 - **RSVP** — parent toggles attending / not attending per kid per event, **only for kids

--- a/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
@@ -77,13 +77,15 @@ Scoped to fit **6 weeks of evenings and weekends**.
   short **"you've been added to <team>"** email — no magic link, since they already have an
   account; just a heads-up and a way in. Explicitly *not* a bulk "copy last year's
   roster" — it's a deliberate pick, because rosters genuinely change.
-- **Directory** — parent name, phone, email, and their kids. Visible to the **owner only**
-  (revised 2026-08-18; it previously read "visible to all signed-in members"). It is the
-  whole team's contact details in one list, so it sits with the one person who runs the
-  team. Coaches are deliberately excluded too: a team can carry up to four, they turn over
-  season to season, and none of that churn is visible to the families whose numbers are on
-  the page — a coach who needs to reach someone asks the owner. Parents and coaches keep
-  the schedule, the lineup, the roster, and RSVP.
+- **Directory** — parent name, phone, email, and their kids. Visible to **coaches and the
+  owner only** (revised 2026-08-18; it previously read "visible to all signed-in members").
+  It is the whole team's contact details in one list, and a parent has no reason to hold
+  every other family's phone number and email; a parent who needs to reach someone goes
+  through the coach. Parents still see the schedule, the lineup, the roster, and RSVP.
+  Owner-only was considered and rejected the same day: coaches already read contact
+  details family-by-family through the roster entry pages their job requires, so
+  excluding them from the directory would remove the convenient list without removing
+  the access — while leaving an assistant coach at the field unable to call a parent.
 - **Schedule** — coach creates games and practices with location and time; parents see a
   month calendar view and a chronological list view.
 - **RSVP** — parent toggles attending / not attending per kid per event, **only for kids

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ src/generated/     # Prisma client output — gitignored, regenerate with pnpm d
 `src/app/` now has real routes: `/` (auth-gated landing), `/signin`, `/invite/[token]`
 (unauthenticated invitation accept page — deliberately outside proxy.ts's matcher), and
 `/t/[teamId]/` (team home, settings, roster, members, the owner-only returning-player
-picker at `roster/returning`, the owner-only member directory, the schedule at `schedule` /
+picker at `roster/returning`, the coach-only member directory, the schedule at `schedule` /
 `schedule/[eventId]`, the read-only chart at `view`, and the two coach-only drag-and-drop
 chart editors — the batting order at `chart` and the positions diamond at
 `chart/positions`) plus `/t/new` for owner-gated team creation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ src/generated/     # Prisma client output — gitignored, regenerate with pnpm d
 `src/app/` now has real routes: `/` (auth-gated landing), `/signin`, `/invite/[token]`
 (unauthenticated invitation accept page — deliberately outside proxy.ts's matcher), and
 `/t/[teamId]/` (team home, settings, roster, members, the owner-only returning-player
-picker at `roster/returning`, the coach-only member directory, the schedule at `schedule` /
+picker at `roster/returning`, the owner-only member directory, the schedule at `schedule` /
 `schedule/[eventId]`, the read-only chart at `view`, and the two coach-only drag-and-drop
 chart editors — the batting order at `chart` and the positions diamond at
 `chart/positions`) plus `/t/new` for owner-gated team creation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ src/generated/     # Prisma client output — gitignored, regenerate with pnpm d
 `src/app/` now has real routes: `/` (auth-gated landing), `/signin`, `/invite/[token]`
 (unauthenticated invitation accept page — deliberately outside proxy.ts's matcher), and
 `/t/[teamId]/` (team home, settings, roster, members, the owner-only returning-player
-picker at `roster/returning`, the member directory, the schedule at `schedule` /
+picker at `roster/returning`, the coach-only member directory, the schedule at `schedule` /
 `schedule/[eventId]`, the read-only chart at `view`, and the two coach-only drag-and-drop
 chart editors — the batting order at `chart` and the positions diamond at
 `chart/positions`) plus `/t/new` for owner-gated team creation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,20 @@ src/generated/     # Prisma client output — gitignored, regenerate with pnpm d
 ```
 
 `src/app/` now has real routes: `/` (auth-gated landing), `/signin`, `/invite/[token]`
-(unauthenticated invitation accept page — deliberately outside proxy.ts's matcher), and
-`/t/[teamId]/` (team home, settings, roster, members, the owner-only returning-player
-picker at `roster/returning`, the coach-only member directory, the schedule at `schedule` /
+(unauthenticated invitation accept page — deliberately outside proxy.ts's matcher),
+`/profile` (the signed-in person's own name and phone — global, not team-scoped, since
+those are `User` columns), and `/t/[teamId]/` (team home, settings, roster, members, the
+owner-only returning-player picker at `roster/returning`, the coach-only member directory,
+the coach-only roster entry detail at `roster/[entryId]`, the schedule at `schedule` /
 `schedule/[eventId]`, the read-only chart at `view`, and the two coach-only drag-and-drop
 chart editors — the batting order at `chart` and the positions diamond at
 `chart/positions`) plus `/t/new` for owner-gated team creation.
+
+**Contact details are staff-facing.** A parent never sees another family's phone or
+email: `/directory` and `roster/[entryId]` are both COACH+, and the team home page gives
+parents a coaching-staff-only contact card (`listCoachContacts`) so "ask your coach" is
+an actual route. `/profile` is the counterpart — the one place a person reads back, and
+fixes, what the team has on file for them.
 
 ## Tech Stack
 
@@ -86,7 +94,9 @@ non-null) reject **every** write regardless of role, owner included.
 ### Proxy is optimistic-only
 
 `proxy.ts` (Next 16's renamed Middleware) does exactly one job here: redirect to sign-in
-when no session cookie is present, matching `/t/:path*`. It must stay that way.
+when no session cookie is present, matching `/t/:path*` and `/profile`. It must stay
+that way — matching another signed-in-only path is fine, reading the database there is
+not.
 
 Do **not** move the membership, role, or archived check into it. Proxy runs on every
 request including prefetches, so a database lookup there fires on link hover; the Next.js

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,11 +52,16 @@ export default async function Home() {
               Your teams are below.
             </p>
           </div>
-          {owner && (
-            <Button asChild>
-              <Link href="/t/new">Create a team</Link>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild variant="outline">
+              <Link href="/profile">Your profile</Link>
             </Button>
-          )}
+            {owner && (
+              <Button asChild>
+                <Link href="/t/new">Create a team</Link>
+              </Button>
+            )}
+          </div>
         </div>
 
         <TeamSelector teams={teams} userTeamIds={userTeamIds} />

--- a/src/app/profile/actions.ts
+++ b/src/app/profile/actions.ts
@@ -40,9 +40,14 @@ export async function updateProfileAction(formData: FormData) {
   }
 
   revalidatePath("/profile");
-  // This person's name and phone are rendered in two staff-facing places, and
-  // their name also appears in the team switcher chrome.
+  // Every other page that renders these two columns. The staff-facing pair
+  // show this person's name, email, and phone to their coaches; the landing
+  // page greets them by name; and the team home page reads the same columns
+  // back through listCoachContacts, so a coach fixing their own number has
+  // to reach the card their parents actually dial.
   revalidatePath("/t/[teamId]/directory", "page");
   revalidatePath("/t/[teamId]/roster/[entryId]", "page");
+  revalidatePath("/t/[teamId]", "page");
+  revalidatePath("/");
   redirect("/profile?saved=1");
 }

--- a/src/app/profile/actions.ts
+++ b/src/app/profile/actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect, unstable_rethrow } from "next/navigation";
+
+import { normalizePhone } from "@/lib/phone";
+import { updateProfile } from "@/lib/profile";
+import { getCurrentUser } from "@/lib/session";
+
+/**
+ * Save the signed-in person's own name and phone.
+ *
+ * The userId comes from the session and never from the form. That is the
+ * whole authorization story for this action: there is no id to forge, so
+ * "edit my profile" cannot be aimed at somebody else's row the way a
+ * hidden-input userId could be. It is also why this action needs no
+ * `requireTeamAccess` — nothing here is team-scoped, and an archived team
+ * must not stop a person from correcting their own phone number.
+ */
+export async function updateProfileAction(formData: FormData) {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/signin?callbackUrl=%2Fprofile");
+  }
+
+  const rawName = String(formData.get("name") ?? "").trim();
+
+  let phone: string | null;
+  try {
+    phone = normalizePhone(formData.get("phone"));
+  } catch {
+    redirect("/profile?error=invalid-phone");
+  }
+
+  try {
+    await updateProfile(user.id, { name: rawName === "" ? null : rawName, phone });
+  } catch (error) {
+    unstable_rethrow(error);
+    redirect("/profile?error=save-failed");
+  }
+
+  revalidatePath("/profile");
+  // This person's name and phone are rendered in two staff-facing places, and
+  // their name also appears in the team switcher chrome.
+  revalidatePath("/t/[teamId]/directory", "page");
+  revalidatePath("/t/[teamId]/roster/[entryId]", "page");
+  redirect("/profile?saved=1");
+}

--- a/src/app/profile/actions.ts
+++ b/src/app/profile/actions.ts
@@ -40,13 +40,12 @@ export async function updateProfileAction(formData: FormData) {
   }
 
   revalidatePath("/profile");
-  // Every other page that renders these two columns. The staff-facing pair
-  // show this person's name, email, and phone to their coaches; the landing
-  // page greets them by name; and the team home page reads the same columns
-  // back through listCoachContacts, so a coach fixing their own number has
-  // to reach the card their parents actually dial.
+  // Every other page that renders User.name or User.phone. This list mirrors
+  // the table in src/lib/profile.ts — add a page there and here together, or
+  // it serves the old value and the save looks broken.
   revalidatePath("/t/[teamId]/directory", "page");
   revalidatePath("/t/[teamId]/roster/[entryId]", "page");
+  revalidatePath("/t/[teamId]/members", "page");
   revalidatePath("/t/[teamId]", "page");
   revalidatePath("/");
   redirect("/profile?saved=1");

--- a/src/app/profile/page.test.tsx
+++ b/src/app/profile/page.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const getCurrentUser = vi.fn();
+const getProfile = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getCurrentUser: (...args: unknown[]) => getCurrentUser(...args),
+}));
+
+vi.mock("@/lib/profile", () => ({
+  getProfile: (...args: unknown[]) => getProfile(...args),
+}));
+
+vi.mock("./actions", () => ({
+  updateProfileAction: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
+async function render(searchParams: { error?: string; saved?: string } = {}) {
+  const { default: ProfilePage } = await import("./page");
+  return renderToStaticMarkup(
+    await ProfilePage({ searchParams: Promise.resolve(searchParams) }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getCurrentUser.mockResolvedValue({
+    id: "user-1",
+    email: "sam@example.com",
+    name: "Sam",
+  });
+  getProfile.mockResolvedValue({
+    name: "Sam",
+    email: "sam@example.com",
+    phone: "555-1234",
+  });
+});
+
+describe("ProfilePage", () => {
+  it("shows the person the phone number the team has on file", async () => {
+    const html = await render();
+
+    expect(getProfile).toHaveBeenCalledWith("user-1");
+    expect(html).toContain('value="555-1234"');
+    expect(html).toContain('value="Sam"');
+    expect(html).toContain("sam@example.com");
+  });
+
+  it("renders an empty phone field when there is no number on file", async () => {
+    getProfile.mockResolvedValue({
+      name: null,
+      email: "sam@example.com",
+      phone: null,
+    });
+
+    const html = await render();
+
+    expect(html).toContain('id="phone"');
+    expect(html).not.toContain('value="555-1234"');
+  });
+
+  // Proxy only checks that a session cookie exists, so the page cannot assume
+  // a signed-in caller — see the comment on proxy.ts.
+  it("redirects a signed-out visitor to sign-in", async () => {
+    getCurrentUser.mockResolvedValue(null);
+
+    await expect(render()).rejects.toThrow("NEXT_REDIRECT:/signin?callbackUrl=%2Fprofile");
+    expect(getProfile).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the session points at a user row that is gone", async () => {
+    getProfile.mockResolvedValue(null);
+
+    await expect(render()).rejects.toThrow("NEXT_REDIRECT:/signin?callbackUrl=%2Fprofile");
+  });
+
+  it("surfaces a rejected phone number", async () => {
+    const html = await render({ error: "invalid-phone" });
+
+    expect(html).toContain("Phone number must be 32 characters or fewer.");
+  });
+
+  it("confirms a save", async () => {
+    const html = await render({ saved: "1" });
+
+    expect(html).toContain("Saved.");
+  });
+
+  it("does not confirm a save that failed", async () => {
+    const html = await render({ saved: "1", error: "save-failed" });
+
+    expect(html).not.toContain("Saved.");
+    expect(html).toContain("Your changes couldn&#x27;t be saved. Try again.");
+  });
+
+  // A database error on the read must not render as "no number on file" —
+  // getProfile deliberately does not swallow it, so the page must not either.
+  it("lets a read failure reach the error boundary", async () => {
+    getProfile.mockRejectedValue(new Error("connection lost"));
+
+    await expect(render()).rejects.toThrow("connection lost");
+  });
+});

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { PageContainer } from "@/components/layout/PageContainer";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getProfile } from "@/lib/profile";
+import { getCurrentUser } from "@/lib/session";
+
+import { updateProfileAction } from "./actions";
+
+export const metadata = {
+  title: "Your profile — Youth Baseball Team Manager",
+};
+
+const ERROR_MESSAGES: Record<string, string> = {
+  "invalid-phone": "Phone number must be 32 characters or fewer.",
+  "save-failed": "Your changes couldn't be saved. Try again.",
+};
+
+/// The one place a person sees and fixes what the team has on file for them.
+///
+/// This exists because the contact details are otherwise written *about* them
+/// and never shown *to* them: a coach types a parent's phone on the roster
+/// entry page, that number is what the staff directory dials, and until this
+/// page there was no screen anywhere in the app where the parent could read
+/// it back. A transposed digit was therefore undetectable by the only person
+/// who knows it is wrong.
+///
+/// Deliberately global rather than under /t/[teamId]: name and phone are
+/// columns on User, one per person, not per team. Proxy matches /profile so a
+/// signed-out visitor is bounced to sign-in before the page runs, but Proxy
+/// is optimistic (cookie presence, not validity), so the real check is here.
+export default async function ProfilePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; saved?: string }>;
+}) {
+  const { error, saved } = await searchParams;
+
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/signin?callbackUrl=%2Fprofile");
+  }
+
+  const profile = await getProfile(user.id);
+  if (!profile) {
+    redirect("/signin?callbackUrl=%2Fprofile");
+  }
+
+  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+
+  return (
+    <PageContainer>
+      <div className="mx-auto w-full max-w-md space-y-6">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-2xl font-bold text-foreground">Your profile</h2>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/">Back</Link>
+          </Button>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Contact details</CardTitle>
+            <CardDescription>
+              This is what your coaches see for you. Your phone number is
+              visible to the coaching staff of your teams, not to other
+              parents.
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent>
+            <form action={updateProfileAction} className="space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="name" className="block text-sm font-medium text-foreground">
+                  Name
+                </label>
+                <input
+                  id="name"
+                  name="name"
+                  type="text"
+                  defaultValue={profile.name ?? ""}
+                  placeholder="Your name"
+                  aria-describedby={errorMessage ? "profile-error" : undefined}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="phone" className="block text-sm font-medium text-foreground">
+                  Phone
+                </label>
+                <input
+                  id="phone"
+                  name="phone"
+                  type="tel"
+                  defaultValue={profile.phone ?? ""}
+                  placeholder="(555) 123-4567"
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Leave blank if you would rather not have a number on file.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <p className="block text-sm font-medium text-foreground">Email</p>
+                <p className="text-sm text-muted-foreground">{profile.email}</p>
+                <p className="text-xs text-muted-foreground">
+                  This is the address you sign in with. Ask your coach if it
+                  needs to change.
+                </p>
+              </div>
+
+              {errorMessage ? (
+                <p id="profile-error" role="alert" className="text-sm text-destructive">
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              {saved && !errorMessage ? (
+                <p role="status" className="text-sm text-muted-foreground">
+                  Saved.
+                </p>
+              ) : null}
+
+              <Button type="submit" className="w-full">
+                Save changes
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </PageContainer>
+  );
+}

--- a/src/app/t/[teamId]/directory/page.test.tsx
+++ b/src/app/t/[teamId]/directory/page.test.tsx
@@ -23,7 +23,7 @@ import { TeamAccessError } from "@/lib/team-access";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
+  requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
   listDirectory.mockResolvedValue([]);
 });
 
@@ -33,13 +33,16 @@ describe("DirectoryPage", () => {
     expect(typeof DirectoryPage).toBe("function");
   });
 
-  it("is visible to a parent, not just the owner", async () => {
+  it("is visible to a coach", async () => {
     const { default: DirectoryPage } = await import("./page");
 
     await expect(
       DirectoryPage({ params: Promise.resolve({ teamId: "team-1" }) }),
     ).resolves.toBeDefined();
-    expect(requireTeamAccess).toHaveBeenCalledWith("team-1", { intent: "read" });
+    expect(requireTeamAccess).toHaveBeenCalledWith("team-1", {
+      intent: "read",
+      minRole: "COACH",
+    });
   });
 
   it("calls notFound() for someone with no membership", async () => {
@@ -50,6 +53,22 @@ describe("DirectoryPage", () => {
     await expect(
       DirectoryPage({ params: Promise.resolve({ teamId: "team-1" }) }),
     ).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+
+  // A parent who pastes the URL gets a 404, not a page of other families'
+  // phone numbers — requireTeamAccess raises insufficient-role for minRole
+  // COACH and the loader treats it exactly like no membership at all.
+  it("calls notFound() for a parent who pastes the URL", async () => {
+    requireTeamAccess.mockRejectedValue(
+      new TeamAccessError("Requires COACH, caller is PARENT", "insufficient-role"),
+    );
+
+    const { default: DirectoryPage } = await import("./page");
+
+    await expect(
+      DirectoryPage({ params: Promise.resolve({ teamId: "team-1" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(listDirectory).not.toHaveBeenCalled();
   });
 
   it("renders a parent's kids on this team", async () => {

--- a/src/app/t/[teamId]/directory/page.test.tsx
+++ b/src/app/t/[teamId]/directory/page.test.tsx
@@ -23,7 +23,7 @@ import { TeamAccessError } from "@/lib/team-access";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
+  requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
   listDirectory.mockResolvedValue([]);
 });
 
@@ -33,7 +33,7 @@ describe("DirectoryPage", () => {
     expect(typeof DirectoryPage).toBe("function");
   });
 
-  it("is visible to a coach", async () => {
+  it("is visible to the owner", async () => {
     const { default: DirectoryPage } = await import("./page");
 
     await expect(
@@ -41,7 +41,7 @@ describe("DirectoryPage", () => {
     ).resolves.toBeDefined();
     expect(requireTeamAccess).toHaveBeenCalledWith("team-1", {
       intent: "read",
-      minRole: "COACH",
+      minRole: "OWNER",
     });
   });
 
@@ -55,12 +55,12 @@ describe("DirectoryPage", () => {
     ).rejects.toThrow("NEXT_NOT_FOUND");
   });
 
-  // A parent who pastes the URL gets a 404, not a page of other families'
-  // phone numbers — requireTeamAccess raises insufficient-role for minRole
-  // COACH and the loader treats it exactly like no membership at all.
-  it("calls notFound() for a parent who pastes the URL", async () => {
+  // A coach or parent who pastes the URL gets a 404, not a page of other
+  // families' phone numbers — requireTeamAccess raises insufficient-role for
+  // minRole OWNER and the loader treats it exactly like no membership at all.
+  it.each(["COACH", "PARENT"])("calls notFound() for a %s who pastes the URL", async (role) => {
     requireTeamAccess.mockRejectedValue(
-      new TeamAccessError("Requires COACH, caller is PARENT", "insufficient-role"),
+      new TeamAccessError(`Requires OWNER, caller is ${role}`, "insufficient-role"),
     );
 
     const { default: DirectoryPage } = await import("./page");

--- a/src/app/t/[teamId]/directory/page.test.tsx
+++ b/src/app/t/[teamId]/directory/page.test.tsx
@@ -23,7 +23,7 @@ import { TeamAccessError } from "@/lib/team-access";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
+  requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
   listDirectory.mockResolvedValue([]);
 });
 
@@ -33,7 +33,7 @@ describe("DirectoryPage", () => {
     expect(typeof DirectoryPage).toBe("function");
   });
 
-  it("is visible to the owner", async () => {
+  it("is visible to a coach", async () => {
     const { default: DirectoryPage } = await import("./page");
 
     await expect(
@@ -41,7 +41,7 @@ describe("DirectoryPage", () => {
     ).resolves.toBeDefined();
     expect(requireTeamAccess).toHaveBeenCalledWith("team-1", {
       intent: "read",
-      minRole: "OWNER",
+      minRole: "COACH",
     });
   });
 
@@ -55,12 +55,12 @@ describe("DirectoryPage", () => {
     ).rejects.toThrow("NEXT_NOT_FOUND");
   });
 
-  // A coach or parent who pastes the URL gets a 404, not a page of other
-  // families' phone numbers — requireTeamAccess raises insufficient-role for
-  // minRole OWNER and the loader treats it exactly like no membership at all.
-  it.each(["COACH", "PARENT"])("calls notFound() for a %s who pastes the URL", async (role) => {
+  // A parent who pastes the URL gets a 404, not a page of other families'
+  // phone numbers — requireTeamAccess raises insufficient-role for minRole
+  // COACH and the loader treats it exactly like no membership at all.
+  it("calls notFound() for a parent who pastes the URL", async () => {
     requireTeamAccess.mockRejectedValue(
-      new TeamAccessError(`Requires OWNER, caller is ${role}`, "insufficient-role"),
+      new TeamAccessError("Requires COACH, caller is PARENT", "insufficient-role"),
     );
 
     const { default: DirectoryPage } = await import("./page");

--- a/src/app/t/[teamId]/directory/page.test.tsx
+++ b/src/app/t/[teamId]/directory/page.test.tsx
@@ -45,23 +45,12 @@ describe("DirectoryPage", () => {
     });
   });
 
-  it("calls notFound() for someone with no membership", async () => {
+  // Covers a parent pasting the URL too: the loader turns every
+  // TeamAccessError into notFound() without reading its reason, and the
+  // minRole: "COACH" assertion above pins where the parent lockout actually
+  // lives (team-access.test.ts proves a PARENT fails that gate).
+  it("calls notFound() when access is refused, before fetching", async () => {
     requireTeamAccess.mockRejectedValue(new TeamAccessError("nope", "no-membership"));
-
-    const { default: DirectoryPage } = await import("./page");
-
-    await expect(
-      DirectoryPage({ params: Promise.resolve({ teamId: "team-1" }) }),
-    ).rejects.toThrow("NEXT_NOT_FOUND");
-  });
-
-  // A parent who pastes the URL gets a 404, not a page of other families'
-  // phone numbers — requireTeamAccess raises insufficient-role for minRole
-  // COACH and the loader treats it exactly like no membership at all.
-  it("calls notFound() for a parent who pastes the URL", async () => {
-    requireTeamAccess.mockRejectedValue(
-      new TeamAccessError("Requires COACH, caller is PARENT", "insufficient-role"),
-    );
 
     const { default: DirectoryPage } = await import("./page");
 

--- a/src/app/t/[teamId]/directory/page.tsx
+++ b/src/app/t/[teamId]/directory/page.tsx
@@ -20,10 +20,14 @@ const ROLE_LABELS: Record<string, string> = {
   PARENT: "Parent",
 };
 
-/// Every signed-in member reads — unlike /members, this is not owner-only.
-/// Each member's kid list is scoped to THIS team's roster (see
-/// design-doc.md #5 Decision 5), so a parent here never learns what team a
-/// child also plays on elsewhere.
+/// Coach-and-above only. The directory is every family's contact details in
+/// one list, so it is staff-facing: a parent gets no route to another
+/// family's phone number or email. Nothing links here for a parent, and
+/// minRole turns a pasted URL into a 404.
+///
+/// Each member's kid list stays scoped to THIS team's roster (see
+/// design-doc.md #5 Decision 5), so a coach on this team never learns what
+/// other team a child also plays on.
 export default async function DirectoryPage({
   params,
 }: {
@@ -32,7 +36,7 @@ export default async function DirectoryPage({
   const { teamId } = await params;
 
   try {
-    await requireTeamAccess(teamId, { intent: "read" });
+    await requireTeamAccess(teamId, { intent: "read", minRole: "COACH" });
   } catch (caught) {
     if (caught instanceof TeamAccessError) {
       notFound();

--- a/src/app/t/[teamId]/directory/page.tsx
+++ b/src/app/t/[teamId]/directory/page.tsx
@@ -20,14 +20,19 @@ const ROLE_LABELS: Record<string, string> = {
   PARENT: "Parent",
 };
 
-/// Coach-and-above only. The directory is every family's contact details in
-/// one list, so it is staff-facing: a parent gets no route to another
-/// family's phone number or email. Nothing links here for a parent, and
-/// minRole turns a pasted URL into a 404.
+/// Owner-only. The directory is every family's contact details in one list,
+/// so it is held by the narrowest audience that can still do the job: the
+/// one person who runs the team. COACH was considered and is too wide —
+/// a team can carry up to four coaches, they turn over season to season,
+/// and none of that is visible to the families whose numbers are on the
+/// page. A coach who needs to reach a family asks the owner.
+///
+/// Nothing links here below OWNER, and minRole turns a pasted URL into a
+/// 404 — the same shape /members already uses.
 ///
 /// Each member's kid list stays scoped to THIS team's roster (see
-/// design-doc.md #5 Decision 5), so a coach on this team never learns what
-/// other team a child also plays on.
+/// design-doc.md #5 Decision 5), so this page never reveals what other
+/// team a child also plays on.
 export default async function DirectoryPage({
   params,
 }: {
@@ -36,7 +41,7 @@ export default async function DirectoryPage({
   const { teamId } = await params;
 
   try {
-    await requireTeamAccess(teamId, { intent: "read", minRole: "COACH" });
+    await requireTeamAccess(teamId, { intent: "read", minRole: "OWNER" });
   } catch (caught) {
     if (caught instanceof TeamAccessError) {
       notFound();

--- a/src/app/t/[teamId]/directory/page.tsx
+++ b/src/app/t/[teamId]/directory/page.tsx
@@ -20,19 +20,14 @@ const ROLE_LABELS: Record<string, string> = {
   PARENT: "Parent",
 };
 
-/// Owner-only. The directory is every family's contact details in one list,
-/// so it is held by the narrowest audience that can still do the job: the
-/// one person who runs the team. COACH was considered and is too wide —
-/// a team can carry up to four coaches, they turn over season to season,
-/// and none of that is visible to the families whose numbers are on the
-/// page. A coach who needs to reach a family asks the owner.
-///
-/// Nothing links here below OWNER, and minRole turns a pasted URL into a
-/// 404 — the same shape /members already uses.
+/// Coach-and-above only. The directory is every family's contact details in
+/// one list, so it is staff-facing: a parent gets no route to another
+/// family's phone number or email. Nothing links here for a parent, and
+/// minRole turns a pasted URL into a 404.
 ///
 /// Each member's kid list stays scoped to THIS team's roster (see
-/// design-doc.md #5 Decision 5), so this page never reveals what other
-/// team a child also plays on.
+/// design-doc.md #5 Decision 5), so a coach on this team never learns what
+/// other team a child also plays on.
 export default async function DirectoryPage({
   params,
 }: {
@@ -41,7 +36,7 @@ export default async function DirectoryPage({
   const { teamId } = await params;
 
   try {
-    await requireTeamAccess(teamId, { intent: "read", minRole: "OWNER" });
+    await requireTeamAccess(teamId, { intent: "read", minRole: "COACH" });
   } catch (caught) {
     if (caught instanceof TeamAccessError) {
       notFound();

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -63,4 +63,29 @@ describe("TeamHomePage navigation", () => {
 
     expect(html).toContain('href="/t/team-1/readiness"');
   });
+
+  it("links a coach to the directory", async () => {
+    const html = await render();
+
+    expect(html).toContain('href="/t/team-1/directory"');
+  });
+
+  it("does not show the directory to a parent", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
+
+    const html = await render();
+
+    expect(html).not.toContain('href="/t/team-1/directory"');
+    // The roster stays open to a parent — it is the team's players, not
+    // every family's contact details.
+    expect(html).toContain('href="/t/team-1/roster"');
+  });
+
+  it("shows the directory to an owner too", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
+
+    const html = await render();
+
+    expect(html).toContain('href="/t/team-1/directory"');
+  });
 });

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 const requireTeamAccess = vi.fn();
 const getTeamById = vi.fn();
+const listCoachContacts = vi.fn();
 
 vi.mock("@/lib/team-access", () => ({
   requireTeamAccess: (...args: unknown[]) => requireTeamAccess(...args),
@@ -11,6 +12,10 @@ vi.mock("@/lib/team-access", () => ({
 
 vi.mock("@/lib/teams", () => ({
   getTeamById: (...args: unknown[]) => getTeamById(...args),
+}));
+
+vi.mock("@/lib/memberships", () => ({
+  listCoachContacts: (...args: unknown[]) => listCoachContacts(...args),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -29,6 +34,7 @@ async function render(teamId = "team-1") {
 beforeEach(() => {
   vi.clearAllMocks();
   requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
+  listCoachContacts.mockResolvedValue([]);
   getTeamById.mockResolvedValue({
     id: "team-1",
     name: "Sluggers",
@@ -39,53 +45,77 @@ beforeEach(() => {
 });
 
 describe("TeamHomePage navigation", () => {
-  it("links a coach to next-game readiness", async () => {
+  it("shows a coach the coach links but not owner-only ones", async () => {
     const html = await render();
 
     expect(html).toContain('href="/t/team-1/readiness"');
-    expect(html).toContain("Next-game readiness");
+    expect(html).toContain('href="/t/team-1/chart"');
+    expect(html).toContain('href="/t/team-1/directory"');
+    expect(html).toContain('href="/t/team-1/roster"');
+    expect(html).not.toContain('href="/t/team-1/settings"');
   });
 
-  it("does not show readiness to a parent", async () => {
+  it("shows a parent only the parent links", async () => {
     requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
 
     const html = await render();
 
     expect(html).not.toContain('href="/t/team-1/readiness"');
-    // The parent's own path to the chart is unaffected.
+    expect(html).not.toContain('href="/t/team-1/chart"');
+    expect(html).not.toContain('href="/t/team-1/directory"');
+    expect(html).not.toContain('href="/t/team-1/settings"');
+    // The parent's own surfaces are unaffected.
     expect(html).toContain('href="/t/team-1/view"');
+    expect(html).toContain('href="/t/team-1/roster"');
+    expect(html).toContain('href="/t/team-1/schedule"');
   });
 
-  it("shows readiness to an owner too", async () => {
+  it("shows an owner the coach links plus settings", async () => {
     requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
 
     const html = await render();
 
     expect(html).toContain('href="/t/team-1/readiness"');
-  });
-
-  it("links a coach to the directory", async () => {
-    const html = await render();
-
     expect(html).toContain('href="/t/team-1/directory"');
+    expect(html).toContain('href="/t/team-1/settings"');
   });
+});
 
-  it("does not show the directory to a parent", async () => {
+describe("TeamHomePage coach contacts", () => {
+  const STAFF = [
+    {
+      userId: "user-9",
+      role: "OWNER",
+      name: "Mel",
+      email: "mel@example.com",
+      phone: "555-9876",
+    },
+    {
+      userId: "user-8",
+      role: "COACH",
+      name: "Pat",
+      email: "pat@example.com",
+      phone: null,
+    },
+  ];
+
+  it("shows a parent the coaching staff's contact card", async () => {
     requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
+    listCoachContacts.mockResolvedValue(STAFF);
 
     const html = await render();
 
-    expect(html).not.toContain('href="/t/team-1/directory"');
-    // The roster stays open to a parent — it is the team's players, not
-    // every family's contact details.
-    expect(html).toContain('href="/t/team-1/roster"');
+    expect(listCoachContacts).toHaveBeenCalledWith("team-1");
+    expect(html).toContain("Coaches");
+    expect(html).toContain('href="mailto:mel@example.com"');
+    expect(html).toContain('href="tel:555-9876"');
+    expect(html).toContain("Pat");
   });
 
-  it("shows the directory to an owner too", async () => {
-    requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
-
+  it("does not fetch or render the card for a coach", async () => {
     const html = await render();
 
-    expect(html).toContain('href="/t/team-1/directory"');
+    expect(listCoachContacts).not.toHaveBeenCalled();
+    expect(html).not.toContain("Coaches");
   });
 });

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -64,21 +64,10 @@ describe("TeamHomePage navigation", () => {
     expect(html).toContain('href="/t/team-1/readiness"');
   });
 
-  it("links an owner to the directory", async () => {
-    requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
-
+  it("links a coach to the directory", async () => {
     const html = await render();
 
     expect(html).toContain('href="/t/team-1/directory"');
-  });
-
-  it("does not show the directory to a coach", async () => {
-    const html = await render();
-
-    expect(html).not.toContain('href="/t/team-1/directory"');
-    // A coach keeps everything else that is theirs.
-    expect(html).toContain('href="/t/team-1/readiness"');
-    expect(html).toContain('href="/t/team-1/chart"');
   });
 
   it("does not show the directory to a parent", async () => {
@@ -90,5 +79,13 @@ describe("TeamHomePage navigation", () => {
     // The roster stays open to a parent — it is the team's players, not
     // every family's contact details.
     expect(html).toContain('href="/t/team-1/roster"');
+  });
+
+  it("shows the directory to an owner too", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
+
+    const html = await render();
+
+    expect(html).toContain('href="/t/team-1/directory"');
   });
 });

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -64,10 +64,21 @@ describe("TeamHomePage navigation", () => {
     expect(html).toContain('href="/t/team-1/readiness"');
   });
 
-  it("links a coach to the directory", async () => {
+  it("links an owner to the directory", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
+
     const html = await render();
 
     expect(html).toContain('href="/t/team-1/directory"');
+  });
+
+  it("does not show the directory to a coach", async () => {
+    const html = await render();
+
+    expect(html).not.toContain('href="/t/team-1/directory"');
+    // A coach keeps everything else that is theirs.
+    expect(html).toContain('href="/t/team-1/readiness"');
+    expect(html).toContain('href="/t/team-1/chart"');
   });
 
   it("does not show the directory to a parent", async () => {
@@ -79,13 +90,5 @@ describe("TeamHomePage navigation", () => {
     // The roster stays open to a parent — it is the team's players, not
     // every family's contact details.
     expect(html).toContain('href="/t/team-1/roster"');
-  });
-
-  it("shows the directory to an owner too", async () => {
-    requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
-
-    const html = await render();
-
-    expect(html).toContain('href="/t/team-1/directory"');
   });
 });

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -2,6 +2,14 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { sortDirectory } from "@/lib/directory-rules";
+import { listCoachContacts } from "@/lib/memberships";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { getTeamById } from "@/lib/teams";
 
@@ -30,6 +38,15 @@ export default async function TeamHomePage({
   if (!team) {
     notFound();
   }
+
+  // Parents only: the coaching staff's contact card. /directory is
+  // coach-and-above, and its recorded escape hatch — "a parent who needs to
+  // reach someone goes through the coach" — needs the coach to be reachable
+  // in-app. listCoachContacts selects OWNER and COACH rows only, so nothing
+  // here is another family's data. Coaches and the owner get the full
+  // directory instead, so the card would be redundant for them.
+  const coachContacts =
+    role === "PARENT" ? sortDirectory(await listCoachContacts(teamId)) : [];
 
   return (
     <div className="space-y-6">
@@ -84,6 +101,47 @@ export default async function TeamHomePage({
           </Button>
         )}
       </div>
+
+      {coachContacts.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-foreground">Coaches</h3>
+          <ul className="space-y-2">
+            {coachContacts.map((coach) => (
+              <li key={coach.userId}>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">
+                      {coach.name ?? coach.email}{" "}
+                      <span className="text-sm font-normal text-muted-foreground">
+                        · {coach.role === "OWNER" ? "Owner" : "Coach"}
+                      </span>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-1 text-sm">
+                    <p>
+                      <a
+                        href={`mailto:${coach.email}`}
+                        className="text-foreground underline"
+                      >
+                        {coach.email}
+                      </a>
+                    </p>
+                    <p className="text-muted-foreground">
+                      {coach.phone ? (
+                        <a href={`tel:${coach.phone}`} className="underline">
+                          {coach.phone}
+                        </a>
+                      ) : (
+                        "—"
+                      )}
+                    </p>
+                  </CardContent>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -65,6 +65,12 @@ export default async function TeamHomePage({
             <Button asChild variant="outline">
               <Link href={`/t/${teamId}/chart`}>Edit batting order</Link>
             </Button>
+
+            {/* Coach-and-above: the directory is every family's contact
+                details, so a parent gets no link and no route to it. */}
+            <Button asChild variant="outline">
+              <Link href={`/t/${teamId}/directory`}>Directory</Link>
+            </Button>
           </>
         )}
 
@@ -73,18 +79,9 @@ export default async function TeamHomePage({
         </Button>
 
         {role === "OWNER" && (
-          <>
-            {/* Owner-only, alongside settings: the directory is every
-                family's contact details in one list, so coaches get no link
-                and no route to it either. */}
-            <Button asChild variant="outline">
-              <Link href={`/t/${teamId}/directory`}>Directory</Link>
-            </Button>
-
-            <Button asChild variant="outline">
-              <Link href={`/t/${teamId}/settings`}>Team settings</Link>
-            </Button>
-          </>
+          <Button asChild variant="outline">
+            <Link href={`/t/${teamId}/settings`}>Team settings</Link>
+          </Button>
         )}
       </div>
     </div>

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -65,12 +65,6 @@ export default async function TeamHomePage({
             <Button asChild variant="outline">
               <Link href={`/t/${teamId}/chart`}>Edit batting order</Link>
             </Button>
-
-            {/* Coach-and-above: the directory is every family's contact
-                details, so a parent gets no link and no route to it. */}
-            <Button asChild variant="outline">
-              <Link href={`/t/${teamId}/directory`}>Directory</Link>
-            </Button>
           </>
         )}
 
@@ -79,9 +73,18 @@ export default async function TeamHomePage({
         </Button>
 
         {role === "OWNER" && (
-          <Button asChild variant="outline">
-            <Link href={`/t/${teamId}/settings`}>Team settings</Link>
-          </Button>
+          <>
+            {/* Owner-only, alongside settings: the directory is every
+                family's contact details in one list, so coaches get no link
+                and no route to it either. */}
+            <Button asChild variant="outline">
+              <Link href={`/t/${teamId}/directory`}>Directory</Link>
+            </Button>
+
+            <Button asChild variant="outline">
+              <Link href={`/t/${teamId}/settings`}>Team settings</Link>
+            </Button>
+          </>
         )}
       </div>
     </div>

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -100,6 +100,12 @@ export default async function TeamHomePage({
             <Link href={`/t/${teamId}/settings`}>Team settings</Link>
           </Button>
         )}
+
+        {/* Everyone: your own name and phone, including the number the
+            coaching staff will call. Not team-scoped — see /profile. */}
+        <Button asChild variant="outline">
+          <Link href="/profile">Your profile</Link>
+        </Button>
       </div>
 
       {coachContacts.length > 0 && (

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -65,15 +65,17 @@ export default async function TeamHomePage({
             <Button asChild variant="outline">
               <Link href={`/t/${teamId}/chart`}>Edit batting order</Link>
             </Button>
+
+            {/* Coach-and-above: the directory is every family's contact
+                details, so a parent gets no link and no route to it. */}
+            <Button asChild variant="outline">
+              <Link href={`/t/${teamId}/directory`}>Directory</Link>
+            </Button>
           </>
         )}
 
         <Button asChild variant="outline">
           <Link href={`/t/${teamId}/roster`}>Roster</Link>
-        </Button>
-
-        <Button asChild variant="outline">
-          <Link href={`/t/${teamId}/directory`}>Directory</Link>
         </Button>
 
         {role === "OWNER" && (

--- a/src/app/t/[teamId]/roster/[entryId]/page.test.tsx
+++ b/src/app/t/[teamId]/roster/[entryId]/page.test.tsx
@@ -13,6 +13,14 @@ vi.mock("@/lib/roster", () => ({
   getRosterEntry: (...args: unknown[]) => getRosterEntry(...args),
 }));
 
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+import { TeamAccessError } from "@/lib/team-access";
+
 const BASE_ENTRY = {
   id: "entry-1",
   jerseyNumber: 7,
@@ -61,22 +69,7 @@ describe("Roster entry page", () => {
     expect(markup).toContain("Remove player");
   });
 
-  it("hides edit and remove controls for a parent", async () => {
-    requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
-    getRosterEntry.mockResolvedValue(BASE_ENTRY);
-
-    const { default: RosterEntryPage } = await import("./page");
-    const result = await RosterEntryPage({
-      params: Promise.resolve({ teamId: "team-1", entryId: "entry-1" }),
-      searchParams: Promise.resolve({}),
-    });
-
-    const markup = renderToStaticMarkup(result);
-    expect(markup).not.toContain("Remove player");
-    expect(markup).not.toContain("Save changes");
-  });
-
-  it("shows guardian contact details to a coach", async () => {
+  it("requires COACH and shows guardian contact details", async () => {
     requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
     getRosterEntry.mockResolvedValue(ENTRY_WITH_GUARDIAN);
 
@@ -88,30 +81,31 @@ describe("Roster entry page", () => {
       }),
     );
 
+    expect(requireTeamAccess).toHaveBeenCalledWith("team-1", {
+      intent: "read",
+      minRole: "COACH",
+    });
     expect(markup).toContain("Guardians");
     expect(markup).toContain("sam@example.com");
     expect(markup).toContain("555-1234");
   });
 
-  // The same rule /directory now follows: a parent reads the player, never
-  // another family's contact details.
-  it("hides the guardians card and its contact details from a parent", async () => {
-    requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
-    getRosterEntry.mockResolvedValue(ENTRY_WITH_GUARDIAN);
+  // The route is coach-and-above like /directory: the page is the roster
+  // admin surface and carries every linked guardian's contact details, so a
+  // parent gets a 404 — and the guardian data is never even fetched.
+  it("calls notFound() below COACH, before fetching the entry", async () => {
+    requireTeamAccess.mockRejectedValue(
+      new TeamAccessError("Requires COACH", "insufficient-role"),
+    );
 
     const { default: RosterEntryPage } = await import("./page");
-    const markup = renderToStaticMarkup(
-      await RosterEntryPage({
+
+    await expect(
+      RosterEntryPage({
         params: Promise.resolve({ teamId: "team-1", entryId: "entry-1" }),
         searchParams: Promise.resolve({}),
       }),
-    );
-
-    expect(markup).not.toContain("Guardians");
-    expect(markup).not.toContain("sam@example.com");
-    expect(markup).not.toContain("555-1234");
-    expect(markup).not.toContain("Sam");
-    // The player themself still renders.
-    expect(markup).toContain("Ada");
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(getRosterEntry).not.toHaveBeenCalled();
   });
 });

--- a/src/app/t/[teamId]/roster/[entryId]/page.test.tsx
+++ b/src/app/t/[teamId]/roster/[entryId]/page.test.tsx
@@ -20,6 +20,20 @@ const BASE_ENTRY = {
   guardians: [],
 };
 
+const ENTRY_WITH_GUARDIAN = {
+  ...BASE_ENTRY,
+  guardians: [
+    {
+      id: "user-9",
+      name: "Sam",
+      email: "sam@example.com",
+      phone: "555-1234",
+      isMember: true,
+      hasSignedIn: true,
+    },
+  ],
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -60,5 +74,44 @@ describe("Roster entry page", () => {
     const markup = renderToStaticMarkup(result);
     expect(markup).not.toContain("Remove player");
     expect(markup).not.toContain("Save changes");
+  });
+
+  it("shows guardian contact details to a coach", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
+    getRosterEntry.mockResolvedValue(ENTRY_WITH_GUARDIAN);
+
+    const { default: RosterEntryPage } = await import("./page");
+    const markup = renderToStaticMarkup(
+      await RosterEntryPage({
+        params: Promise.resolve({ teamId: "team-1", entryId: "entry-1" }),
+        searchParams: Promise.resolve({}),
+      }),
+    );
+
+    expect(markup).toContain("Guardians");
+    expect(markup).toContain("sam@example.com");
+    expect(markup).toContain("555-1234");
+  });
+
+  // The same rule /directory now follows: a parent reads the player, never
+  // another family's contact details.
+  it("hides the guardians card and its contact details from a parent", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
+    getRosterEntry.mockResolvedValue(ENTRY_WITH_GUARDIAN);
+
+    const { default: RosterEntryPage } = await import("./page");
+    const markup = renderToStaticMarkup(
+      await RosterEntryPage({
+        params: Promise.resolve({ teamId: "team-1", entryId: "entry-1" }),
+        searchParams: Promise.resolve({}),
+      }),
+    );
+
+    expect(markup).not.toContain("Guardians");
+    expect(markup).not.toContain("sam@example.com");
+    expect(markup).not.toContain("555-1234");
+    expect(markup).not.toContain("Sam");
+    // The player themself still renders.
+    expect(markup).toContain("Ada");
   });
 });

--- a/src/app/t/[teamId]/roster/[entryId]/page.tsx
+++ b/src/app/t/[teamId]/roster/[entryId]/page.tsx
@@ -50,10 +50,14 @@ function guardianStatus(guardian: RosterEntryGuardian): string {
   return guardian.hasSignedIn ? "Signed in" : "Invitation pending";
 }
 
-/// Every member reads. Editing and removal require COACH+, enforced both by
-/// hiding the controls here and by requireTeamAccess inside each action —
-/// this page's own check is "read" so a parent can still land here from the
-/// roster list, matching the settings-page pattern of read-to-view.
+/// Coach-and-above, like /directory: this page is the roster admin surface —
+/// jersey and DOB edits plus every linked guardian's name, email, and phone —
+/// and the roster list has never rendered its link to parents. Gating the
+/// whole route (rather than hiding the guardian card in JSX) makes the
+/// boundary structural: guardian contact details are only ever fetched for a
+/// caller already proven COACH+, so no future edit to this page's markup can
+/// leak them to a parent. Each mutating action re-checks COACH+ with write
+/// intent for itself.
 export default async function RosterEntryPage({
   params,
   searchParams,
@@ -64,9 +68,8 @@ export default async function RosterEntryPage({
   const { teamId, entryId } = await params;
   const { error, saved, invited } = await searchParams;
 
-  let role;
   try {
-    ({ role } = await requireTeamAccess(teamId, { intent: "read" }));
+    await requireTeamAccess(teamId, { intent: "read", minRole: "COACH" });
   } catch (caught) {
     if (caught instanceof TeamAccessError) {
       notFound();
@@ -79,7 +82,6 @@ export default async function RosterEntryPage({
     notFound();
   }
 
-  const canEdit = role !== "PARENT";
   const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
 
   return (
@@ -93,213 +95,201 @@ export default async function RosterEntryPage({
         </CardHeader>
 
         <CardContent>
-          {canEdit ? (
-            <form action={updateRosterEntryAction} className="space-y-4">
-              <input type="hidden" name="teamId" value={teamId} />
-              <input type="hidden" name="entryId" value={entryId} />
+          <form action={updateRosterEntryAction} className="space-y-4">
+            <input type="hidden" name="teamId" value={teamId} />
+            <input type="hidden" name="entryId" value={entryId} />
 
-              <div className="space-y-2">
-                <label htmlFor="name" className="block text-sm font-medium text-foreground">
-                  Name
-                </label>
-                <input
-                  id="name"
-                  name="name"
-                  type="text"
-                  required
-                  defaultValue={entry.player.name}
-                  aria-describedby={errorMessage ? "entry-error" : undefined}
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </div>
+            <div className="space-y-2">
+              <label htmlFor="name" className="block text-sm font-medium text-foreground">
+                Name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                required
+                defaultValue={entry.player.name}
+                aria-describedby={errorMessage ? "entry-error" : undefined}
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
 
-              <div className="space-y-2">
-                <label htmlFor="dateOfBirth" className="block text-sm font-medium text-foreground">
-                  Date of birth (optional)
-                </label>
-                <input
-                  id="dateOfBirth"
-                  name="dateOfBirth"
-                  type="date"
-                  defaultValue={toDateInputValue(entry.player.dateOfBirth)}
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </div>
+            <div className="space-y-2">
+              <label htmlFor="dateOfBirth" className="block text-sm font-medium text-foreground">
+                Date of birth (optional)
+              </label>
+              <input
+                id="dateOfBirth"
+                name="dateOfBirth"
+                type="date"
+                defaultValue={toDateInputValue(entry.player.dateOfBirth)}
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
 
-              <div className="space-y-2">
-                <label htmlFor="jerseyNumber" className="block text-sm font-medium text-foreground">
-                  Jersey number (optional)
-                </label>
-                <input
-                  id="jerseyNumber"
-                  name="jerseyNumber"
-                  type="number"
-                  min={0}
-                  max={99}
-                  defaultValue={entry.jerseyNumber ?? ""}
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-              </div>
+            <div className="space-y-2">
+              <label htmlFor="jerseyNumber" className="block text-sm font-medium text-foreground">
+                Jersey number (optional)
+              </label>
+              <input
+                id="jerseyNumber"
+                name="jerseyNumber"
+                type="number"
+                min={0}
+                max={99}
+                defaultValue={entry.jerseyNumber ?? ""}
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
 
-              {errorMessage ? (
-                <p id="entry-error" role="alert" className="text-sm text-destructive">
-                  {errorMessage}
-                </p>
-              ) : null}
-
-              {saved && !errorMessage ? (
-                <p role="status" className="text-sm text-muted-foreground">
-                  Saved.
-                </p>
-              ) : null}
-
-              <Button type="submit" className="w-full">
-                Save changes
-              </Button>
-            </form>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              {entry.player.dateOfBirth
-                ? `Born ${toDateInputValue(entry.player.dateOfBirth)}`
-                : "No date of birth on file."}
-            </p>
-          )}
-        </CardContent>
-      </Card>
-
-      {canEdit ? (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Guardians</CardTitle>
-            <CardDescription>
-              Guardians linked here get access to this team as parents, and are mailed an
-              invitation the first time they&apos;re linked to anyone on this team.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {invited && !errorMessage ? (
-              <p role="status" className="text-sm text-muted-foreground">
-                Invitation sent.
+            {errorMessage ? (
+              <p id="entry-error" role="alert" className="text-sm text-destructive">
+                {errorMessage}
               </p>
             ) : null}
 
-            {entry.guardians.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No guardians linked yet.</p>
-            ) : (
-              <ul className="space-y-2">
-                {entry.guardians.map((guardian) => (
-                  <li
-                    key={guardian.id}
-                    className="space-y-3 rounded-md border border-border p-3"
-                  >
-                    <div className="flex items-center justify-between gap-4">
-                      <div>
-                        <p className="text-sm font-medium text-foreground">
-                          {guardian.name ?? guardian.email}
-                        </p>
-                        <p className="text-sm text-muted-foreground">{guardian.email}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {guardianStatus(guardian)}
-                        </p>
-                      </div>
-                      <div className="flex shrink-0 gap-2">
-                        {!guardian.hasSignedIn ? (
-                          <form action={resendInvitationAction}>
-                            <input type="hidden" name="teamId" value={teamId} />
-                            <input type="hidden" name="entryId" value={entryId} />
-                            <input type="hidden" name="userId" value={guardian.id} />
-                            <Button type="submit" variant="outline" size="sm">
-                              Resend
-                            </Button>
-                          </form>
-                        ) : null}
-                        <form action={unlinkGuardianAction}>
+            {saved && !errorMessage ? (
+              <p role="status" className="text-sm text-muted-foreground">
+                Saved.
+              </p>
+            ) : null}
+
+            <Button type="submit" className="w-full">
+              Save changes
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Guardians</CardTitle>
+          <CardDescription>
+            Guardians linked here get access to this team as parents, and are mailed an
+            invitation the first time they&apos;re linked to anyone on this team.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {invited && !errorMessage ? (
+            <p role="status" className="text-sm text-muted-foreground">
+              Invitation sent.
+            </p>
+          ) : null}
+
+          {entry.guardians.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No guardians linked yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {entry.guardians.map((guardian) => (
+                <li
+                  key={guardian.id}
+                  className="space-y-3 rounded-md border border-border p-3"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        {guardian.name ?? guardian.email}
+                      </p>
+                      <p className="text-sm text-muted-foreground">{guardian.email}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {guardianStatus(guardian)}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 gap-2">
+                      {!guardian.hasSignedIn ? (
+                        <form action={resendInvitationAction}>
                           <input type="hidden" name="teamId" value={teamId} />
                           <input type="hidden" name="entryId" value={entryId} />
                           <input type="hidden" name="userId" value={guardian.id} />
                           <Button type="submit" variant="outline" size="sm">
-                            Unlink
+                            Resend
                           </Button>
                         </form>
-                      </div>
+                      ) : null}
+                      <form action={unlinkGuardianAction}>
+                        <input type="hidden" name="teamId" value={teamId} />
+                        <input type="hidden" name="entryId" value={entryId} />
+                        <input type="hidden" name="userId" value={guardian.id} />
+                        <Button type="submit" variant="outline" size="sm">
+                          Unlink
+                        </Button>
+                      </form>
                     </div>
-                    <form
-                      action={setGuardianPhoneAction}
-                      className="flex items-end gap-2 border-t border-border pt-3"
-                    >
-                      <input type="hidden" name="teamId" value={teamId} />
-                      <input type="hidden" name="entryId" value={entryId} />
-                      <input type="hidden" name="userId" value={guardian.id} />
-                      <div className="flex-1 space-y-1">
-                        <label
-                          htmlFor={`phone-${guardian.id}`}
-                          className="block text-xs font-medium text-foreground"
-                        >
-                          Phone
-                        </label>
-                        <input
-                          id={`phone-${guardian.id}`}
-                          name="phone"
-                          type="tel"
-                          defaultValue={guardian.phone ?? ""}
-                          placeholder="(555) 123-4567"
-                          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                        />
-                      </div>
-                      <Button type="submit" variant="outline" size="sm">
-                        Save phone
-                      </Button>
-                    </form>
-                  </li>
-                ))}
-              </ul>
-            )}
+                  </div>
+                  <form
+                    action={setGuardianPhoneAction}
+                    className="flex items-end gap-2 border-t border-border pt-3"
+                  >
+                    <input type="hidden" name="teamId" value={teamId} />
+                    <input type="hidden" name="entryId" value={entryId} />
+                    <input type="hidden" name="userId" value={guardian.id} />
+                    <div className="flex-1 space-y-1">
+                      <label
+                        htmlFor={`phone-${guardian.id}`}
+                        className="block text-xs font-medium text-foreground"
+                      >
+                        Phone
+                      </label>
+                      <input
+                        id={`phone-${guardian.id}`}
+                        name="phone"
+                        type="tel"
+                        defaultValue={guardian.phone ?? ""}
+                        placeholder="(555) 123-4567"
+                        className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </div>
+                    <Button type="submit" variant="outline" size="sm">
+                      Save phone
+                    </Button>
+                  </form>
+                </li>
+              ))}
+            </ul>
+          )}
 
-            <form action={linkGuardianAction} className="space-y-2 border-t border-border pt-4">
-              <input type="hidden" name="teamId" value={teamId} />
-              <input type="hidden" name="entryId" value={entryId} />
+          <form action={linkGuardianAction} className="space-y-2 border-t border-border pt-4">
+            <input type="hidden" name="teamId" value={teamId} />
+            <input type="hidden" name="entryId" value={entryId} />
 
-              <label htmlFor="guardianEmail" className="block text-sm font-medium text-foreground">
-                Add a guardian by email
-              </label>
-              <div className="flex gap-2">
-                <input
-                  id="guardianEmail"
-                  name="email"
-                  type="email"
-                  required
-                  placeholder="parent@example.com"
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-                <Button type="submit" variant="outline">
-                  Add
-                </Button>
-              </div>
-            </form>
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {canEdit ? (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Remove from roster</CardTitle>
-            <CardDescription>
-              Removes this player&apos;s spot on this team only. The player and their
-              guardians are not deleted.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form action={removeRosterEntryAction}>
-              <input type="hidden" name="teamId" value={teamId} />
-              <input type="hidden" name="entryId" value={entryId} />
-              <Button type="submit" variant="destructive">
-                Remove player
+            <label htmlFor="guardianEmail" className="block text-sm font-medium text-foreground">
+              Add a guardian by email
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="guardianEmail"
+                name="email"
+                type="email"
+                required
+                placeholder="parent@example.com"
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <Button type="submit" variant="outline">
+                Add
               </Button>
-            </form>
-          </CardContent>
-        </Card>
-      ) : null}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Remove from roster</CardTitle>
+          <CardDescription>
+            Removes this player&apos;s spot on this team only. The player and their
+            guardians are not deleted.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form action={removeRosterEntryAction}>
+            <input type="hidden" name="teamId" value={teamId} />
+            <input type="hidden" name="entryId" value={entryId} />
+            <Button type="submit" variant="destructive">
+              Remove player
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/app/t/[teamId]/roster/[entryId]/page.tsx
+++ b/src/app/t/[teamId]/roster/[entryId]/page.tsx
@@ -167,44 +167,41 @@ export default async function RosterEntryPage({
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Guardians</CardTitle>
-          <CardDescription>
-            Guardians linked here get access to this team as parents, and are mailed an
-            invitation the first time they&apos;re linked to anyone on this team.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {invited && !errorMessage ? (
-            <p role="status" className="text-sm text-muted-foreground">
-              Invitation sent.
-            </p>
-          ) : null}
+      {canEdit ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Guardians</CardTitle>
+            <CardDescription>
+              Guardians linked here get access to this team as parents, and are mailed an
+              invitation the first time they&apos;re linked to anyone on this team.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {invited && !errorMessage ? (
+              <p role="status" className="text-sm text-muted-foreground">
+                Invitation sent.
+              </p>
+            ) : null}
 
-          {entry.guardians.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No guardians linked yet.</p>
-          ) : (
-            <ul className="space-y-2">
-              {entry.guardians.map((guardian) => (
-                <li
-                  key={guardian.id}
-                  className="space-y-3 rounded-md border border-border p-3"
-                >
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <p className="text-sm font-medium text-foreground">
-                        {guardian.name ?? guardian.email}
-                      </p>
-                      <p className="text-sm text-muted-foreground">{guardian.email}</p>
-                      {!canEdit && guardian.phone ? (
-                        <p className="text-sm text-muted-foreground">{guardian.phone}</p>
-                      ) : null}
-                      <p className="text-xs text-muted-foreground">
-                        {guardianStatus(guardian)}
-                      </p>
-                    </div>
-                    {canEdit ? (
+            {entry.guardians.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No guardians linked yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {entry.guardians.map((guardian) => (
+                  <li
+                    key={guardian.id}
+                    className="space-y-3 rounded-md border border-border p-3"
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <div>
+                        <p className="text-sm font-medium text-foreground">
+                          {guardian.name ?? guardian.email}
+                        </p>
+                        <p className="text-sm text-muted-foreground">{guardian.email}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {guardianStatus(guardian)}
+                        </p>
+                      </div>
                       <div className="flex shrink-0 gap-2">
                         {!guardian.hasSignedIn ? (
                           <form action={resendInvitationAction}>
@@ -225,9 +222,7 @@ export default async function RosterEntryPage({
                           </Button>
                         </form>
                       </div>
-                    ) : null}
-                  </div>
-                  {canEdit ? (
+                    </div>
                     <form
                       action={setGuardianPhoneAction}
                       className="flex items-end gap-2 border-t border-border pt-3"
@@ -255,13 +250,11 @@ export default async function RosterEntryPage({
                         Save phone
                       </Button>
                     </form>
-                  ) : null}
-                </li>
-              ))}
-            </ul>
-          )}
+                  </li>
+                ))}
+              </ul>
+            )}
 
-          {canEdit ? (
             <form action={linkGuardianAction} className="space-y-2 border-t border-border pt-4">
               <input type="hidden" name="teamId" value={teamId} />
               <input type="hidden" name="entryId" value={entryId} />
@@ -283,9 +276,9 @@ export default async function RosterEntryPage({
                 </Button>
               </div>
             </form>
-          ) : null}
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      ) : null}
 
       {canEdit ? (
         <Card>

--- a/src/lib/memberships.test.ts
+++ b/src/lib/memberships.test.ts
@@ -29,13 +29,64 @@ vi.mock("./db", () => ({
   },
 }));
 
-import { LastOwnerError, listDirectory, listTeamMembers, setMemberRole } from "./memberships";
+import {
+  LastOwnerError,
+  listCoachContacts,
+  listDirectory,
+  listTeamMembers,
+  setMemberRole,
+} from "./memberships";
 
 beforeEach(() => {
   vi.clearAllMocks();
   transaction.mockImplementation((callback: (tx: unknown) => unknown) =>
     callback(tx),
   );
+});
+
+describe("listCoachContacts", () => {
+  it("filters to OWNER and COACH in the query itself", async () => {
+    findManyMemberships.mockResolvedValue([]);
+
+    await listCoachContacts("team-1");
+
+    expect(findManyMemberships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { teamId: "team-1", role: { in: ["OWNER", "COACH"] } },
+      }),
+    );
+  });
+
+  it("maps staff rows to flat contact records", async () => {
+    findManyMemberships.mockResolvedValue([
+      {
+        userId: "user-1",
+        role: "OWNER",
+        user: { name: "Mel", email: "mel@example.com", phone: "555-9876" },
+      },
+    ]);
+
+    const contacts = await listCoachContacts("team-1");
+
+    expect(contacts).toEqual([
+      {
+        userId: "user-1",
+        role: "OWNER",
+        name: "Mel",
+        email: "mel@example.com",
+        phone: "555-9876",
+      },
+    ]);
+  });
+
+  it("returns an empty list when the query fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    findManyMemberships.mockRejectedValue(new Error("boom"));
+
+    await expect(listCoachContacts("team-1")).resolves.toEqual([]);
+
+    consoleError.mockRestore();
+  });
 });
 
 describe("listTeamMembers", () => {

--- a/src/lib/memberships.ts
+++ b/src/lib/memberships.ts
@@ -41,6 +41,51 @@ export async function listTeamMembers(teamId: string): Promise<TeamMember[]> {
   }
 }
 
+export type CoachContact = {
+  userId: string;
+  role: Role;
+  name: string | null;
+  email: string;
+  phone: string | null;
+};
+
+/**
+ * The coaching staff — OWNER and COACH rows only — with contact details.
+ *
+ * This is the one slice of the directory a parent may read. /directory is
+ * coach-and-above because it holds every family's contact details, and the
+ * recorded escape hatch is "a parent who needs to reach someone goes through
+ * the coach" — which only works if the coach is reachable. The role filter
+ * in the query (not in the caller) is the boundary: no PARENT row and no
+ * player link can leave the database through this function.
+ */
+export async function listCoachContacts(teamId: string): Promise<CoachContact[]> {
+  try {
+    const memberships = await db.membership.findMany({
+      where: { teamId, role: { in: ["OWNER", "COACH"] } },
+      select: {
+        userId: true,
+        role: true,
+        user: {
+          select: { name: true, email: true, phone: true },
+        },
+      },
+    });
+
+    return memberships.map((m) => ({
+      userId: m.userId,
+      role: m.role,
+      name: m.user.name,
+      email: m.user.email,
+      phone: m.user.phone,
+    }));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("Failed to fetch coach contacts:", message);
+    return [];
+  }
+}
+
 export type DirectoryEntry = {
   userId: string;
   role: Role;

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const findUniqueUser = vi.fn();
+const updateUser = vi.fn();
+
+vi.mock("./db", () => ({
+  db: {
+    user: {
+      findUnique: (...args: unknown[]) => findUniqueUser(...args),
+      update: (...args: unknown[]) => updateUser(...args),
+    },
+  },
+}));
+
+import { getProfile, updateProfile } from "./profile";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getProfile", () => {
+  it("reads only the caller's own row, and only profile columns", async () => {
+    findUniqueUser.mockResolvedValue({
+      name: "Sam",
+      email: "sam@example.com",
+      phone: "555-1234",
+    });
+
+    const profile = await getProfile("user-1");
+
+    expect(findUniqueUser).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: { name: true, email: true, phone: true },
+    });
+    expect(profile).toEqual({
+      name: "Sam",
+      email: "sam@example.com",
+      phone: "555-1234",
+    });
+  });
+
+  // Unlike the list reads in teams.ts and memberships.ts, this one does not
+  // swallow errors: a blank phone field would read as "no number on file",
+  // which is the opposite of what an outage means.
+  it("lets a database error propagate rather than reporting an empty profile", async () => {
+    findUniqueUser.mockRejectedValue(new Error("connection lost"));
+
+    await expect(getProfile("user-1")).rejects.toThrow("connection lost");
+  });
+});
+
+describe("updateProfile", () => {
+  it("writes name and phone to the given user", async () => {
+    updateUser.mockResolvedValue({});
+
+    await updateProfile("user-1", { name: "Sam", phone: "555-1234" });
+
+    expect(updateUser).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { name: "Sam", phone: "555-1234" },
+    });
+  });
+
+  it("clears both fields when handed nulls", async () => {
+    updateUser.mockResolvedValue({});
+
+    await updateProfile("user-1", { name: null, phone: null });
+
+    expect(updateUser).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { name: null, phone: null },
+    });
+  });
+
+  it("never writes email", async () => {
+    updateUser.mockResolvedValue({});
+
+    await updateProfile("user-1", { name: "Sam", phone: null });
+
+    const [{ data }] = updateUser.mock.calls[0] as [{ data: object }];
+    expect(data).not.toHaveProperty("email");
+  });
+});

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,0 +1,59 @@
+import { db } from "./db";
+
+/// The signed-in person's own record.
+///
+/// `User.name` and `User.phone` are global columns — a person is one person
+/// across every team they touch — so this module takes no teamId and is
+/// deliberately not team-scoped. It reads and writes exactly one row: the one
+/// whose id the caller already proved is theirs via `getCurrentUser`. There is
+/// no "look up another user's profile" function here on purpose; the two
+/// staff-facing views of someone else's contact details are `listDirectory`
+/// and the roster entry page, both gated at COACH.
+
+export type Profile = {
+  name: string | null;
+  email: string;
+  phone: string | null;
+};
+
+export type ProfileUpdate = {
+  name: string | null;
+  phone: string | null;
+};
+
+/**
+ * Load one person's own profile.
+ *
+ * A database error propagates rather than being caught and reported as an
+ * empty profile — the same posture as `requireTeamAccess`, and it matters
+ * more here than on a list page. This page's whole job is to answer "what
+ * number does the team have for me"; rendering a blank field on a failed
+ * read would answer "none on file", which is a different and wrong answer.
+ */
+export async function getProfile(userId: string): Promise<Profile | null> {
+  return db.user.findUnique({
+    where: { id: userId },
+    select: { name: true, email: true, phone: true },
+  });
+}
+
+/**
+ * Update one person's own name and phone.
+ *
+ * `email` is deliberately absent: it is the magic-link identity Auth.js keys
+ * sessions and invitations on, so changing it is an account migration rather
+ * than a profile edit.
+ *
+ * Last write wins against a coach editing the same person's phone from a
+ * roster entry page. That race is acceptable — both writers are entering the
+ * number they believe is right, and the person themself is the better source.
+ */
+export async function updateProfile(
+  userId: string,
+  { name, phone }: ProfileUpdate,
+): Promise<void> {
+  await db.user.update({
+    where: { id: userId },
+    data: { name, phone },
+  });
+}

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -10,6 +10,25 @@ import { db } from "./db";
 /// staff-facing views of someone else's contact details are `listDirectory`
 /// and the roster entry page, both gated at COACH.
 
+/// **Every page that renders `User.name` or `User.phone`.** `updateProfileAction`
+/// revalidates this list, and it is the list to check against when adding a
+/// page that shows a person's name or phone — a new consumer that is not
+/// revalidated serves the old value until something else happens to bust the
+/// cache, which is invisible in tests and looks like "the save didn't work".
+///
+/// | Page | Reads | Audience |
+/// |---|---|---|
+/// | `/` | name | the person themself ("Welcome back, …") |
+/// | `/profile` | name, phone | the person themself |
+/// | `/t/[teamId]` | name, phone | parents, via `listCoachContacts` — staff only |
+/// | `/t/[teamId]/directory` | name, phone | COACH+, via `listDirectory` |
+/// | `/t/[teamId]/roster/[entryId]` | name, phone | COACH+, via `getRosterEntry` |
+/// | `/t/[teamId]/members` | name | OWNER, via `listTeamMembers` |
+///
+/// `email` is absent deliberately: it is not editable here, so no page goes
+/// stale on it. `/t/[teamId]/roster/invite` reads guardian *emails* only and
+/// so is not on this list.
+
 export type Profile = {
   name: string | null;
   email: string;

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -16,7 +16,7 @@ function request(path: string, cookies: Record<string, string> = {}) {
 }
 
 describe("proxy", () => {
-  it("only runs on team-scoped routes", () => {
+  it("runs on the signed-in-only routes: team-scoped pages and /profile", () => {
     expect(config.matcher).toEqual(["/t/:path*", "/profile"]);
   });
 

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -17,7 +17,7 @@ function request(path: string, cookies: Record<string, string> = {}) {
 
 describe("proxy", () => {
   it("only runs on team-scoped routes", () => {
-    expect(config.matcher).toBe("/t/:path*");
+    expect(config.matcher).toEqual(["/t/:path*", "/profile"]);
   });
 
   it("redirects to sign-in when no session cookie is present", () => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -44,6 +44,10 @@ export function proxy(request: NextRequest) {
   return NextResponse.redirect(signInUrl);
 }
 
+/// `/profile` is matched alongside the team routes: it is signed-in-only and
+/// shows the person their own contact details. `/invite/[token]` stays out,
+/// deliberately — accepting an invitation is how someone gets a session in
+/// the first place.
 export const config = {
-  matcher: "/t/:path*",
+  matcher: ["/t/:path*", "/profile"],
 };


### PR DESCRIPTION
A parent signed into a team could open `/t/[teamId]/directory` and read every
other family's name, phone, and email. That was the shipped intent ("visible to
all signed-in members" in the product brief), but it is the wrong call for a
team of kids: a parent has no reason to hold the whole roster's contact details.

## Contact details are now staff-facing

- **`/directory` requires `minRole: "COACH"`.** Nothing links there for a parent,
  and a pasted URL raises `insufficient-role`, which the loader already turns
  into a 404 — the same shape as the chart editors.
- **`/t/[teamId]/roster/[entryId]` is COACH+ too.** It had the same exposure one
  tap at a time: its Guardians card rendered every linked guardian's name, email,
  phone, and invitation status, and the parent-reachable read view was reachable
  only by pasting a URL — where it showed another family's child's name, jersey,
  and date of birth. Gating the route rather than hiding the card in JSX makes
  the boundary structural: guardian PII is never fetched for a caller below
  COACH, so no future edit to the markup can leak it.
- **Parents get a coaching-staff contact card** on the team home page. The rule's
  escape hatch — "a parent who needs to reach someone goes through the coach" —
  had no implemented path, since no parent-visible page rendered any email or
  phone. `listCoachContacts` filters to OWNER/COACH rows in the query itself, so
  no other family's data can leave the database through it.
- Schedule, lineup, roster list, and RSVP are unchanged for parents.

## A self-serve profile

Closing those two surfaces removed the last screen where a person could read
back what the team has on file for them, so a coach's typo in a phone number
became undetectable by the one person who knows it is wrong. `/profile` shows
the signed-in person their name, phone, and sign-in email, and saves the first
two. It is global rather than team-scoped, because those are `User` columns —
one per person, not per team. Email stays read-only: it is the magic-link
identity, so changing it is an account migration, not a profile edit.

`updateProfileAction` takes the userId from the session and never the form, so
there is no id to forge and the action needs no team-access check — an archived
team must not stop someone correcting their own phone number.

## Notes

- The product brief's directory bullet is revised in place, with the prior
  wording preserved, since this reverses a decision it recorded rather than
  drifting from it. Owner-only was considered and rejected: coaches already read
  contact details family-by-family through the roster pages their job requires,
  so excluding them would remove the convenient list without removing the
  access, while leaving an assistant coach at the field unable to call a parent.
- One consequence worth naming: no parent now sees a date of birth anywhere.
  Previously any parent could read any child's DOB by pasting a roster-entry
  URL, which is the leak this closes; a parent already knows their own kid's
  birthday.
- `pnpm check` passes: lint, typecheck, and 807 tests.
