### PR TITLE
Persistent team nav, and a lineup chart that outlives the schedule

### DIFF
--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -208,6 +208,13 @@ All inside the existing viewBox — `DIAMOND_GEOMETRY.width = 400`,
 wordmark, one banana button ("Email me a magic link"), and a tiny flat field illustration
 (a cropped reuse of `FieldArt`). Empty-state copy: "The gate's open."
 
+**Team chrome (post-ship addition)** — every `/t/[teamId]` view now carries a persistent
+`TeamNav` in the team layout: pill tabs on the header band, the active section filled
+Field Green, the rest on card stock with a warm border. Deliberately no banana in the
+nav — it appears on every screen, and a yellow tab would spend the one-banana budget
+everywhere at once. The old wall of outline buttons on the team home was retired in its
+favor.
+
 **Team home + `TeamCard`** — cards become **pennant cards**: small felt-green pennant
 glyph, slab team name, warm card stock. Archived teams go sepia and desaturated — a
 retired jersey — instead of just being text-muted. The badge keeps the word **Archived**:
@@ -226,7 +233,9 @@ a ⚾ micro-animation (Motion, `prefers-reduced-motion`-gated).
 
 **Lineup view (`/view`)** — the payoff page. The full-field diamond above; batting order
 as **dugout roster rows** (sketch B): jersey-dot slot number, name, RSVP pill. The
-existing `Reveal` staggers rows in like a lineup being announced.
+existing `Reveal` staggers rows in like a lineup being announced. The standing chart
+renders even with no game on the schedule (it's standing, not per-game); only the RSVP
+tags and legend are per-game and come off when there's nothing to respond to.
 
 **Chart editors** — restraint zone; dnd-kit owns every dragged element (the AGENTS.md
 rule), so flair goes only into *static* styling: field art behind the position targets,

--- a/src/app/t/[teamId]/layout.tsx
+++ b/src/app/t/[teamId]/layout.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { TeamNav } from "@/components/TeamNav";
 import { TeamSwitcher } from "@/components/TeamSwitcher";
+import type { Role } from "@/generated/prisma/enums";
 import { isOwnerEmail } from "@/lib/owner";
 import { getCurrentUser } from "@/lib/session";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
@@ -31,7 +32,7 @@ export default async function TeamLayout({
 }) {
   const { teamId } = await params;
 
-  let role;
+  let role: Role;
   try {
     ({ role } = await requireTeamAccess(teamId, { intent: "read" }));
   } catch (error) {

--- a/src/app/t/[teamId]/layout.tsx
+++ b/src/app/t/[teamId]/layout.tsx
@@ -1,7 +1,9 @@
 import type { ReactNode } from "react";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { PageContainer } from "@/components/layout/PageContainer";
+import { TeamNav } from "@/components/TeamNav";
 import { TeamSwitcher } from "@/components/TeamSwitcher";
 import { isOwnerEmail } from "@/lib/owner";
 import { getCurrentUser } from "@/lib/session";
@@ -29,8 +31,9 @@ export default async function TeamLayout({
 }) {
   const { teamId } = await params;
 
+  let role;
   try {
-    await requireTeamAccess(teamId, { intent: "read" });
+    ({ role } = await requireTeamAccess(teamId, { intent: "read" }));
   } catch (error) {
     if (error instanceof TeamAccessError) {
       notFound();
@@ -57,9 +60,19 @@ export default async function TeamLayout({
 
   return (
     <PageContainer>
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-4 border-b border-border pb-4">
-        <h2 className="font-display text-2xl text-foreground">{team.name}</h2>
-        <TeamSwitcher teams={switcherTeams} currentTeamId={teamId} />
+      {/* The team's own header band: name, switcher, and the persistent nav.
+          TeamNav's role prop only decides which links render — every page
+          underneath still calls requireTeamAccess for itself. */}
+      <div className="mb-6 space-y-4 border-b-2 border-border pb-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <Link href={`/t/${teamId}`}>
+            <h2 className="font-display text-2xl text-foreground">
+              {team.name}
+            </h2>
+          </Link>
+          <TeamSwitcher teams={switcherTeams} currentTeamId={teamId} />
+        </div>
+        <TeamNav teamId={teamId} role={role} />
       </div>
       {children}
     </PageContainer>

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -44,40 +44,30 @@ beforeEach(() => {
   });
 });
 
-describe("TeamHomePage navigation", () => {
-  it("shows a coach the coach links but not owner-only ones", async () => {
+describe("TeamHomePage", () => {
+  // Navigation moved to the layout's persistent TeamNav — its role gating is
+  // covered in src/components/TeamNav.test.tsx. The page itself renders team
+  // facts only, so the old button grid must not creep back in.
+  it("renders the team facts and no navigation links of its own", async () => {
     const html = await render();
 
-    expect(html).toContain('href="/t/team-1/readiness"');
-    expect(html).toContain('href="/t/team-1/chart"');
-    expect(html).toContain('href="/t/team-1/directory"');
-    expect(html).toContain('href="/t/team-1/roster"');
-    expect(html).not.toContain('href="/t/team-1/settings"');
+    expect(html).toContain("Fall 2026");
+    expect(html).toContain("All players bat and field");
+    expect(html).not.toContain('href="/t/team-1/');
   });
 
-  it("shows a parent only the parent links", async () => {
-    requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
+  it("flags an archived team as read-only", async () => {
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sluggers",
+      season: "Fall 2026",
+      allPlay: true,
+      archivedAt: new Date("2026-01-01T00:00:00Z"),
+    });
 
     const html = await render();
 
-    expect(html).not.toContain('href="/t/team-1/readiness"');
-    expect(html).not.toContain('href="/t/team-1/chart"');
-    expect(html).not.toContain('href="/t/team-1/directory"');
-    expect(html).not.toContain('href="/t/team-1/settings"');
-    // The parent's own surfaces are unaffected.
-    expect(html).toContain('href="/t/team-1/view"');
-    expect(html).toContain('href="/t/team-1/roster"');
-    expect(html).toContain('href="/t/team-1/schedule"');
-  });
-
-  it("shows an owner the coach links plus settings", async () => {
-    requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
-
-    const html = await render();
-
-    expect(html).toContain('href="/t/team-1/readiness"');
-    expect(html).toContain('href="/t/team-1/directory"');
-    expect(html).toContain('href="/t/team-1/settings"');
+    expect(html).toContain("archived and read-only");
   });
 });
 

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import type { Role } from "@/generated/prisma/enums";
 import { sortDirectory } from "@/lib/directory-rules";
 import { listCoachContacts } from "@/lib/memberships";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
@@ -22,7 +23,7 @@ export default async function TeamHomePage({
 }) {
   const { teamId } = await params;
 
-  let role;
+  let role: Role;
   try {
     ({ role } = await requireTeamAccess(teamId, { intent: "read" }));
   } catch (error) {

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -1,7 +1,5 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -64,53 +62,10 @@ export default async function TeamHomePage({
         )}
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        <Button asChild variant="outline">
-          <Link href={`/t/${teamId}/schedule`}>Schedule</Link>
-        </Button>
-
-        {/* The payoff page gets this screen's one banana (design-plan.md §2). */}
-        <Button
-          asChild
-          className="bg-banana text-banana-foreground hover:bg-banana/90"
-        >
-          <Link href={`/t/${teamId}/view`}>Lineup</Link>
-        </Button>
-
-        {role !== "PARENT" && (
-          <>
-            <Button asChild variant="outline">
-              <Link href={`/t/${teamId}/readiness`}>Next-game readiness</Link>
-            </Button>
-
-            <Button asChild variant="outline">
-              <Link href={`/t/${teamId}/chart`}>Edit batting order</Link>
-            </Button>
-
-            {/* Coach-and-above: the directory is every family's contact
-                details, so a parent gets no link and no route to it. */}
-            <Button asChild variant="outline">
-              <Link href={`/t/${teamId}/directory`}>Directory</Link>
-            </Button>
-          </>
-        )}
-
-        <Button asChild variant="outline">
-          <Link href={`/t/${teamId}/roster`}>Roster</Link>
-        </Button>
-
-        {role === "OWNER" && (
-          <Button asChild variant="outline">
-            <Link href={`/t/${teamId}/settings`}>Team settings</Link>
-          </Button>
-        )}
-
-        {/* Everyone: your own name and phone, including the number the
-            coaching staff will call. Not team-scoped — see /profile. */}
-        <Button asChild variant="outline">
-          <Link href="/profile">Your profile</Link>
-        </Button>
-      </div>
+      {/* Navigation used to live here as a wall of outline buttons; it is now
+          the persistent TeamNav in the /t/[teamId] layout, on every team view.
+          Role-gated links (directory, settings) are gated there — and, as
+          always, enforced by each page itself. */}
 
       {coachContacts.length > 0 && (
         <div className="space-y-2">

--- a/src/app/t/[teamId]/roster/page.tsx
+++ b/src/app/t/[teamId]/roster/page.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import type { Role } from "@/generated/prisma/enums";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { getRoster } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
@@ -42,7 +43,7 @@ export default async function RosterPage({
   const { teamId } = await params;
   const { error, added } = await searchParams;
 
-  let role;
+  let role: Role;
   try {
     ({ role } = await requireTeamAccess(teamId, { intent: "read" }));
   } catch (caught) {

--- a/src/app/t/[teamId]/schedule/[eventId]/page.tsx
+++ b/src/app/t/[teamId]/schedule/[eventId]/page.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import type { Role } from "@/generated/prisma/enums";
 import { formatEventDateTime, instantToWallClock } from "@/lib/calendar";
 import { getRoster } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
@@ -52,7 +53,7 @@ export default async function EventPage({
   const { teamId, eventId } = await params;
   const { error, saved, confirm } = await searchParams;
 
-  let role;
+  let role: Role;
   let userId;
   try {
     ({ role, userId } = await requireTeamAccess(teamId, { intent: "read" }));

--- a/src/app/t/[teamId]/schedule/page.tsx
+++ b/src/app/t/[teamId]/schedule/page.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import type { Role } from "@/generated/prisma/enums";
 import {
   adjacentMonth,
   bucketEventsByDay,
@@ -76,7 +77,7 @@ export default async function SchedulePage({
   const { teamId } = await params;
   const { view: rawView, month: rawMonth, past, error, added } = await searchParams;
 
-  let role;
+  let role: Role;
   try {
     ({ role } = await requireTeamAccess(teamId, { intent: "read" }));
   } catch (caught) {

--- a/src/app/t/[teamId]/view/Diamond.tsx
+++ b/src/app/t/[teamId]/view/Diamond.tsx
@@ -43,11 +43,13 @@ function Marker({
   y,
   label,
   player,
+  showRsvp,
 }: {
   x: number;
   y: number;
   label: string;
   player: ChartViewPlayer | undefined;
+  showRsvp: boolean;
 }) {
   const style = player ? RSVP_STYLE[player.rsvpState] : null;
 
@@ -90,7 +92,7 @@ function Marker({
         {player ? shortName(player.playerName) : "Open"}
       </text>
 
-      {style ? (
+      {style && showRsvp ? (
         <text
           y={TAG_OFFSET}
           textAnchor="middle"
@@ -108,6 +110,7 @@ export function Diamond({
   byPosition,
   allPlay,
   outfield = [],
+  showRsvp = true,
 }: {
   /// Seated players, keyed by position. Only ever holds spots this team
   /// fields — `buildChartView` pools the rest, including an allPlay team's
@@ -118,6 +121,10 @@ export function Diamond({
   /// Everyone the diamond doesn't seat. Drawn as the outfield zone on an
   /// allPlay team, and ignored otherwise — a benched player belongs on neither.
   outfield?: readonly ChartViewPlayer[];
+  /// False when there is no upcoming game to respond to: the chart still
+  /// draws, but the per-player RSVP tags come off — "No response" against no
+  /// game would read as a team-wide silence rather than a bye week.
+  showRsvp?: boolean;
 }) {
   // An allPlay team fields neither a catcher nor three named outfielders: the
   // coach pitches, and the outfield is one zone holding everyone the infield
@@ -154,6 +161,7 @@ export function Diamond({
               y={y}
               label={POSITION_LABELS[position]}
               player={byPosition.get(position)}
+              showRsvp={showRsvp}
             />
           );
         })}
@@ -165,6 +173,7 @@ export function Diamond({
             y={zoneCoords[index].y}
             label={OUTFIELD_ZONE_LABEL}
             player={player}
+            showRsvp={showRsvp}
           />
         ))}
       </svg>
@@ -177,7 +186,9 @@ export function Diamond({
             <li key={position}>
               {POSITION_LABELS[position]}:{" "}
               {player
-                ? `${player.playerName}, ${RSVP_STYLE[player.rsvpState].label}`
+                ? showRsvp
+                  ? `${player.playerName}, ${RSVP_STYLE[player.rsvpState].label}`
+                  : player.playerName
                 : "Open"}
             </li>
           );
@@ -186,9 +197,10 @@ export function Diamond({
           <li>
             Outfield:{" "}
             {zone
-              .map(
-                (player) =>
-                  `${player.playerName}, ${RSVP_STYLE[player.rsvpState].label}`,
+              .map((player) =>
+                showRsvp
+                  ? `${player.playerName}, ${RSVP_STYLE[player.rsvpState].label}`
+                  : player.playerName,
               )
               .join("; ")}
           </li>

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -137,7 +137,6 @@ describe("ViewPage with no upcoming game", () => {
 });
 
 describe("ViewPage empty states", () => {
-
   it("shows a no-chart-set-yet empty state when every roster entry is benched", async () => {
     getChart.mockResolvedValue([
       {

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -100,15 +100,43 @@ describe("ViewPage access", () => {
   });
 });
 
-describe("ViewPage empty states", () => {
-  it("shows a no-upcoming-game empty state and never calls the chart reads", async () => {
+describe("ViewPage with no upcoming game", () => {
+  // The chart is standing, not per-game — it outlives the schedule, so a
+  // parent between games (or after the season's last one) still sees it.
+  it("still shows the standing chart under a no-upcoming-game header", async () => {
     nextGame.mockResolvedValue(null);
 
     const html = await render();
 
     expect(html).toContain("No upcoming game");
-    expect(getChart).not.toHaveBeenCalled();
+    expect(html).toContain("Ava");
+    expect(html).toContain("Batting order");
+    expect(html).toContain(">SS<");
   });
+
+  it("drops every RSVP decoration — there is no game to respond to", async () => {
+    nextGame.mockResolvedValue(null);
+
+    const html = await render();
+
+    expect(listEventRsvps).not.toHaveBeenCalled();
+    expect(html).not.toContain("No response");
+    expect(html).not.toContain("Going");
+    expect(html).not.toContain("RSVP is just for planning");
+  });
+
+  it("shows the no-chart empty state when there is no game and no chart", async () => {
+    nextGame.mockResolvedValue(null);
+    getChart.mockResolvedValue([]);
+
+    const html = await render();
+
+    expect(html).toContain("No upcoming game");
+    expect(html).toContain("No chart set yet");
+  });
+});
+
+describe("ViewPage empty states", () => {
 
   it("shows a no-chart-set-yet empty state when every roster entry is benched", async () => {
     getChart.mockResolvedValue([

--- a/src/app/t/[teamId]/view/page.tsx
+++ b/src/app/t/[teamId]/view/page.tsx
@@ -53,29 +53,15 @@ export default async function ViewPage({
 
   // Deliberately NOT wrapped in try/catch — nextGame's contract is that a
   // database outage propagates rather than rendering the same "no upcoming
-  // game" empty state a healthy team would show on a bye week.
+  // game" header a healthy team would show on a bye week.
   const game = await nextGame(teamId);
 
-  if (!game) {
-    return (
-      <div className="mx-auto w-full max-w-md space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>No upcoming game</CardTitle>
-            <CardDescription>
-              The lineup shows up here once a game is on the schedule. Enjoy
-              the day off.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button asChild variant="outline">
-              <Link href={`/t/${teamId}/schedule`}>Go to schedule</Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
+  // The chart is standing, not per-game (AGENTS.md rule 2), so it renders
+  // with or without a game on the schedule — a parent between seasons still
+  // sees where their kid plays. Only the RSVP decoration is per-game: with no
+  // game there is nothing to respond to, so `showRsvp` strips the tags and
+  // the legend rather than stamping "No response" on the whole team.
+  const showRsvp = game !== null;
 
   const [team, chartEntries, rsvpRows] = await Promise.all([
     // Needed for allPlay alone: it decides whether an unplaced player is in
@@ -85,7 +71,7 @@ export default async function ViewPage({
     // 404ing a page that already passed its access check.
     getTeamById(teamId),
     getChart(teamId),
-    listEventRsvps(teamId, game.id),
+    game ? listEventRsvps(teamId, game.id) : Promise.resolve([]),
   ]);
 
   const rsvpStates = buildRsvpStateMap(
@@ -94,21 +80,42 @@ export default async function ViewPage({
   );
   const chart = buildChartView(chartEntries, rsvpStates, team?.allPlay ?? true);
 
-  const heading = game.opponent ? `Next game vs ${game.opponent}` : "Next game";
+  const heading = game?.opponent
+    ? `Next game vs ${game.opponent}`
+    : "Next game";
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>{heading}</CardTitle>
-          <CardDescription>{formatEventDateTime(game.startsAt)}</CardDescription>
-        </CardHeader>
-        {game.location ? (
+      {game ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>{heading}</CardTitle>
+            <CardDescription>
+              {formatEventDateTime(game.startsAt)}
+            </CardDescription>
+          </CardHeader>
+          {game.location ? (
+            <CardContent>
+              <p className="text-sm text-foreground">{game.location}</p>
+            </CardContent>
+          ) : null}
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>No upcoming game</CardTitle>
+            <CardDescription>
+              Nothing is on the schedule right now — this is the standing
+              chart, ready for the next one.
+            </CardDescription>
+          </CardHeader>
           <CardContent>
-            <p className="text-sm text-foreground">{game.location}</p>
+            <Button asChild variant="outline">
+              <Link href={`/t/${teamId}/schedule`}>Go to schedule</Link>
+            </Button>
           </CardContent>
-        ) : null}
-      </Card>
+        </Card>
+      )}
 
       {!chart.hasChart ? (
         <Card>
@@ -131,6 +138,7 @@ export default async function ViewPage({
                   byPosition={chart.byPosition}
                   allPlay={team?.allPlay ?? true}
                   outfield={chart.unassigned}
+                  showRsvp={showRsvp}
                 />
               </CardContent>
             </Card>
@@ -172,9 +180,11 @@ export default async function ViewPage({
                               ) : null}
                             </span>
                           </div>
-                          <span className={`text-xs ${style.tagClassName}`}>
-                            {style.label}
-                          </span>
+                          {showRsvp ? (
+                            <span className={`text-xs ${style.tagClassName}`}>
+                              {style.label}
+                            </span>
+                          ) : null}
                         </li>
                       );
                     })}
@@ -184,22 +194,27 @@ export default async function ViewPage({
             </Card>
           </div>
 
-          <StitchDivider className="mt-6" />
+          {showRsvp ? (
+            <>
+              <StitchDivider className="mt-6" />
 
-          <p className="mt-3 text-xs text-muted-foreground">
-            <span className={RSVP_STYLE.attending.tagClassName}>
-              {RSVP_STYLE.attending.label}
-            </span>{" "}
-            ·{" "}
-            <span className={RSVP_STYLE.declined.tagClassName}>
-              {RSVP_STYLE.declined.label}
-            </span>{" "}
-            ·{" "}
-            <span className={RSVP_STYLE["no-response"].tagClassName}>
-              {RSVP_STYLE["no-response"].label}
-            </span>{" "}
-            — RSVP is just for planning. Everyone stays in their slot either way.
-          </p>
+              <p className="mt-3 text-xs text-muted-foreground">
+                <span className={RSVP_STYLE.attending.tagClassName}>
+                  {RSVP_STYLE.attending.label}
+                </span>{" "}
+                ·{" "}
+                <span className={RSVP_STYLE.declined.tagClassName}>
+                  {RSVP_STYLE.declined.label}
+                </span>{" "}
+                ·{" "}
+                <span className={RSVP_STYLE["no-response"].tagClassName}>
+                  {RSVP_STYLE["no-response"].label}
+                </span>{" "}
+                — RSVP is just for planning. Everyone stays in their slot
+                either way.
+              </p>
+            </>
+          ) : null}
         </Reveal>
       )}
     </div>

--- a/src/components/TeamNav.test.tsx
+++ b/src/components/TeamNav.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const usePathname = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => usePathname(),
+}));
+
+import { TeamNav } from "./TeamNav";
+import type { Role } from "@/generated/prisma/enums";
+
+function render(role: Role, pathname = "/t/team-1") {
+  usePathname.mockReturnValue(pathname);
+  return renderToStaticMarkup(<TeamNav teamId="team-1" role={role} />);
+}
+
+/// Pulls the rendered anchor for one href so assertions about active state
+/// read the attribute on the right link, not anywhere in the markup.
+function linkFor(html: string, href: string): string {
+  const match = html.match(new RegExp(`<a[^>]*href="${href}"[^>]*>`));
+  expect(match, `expected a link to ${href}`).not.toBeNull();
+  return match![0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TeamNav role gating", () => {
+  it("shows a parent only the shared links", () => {
+    const html = render("PARENT");
+
+    for (const href of [
+      "/t/team-1",
+      "/t/team-1/schedule",
+      "/t/team-1/view",
+      "/t/team-1/roster",
+      "/profile",
+    ]) {
+      expect(html).toContain(`href="${href}"`);
+    }
+    expect(html).not.toContain('href="/t/team-1/readiness"');
+    expect(html).not.toContain('href="/t/team-1/chart"');
+    expect(html).not.toContain('href="/t/team-1/directory"');
+    expect(html).not.toContain('href="/t/team-1/settings"');
+  });
+
+  it("shows a coach the coach links but not settings", () => {
+    const html = render("COACH");
+
+    expect(html).toContain('href="/t/team-1/readiness"');
+    expect(html).toContain('href="/t/team-1/chart"');
+    expect(html).toContain('href="/t/team-1/directory"');
+    expect(html).not.toContain('href="/t/team-1/settings"');
+  });
+
+  it("shows the owner everything including settings", () => {
+    const html = render("OWNER");
+
+    expect(html).toContain('href="/t/team-1/settings"');
+  });
+});
+
+describe("TeamNav active tab", () => {
+  it("marks the current section with aria-current", () => {
+    const html = render("PARENT", "/t/team-1/schedule");
+
+    expect(linkFor(html, "/t/team-1/schedule")).toContain('aria-current="page"');
+    expect(linkFor(html, "/t/team-1/view")).not.toContain("aria-current");
+  });
+
+  it("keeps a section active on its nested routes", () => {
+    const html = render("COACH", "/t/team-1/chart/positions");
+
+    expect(linkFor(html, "/t/team-1/chart")).toContain('aria-current="page"');
+  });
+
+  it("marks Home only on the team home itself, not on every subpage", () => {
+    const home = render("PARENT", "/t/team-1");
+    expect(linkFor(home, "/t/team-1")).toContain('aria-current="page"');
+
+    const sub = render("PARENT", "/t/team-1/roster/entry-9");
+    expect(linkFor(sub, "/t/team-1")).not.toContain("aria-current");
+    expect(linkFor(sub, "/t/team-1/roster")).toContain('aria-current="page"');
+  });
+});

--- a/src/components/TeamNav.test.tsx
+++ b/src/components/TeamNav.test.tsx
@@ -63,17 +63,11 @@ describe("TeamNav role gating", () => {
 });
 
 describe("TeamNav active tab", () => {
-  it("marks the current section with aria-current", () => {
+  it("marks the tab whose target is the current page", () => {
     const html = render("PARENT", "/t/team-1/schedule");
 
     expect(linkFor(html, "/t/team-1/schedule")).toContain('aria-current="page"');
     expect(linkFor(html, "/t/team-1/view")).not.toContain("aria-current");
-  });
-
-  it("keeps a section active on its nested routes", () => {
-    const html = render("COACH", "/t/team-1/chart/positions");
-
-    expect(linkFor(html, "/t/team-1/chart")).toContain('aria-current="page"');
   });
 
   it("marks Home only on the team home itself, not on every subpage", () => {
@@ -82,6 +76,77 @@ describe("TeamNav active tab", () => {
 
     const sub = render("PARENT", "/t/team-1/roster/entry-9");
     expect(linkFor(sub, "/t/team-1")).not.toContain("aria-current");
-    expect(linkFor(sub, "/t/team-1/roster")).toContain('aria-current="page"');
+  });
+
+  it("keeps a section lit on its nested routes", () => {
+    for (const [pathname, tab] of [
+      ["/t/team-1/chart/positions", "/t/team-1/chart"],
+      ["/t/team-1/roster/entry-9", "/t/team-1/roster"],
+      ["/t/team-1/roster/returning", "/t/team-1/roster"],
+      ["/t/team-1/schedule/event-4", "/t/team-1/schedule"],
+    ] as const) {
+      expect(linkFor(render("OWNER", pathname), tab)).toContain("aria-current");
+    }
+  });
+
+  // ARIA reserves "page" for the link whose target IS the current page; a tab
+  // that merely contains it is "true". Announcing the Chart tab as the current
+  // page while the reader is in the positions editor is just false.
+  it("announces a containing section as true, not as the current page", () => {
+    const html = render("COACH", "/t/team-1/chart/positions");
+    const chart = linkFor(html, "/t/team-1/chart");
+
+    // Asserted as the exact rendered value: a bare `aria-current` attribute
+    // would satisfy a substring check while meaning something else entirely.
+    expect(chart).toContain('aria-current="true"');
+  });
+
+  // /members is owner-only and reached from Settings, but sits at a sibling
+  // URL — without an explicit claim the persistent nav goes completely dark
+  // on the one page that links to it.
+  it("lights Settings on the members page it links to", () => {
+    const html = render("OWNER", "/t/team-1/members");
+
+    expect(linkFor(html, "/t/team-1/settings")).toContain("aria-current");
+  });
+
+  it("never lights two tabs at once", () => {
+    for (const pathname of [
+      "/t/team-1",
+      "/t/team-1/schedule",
+      "/t/team-1/schedule/event-4",
+      "/t/team-1/view",
+      "/t/team-1/roster/returning",
+      "/t/team-1/chart/positions",
+      "/t/team-1/members",
+      "/t/team-1/settings",
+    ]) {
+      const lit = render("OWNER", pathname).match(/aria-current/g) ?? [];
+      expect(lit, `${pathname} lit ${lit.length} tabs`).toHaveLength(1);
+    }
+  });
+});
+
+describe("TeamNav focus styling", () => {
+  // The outline Buttons this nav replaced carried focus rings via
+  // buttonVariants; design-plan.md §10 requires them outright. Losing them on
+  // the app's primary navigation is the regression this guards.
+  it("gives every tab a visible focus ring", () => {
+    const html = render("COACH", "/t/team-1/view");
+
+    for (const href of ["/t/team-1/schedule", "/t/team-1/view"]) {
+      expect(linkFor(html, href)).toContain("focus-visible:ring-2");
+    }
+  });
+
+  it("rings the active tab in banana, not the green that would vanish on it", () => {
+    const html = render("COACH", "/t/team-1/view");
+
+    expect(linkFor(html, "/t/team-1/view")).toContain(
+      "focus-visible:ring-banana",
+    );
+    expect(linkFor(html, "/t/team-1/schedule")).toContain(
+      "focus-visible:ring-ring",
+    );
   });
 });

--- a/src/components/TeamNav.tsx
+++ b/src/components/TeamNav.tsx
@@ -12,7 +12,40 @@ type TeamNavItem = {
   /// Match this href exactly instead of as a prefix — only the team home
   /// needs it, since every other team route lives underneath it.
   exact?: boolean;
+  /// Extra routes this tab owns that don't sit under its own href. Members
+  /// is the only one: it's reached from Settings but lives at a sibling URL,
+  /// so without this the nav goes blank on the one page it's linked from.
+  alsoMatch?: readonly string[];
 };
+
+/// How a tab relates to the current URL: it *is* the page, it merely contains
+/// the page, or neither. Both lit states look identical, but they must not be
+/// announced identically — ARIA reserves `aria-current="page"` for the link
+/// whose target is the current page, and a containing section is
+/// `aria-current="true"`. Saying "current page" on the Chart tab while the
+/// reader is two segments deeper in the positions editor is simply false.
+///
+/// Pure and router-free so the matching is testable on its own.
+export function matchNavItem(
+  item: TeamNavItem,
+  pathname: string,
+): "page" | "section" | null {
+  if (pathname === item.href) {
+    return "page";
+  }
+  if (item.exact) {
+    return null;
+  }
+
+  // The trailing slash matters: without it a hypothetical /viewer route would
+  // light the /view tab.
+  const owned = [item.href, ...(item.alsoMatch ?? [])];
+  return owned.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  )
+    ? "section"
+    : null;
+}
 
 /// One list, gated by role, so the nav and its tests agree on exactly which
 /// links each role sees. This gating is presentational only — every page
@@ -36,7 +69,11 @@ function navItems(teamId: string, role: Role): TeamNavItem[] {
   }
 
   if (role === "OWNER") {
-    items.push({ href: `${base}/settings`, label: "Settings" });
+    items.push({
+      href: `${base}/settings`,
+      label: "Settings",
+      alsoMatch: [`${base}/members`],
+    });
   }
 
   items.push({ href: "/profile", label: "Profile" });
@@ -63,22 +100,29 @@ export function TeamNav({ teamId, role }: { teamId: string; role: Role }) {
       // thumb instead of wrapping into a wall of buttons.
       className="-mx-4 overflow-x-auto px-4 sm:-mx-6 sm:px-6 lg:mx-0 lg:px-0"
     >
-      <ul className="flex w-max items-center gap-2 pb-1 lg:w-full lg:flex-wrap">
+      {/* py-1.5 rather than pb-1: `overflow-x-auto` makes overflow-y `auto`
+          too, so a focus ring on the top or bottom edge would be clipped
+          without room to draw it. */}
+      <ul className="flex w-max items-center gap-2 py-1.5 lg:w-full lg:flex-wrap">
         {navItems(teamId, role).map((item) => {
-          const active = item.exact
-            ? pathname === item.href
-            : pathname === item.href || pathname.startsWith(`${item.href}/`);
+          const match = matchNavItem(item, pathname);
 
           return (
             <li key={item.href}>
               <Link
                 href={item.href}
-                aria-current={active ? "page" : undefined}
+                aria-current={
+                  match === "page" ? "page" : match === "section" ? true : undefined
+                }
                 className={cn(
-                  "inline-flex items-center whitespace-nowrap rounded-full border-2 px-4 py-1.5 text-sm font-semibold transition-colors",
-                  active
-                    ? "border-primary bg-primary text-primary-foreground shadow-sm"
-                    : "border-border bg-card text-foreground hover:border-primary/60 hover:bg-accent",
+                  "inline-flex items-center whitespace-nowrap rounded-full border-2 px-4 py-1.5 text-sm font-semibold ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+                  match
+                    ? // Banana ring on the green fill, per design-plan.md §10:
+                      // --ring is Field Green in light mode, which would be a
+                      // green ring on a green pill — invisible exactly where
+                      // this app is read, outdoors in sunlight.
+                      "border-primary bg-primary text-primary-foreground shadow-sm focus-visible:ring-banana"
+                    : "border-border bg-card text-foreground hover:border-primary/60 hover:bg-accent focus-visible:ring-ring",
                 )}
               >
                 {item.label}

--- a/src/components/TeamNav.tsx
+++ b/src/components/TeamNav.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import type { Role } from "@/generated/prisma/enums";
+import { cn } from "@/lib/utils";
+
+type TeamNavItem = {
+  href: string;
+  label: string;
+  /// Match this href exactly instead of as a prefix — only the team home
+  /// needs it, since every other team route lives underneath it.
+  exact?: boolean;
+};
+
+/// One list, gated by role, so the nav and its tests agree on exactly which
+/// links each role sees. This gating is presentational only — every page
+/// checks requireTeamAccess for itself, so hiding a link here is a courtesy,
+/// never the boundary.
+function navItems(teamId: string, role: Role): TeamNavItem[] {
+  const base = `/t/${teamId}`;
+  const items: TeamNavItem[] = [
+    { href: base, label: "Home", exact: true },
+    { href: `${base}/schedule`, label: "Schedule" },
+    { href: `${base}/view`, label: "Lineup" },
+    { href: `${base}/roster`, label: "Roster" },
+  ];
+
+  if (role !== "PARENT") {
+    items.push(
+      { href: `${base}/readiness`, label: "Readiness" },
+      { href: `${base}/chart`, label: "Chart" },
+      { href: `${base}/directory`, label: "Directory" },
+    );
+  }
+
+  if (role === "OWNER") {
+    items.push({ href: `${base}/settings`, label: "Settings" });
+  }
+
+  items.push({ href: "/profile", label: "Profile" });
+
+  return items;
+}
+
+/// The team's persistent navigation, rendered by the /t/[teamId] layout so it
+/// travels with every team view. Pill tabs on the header band: the active tab
+/// fills Field Green, the rest sit on card stock with a warm border. No banana
+/// here on purpose — the nav appears on every screen, and a yellow tab would
+/// spend the one-banana-per-screen budget (design-plan.md §2) everywhere at
+/// once.
+///
+/// A client component only for `usePathname` — the active tab has to follow
+/// client-side navigation, which the server layout never re-renders for.
+export function TeamNav({ teamId, role }: { teamId: string; role: Role }) {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Team"
+      // Bleeds to the screen edge on phones so the row scrolls under the
+      // thumb instead of wrapping into a wall of buttons.
+      className="-mx-4 overflow-x-auto px-4 sm:-mx-6 sm:px-6 lg:mx-0 lg:px-0"
+    >
+      <ul className="flex w-max items-center gap-2 pb-1 lg:w-full lg:flex-wrap">
+        {navItems(teamId, role).map((item) => {
+          const active = item.exact
+            ? pathname === item.href
+            : pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "inline-flex items-center whitespace-nowrap rounded-full border-2 px-4 py-1.5 text-sm font-semibold transition-colors",
+                  active
+                    ? "border-primary bg-primary text-primary-foreground shadow-sm"
+                    : "border-border bg-card text-foreground hover:border-primary/60 hover:bg-accent",
+                )}
+              >
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/TeamNav.tsx
+++ b/src/components/TeamNav.tsx
@@ -83,10 +83,12 @@ function navItems(teamId: string, role: Role): TeamNavItem[] {
 
 /// The team's persistent navigation, rendered by the /t/[teamId] layout so it
 /// travels with every team view. Pill tabs on the header band: the active tab
-/// fills Field Green, the rest sit on card stock with a warm border. No banana
-/// here on purpose — the nav appears on every screen, and a yellow tab would
-/// spend the one-banana-per-screen budget (design-plan.md §2) everywhere at
-/// once.
+/// fills Field Green, the rest sit on card stock with a warm border.
+///
+/// No *resting* banana on purpose — the nav appears on every screen, and a
+/// yellow tab would spend the one-banana-per-screen budget (design-plan.md §2)
+/// everywhere at once. The banana appears only in the active tab's focus ring,
+/// which §10 asks for by name and which is transient rather than decoration.
 ///
 /// A client component only for `usePathname` — the active tab has to follow
 /// client-side navigation, which the server layout never re-renders for.


### PR DESCRIPTION
## Summary

Two fixes reported from the field, both visible on a phone at a ballpark. The team's navigation was a wall of undifferentiated outline buttons that existed only on the team home page; it is now `TeamNav`, a styled pill-tab bar rendered by the `/t/[teamId]` layout, so it travels with every team view. Separately, the Lineup page used to replace the entire chart with a "No upcoming game" card once the schedule ran out — the chart is standing rather than per-game, so it now renders with or without a game on the calendar.

## Key Decisions

**The active tab is Field Green, not Banana Yellow.** The obvious "make it pop" move is a yellow active tab, and it is wrong here: `docs/design/design-plan.md` §2 rations the banana to one element per screen, and the nav is on *every* screen. A permanent yellow tab would collide with each page's own banana — the outfield fence on the lineup diamond, the drop-target glow in the chart editors. Green active fill on card-stock pills gets the contrast without spending a budget that isn't the nav's to spend.

**The banana does appear in the focus ring, deliberately.** `--ring` is Field Green in light mode, so the app's default focus ring on a green-filled active pill would be a green ring on green — invisible in exactly the conditions this app is used in. §10 of the design plan anticipates this and calls for a yellow ring on green, which is what the active tab uses; inactive card-stock pills keep the standard `ring-ring`.

**`TeamNav` is a client component, and only for `usePathname`.** The active tab has to follow client-side navigation, and a Next.js layout does not re-render on transitions between sibling pages — so a server-computed active state would stick on whichever tab was current at first paint. The matching itself is a pure exported function (`matchNavItem`) so it is testable without a router.

**Role gating in the nav is presentational, never the boundary.** `TeamNav` takes the `role` the layout already resolved and hides links a role can't use, exactly as the old button grid did. Every page underneath still calls `requireTeamAccess` for itself — the layout's check is not the authorization boundary (see the comment in `layout.tsx`), and this change does not make it one.

**The chart outlives the schedule, but RSVP does not.** Rendering the standing chart with no game means every player's RSVP resolves to "No response", which would read as a team-wide silence rather than "there is nothing to respond to". So a new `showRsvp` prop on `Diamond` strips the per-player tags, the batting-order tags, and the legend when `nextGame` returns null — the chart is shown, the per-game decoration is not. `getChart` still runs; `listEventRsvps` is skipped entirely, since there is no event to query.

## What's in Scope

- New `src/components/TeamNav.tsx` — pill-tab nav: green active fill, card-stock inactive tabs with a warm border and banana-tint hover, focus-visible rings, a `nav` landmark with an accessible name, and horizontal scroll (edge-bleeding) on phones instead of wrapping.
- Rendered by `src/app/t/[teamId]/layout.tsx` on every team route; the team name in the header now links back to the team home.
- Removed the old navigation button grid from `src/app/t/[teamId]/page.tsx`; the home page now carries team facts and the parents' coaching-staff contact card only.
- `/t/[teamId]/view` renders the standing chart whether or not a game is scheduled, with the no-game state as a header card ("this is the standing chart, ready for the next one") above the chart rather than in place of it.
- `showRsvp` on `Diamond`, threaded through the markers **and** the `sr-only` list so the screen-reader path matches what sighted users get.
- Tests: new `src/components/TeamNav.test.tsx` (role gating, active-tab matching across every nested route, ARIA correctness, focus styling); the home page's link assertions moved there; new view-page cases for chart-without-game and suppressed RSVP decoration.
- `docs/design/design-plan.md` updated — it is the as-built record and is drift-tested by `src/design-plan-drift.test.ts`.

### Out of Scope

- The top application header (`PageContainer`'s pinstripe wordmark band) is untouched — the reported problem was the team navigation row, not the app title bar.

## Bugs Found and Fixed During Self-Review

Reviewing the diff before requesting review caught three real defects, each fixed in `3aeac84` with a regression test that fails against the pre-fix code.

**1. The nav had no focus-visible styling at all.** The `<Button variant="outline">` elements it replaced carry `focus-visible:ring-2 ring-ring ring-offset-2` via `buttonVariants`, and §10 of the design plan requires focus rings outright. The new pills had none and fell back to the UA outline — worst on the active tab, where that outline is drawn against a dark green fill and is easy to lose. This is now the app's primary navigation, so it was the worst possible control to leave unstyled. Restored using the codebase's existing convention, with the banana ring on the active pill for the reason given above. Two follow-on details: `overflow-x-auto` makes computed `overflow-y: auto`, and the row had `pb-1` and no top padding, so a ring would have been clipped — the row is now `py-1.5`.

**2. The nav went completely dark on `/t/[teamId]/members`.** That route is owner-only and is reached from Settings ("Members & invitations"), but it lives at a sibling URL rather than under `/settings`, so no tab claimed it: an owner clicking through from Settings landed on a page where the persistent nav highlighted nothing. Every other nested route already inherited its parent's highlight. Tabs can now claim extra routes via `alsoMatch`, and Settings claims `/members`.

**3. `aria-current="page"` was announced for containing sections.** On `/t/[teamId]/chart/positions` the Chart tab claimed to be the current page, but the current page is the positions editor two segments deeper. ARIA reserves `"page"` for the link whose target *is* the current page; a containing section is `"true"`. A screen-reader user was being told they had arrived somewhere they hadn't. Matching now returns `"page" | "section" | null` and maps the tokens correctly — the two states still look identical, they just no longer *sound* identical.

Two things were checked specifically and came back clean: no nav link leads a role to a page its own `requireTeamAccess` would 404 (verified against the `minRole` each destination actually enforces), and no route lost its only inbound link.

## Known Gaps / Follow-ups

- **Profile is a one-way trip, and this change makes that more visible.** `/profile` is global rather than team-scoped, so it has no `teamId` to build nav links from and does not render `TeamNav`; its only exit is a "Back" link to the app root. Promoting Profile into the persistent nav means a parent can reach it from any screen but still returns via root → team → page. Fixing it properly means passing a return path, which needs validating to avoid an open redirect — deliberately not smuggled into a styling PR. The dead end predates this change.
- Not verified in a browser: the team routes are auth-gated and need a live `DATABASE_URL` and a session, neither of which exists in this environment. Verified instead via `pnpm check` and a full `next build`, plus server-rendered markup assertions in the tests. The pill layout on a real phone is the one thing worth a human eye — that is the manual step in the test plan below.
- The nav shows every tab for an archived team; the pages themselves still reject writes (`team-access.ts` rejects every write on an archived team, owner included). Making the nav visibly signal read-only is a separate design question.

## Test Plan

- [ ] Run the check gate: `pnpm install && pnpm db:generate && pnpm check` (lint → typecheck → 907 tests). Then `pnpm exec next build` — use `next build` directly rather than `pnpm build`, which additionally runs `prisma migrate deploy` and so needs a live `DATABASE_URL`.
- [ ] With a database configured, run `pnpm dev` and sign in as an owner. Visit `/t/<teamId>` and confirm the pill nav appears under the team name, then click through Schedule → Lineup → Roster → Chart and confirm the nav stays put on every view and the green active pill follows you. Open `/t/<teamId>/chart/positions` and confirm the **Chart** tab stays highlighted on the nested route.
- [ ] Tab through the nav with the keyboard and confirm every pill shows a visible focus ring, including the active green one, and that no ring is clipped at the top or bottom of the row.
- [ ] From Settings, click "Members & invitations" and confirm the **Settings** tab stays highlighted on `/members` rather than the nav going blank.
- [ ] Narrow the browser to phone width (~390px) and confirm the nav scrolls sideways to the screen edge rather than wrapping into a block of buttons.
- [ ] Sign in as a parent on the same team and confirm Readiness, Chart, Directory and Settings are absent from the nav — then hit `/t/<teamId>/directory` directly and confirm it still 404s (the page, not the nav, is the boundary).
- [ ] Edge case — the reported bug: on a team whose games are all in the past (or delete the remaining games), open `/t/<teamId>/view`. The positions diamond and batting order must both render under a "No upcoming game" card, with **no** "No response" tags on the markers or rows and no RSVP legend at the bottom. Re-add a future game and confirm the RSVP tags and legend come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XCYnv1DwXpcZx7jJ1XE3u