### PR TITLE
Add sign-out to the profile page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ docs/design/       # The design plan and its SVG mockups — kept in step with t
 `src/app/` now has real routes: `/` (auth-gated landing), `/signin`, `/invite/[token]`
 (unauthenticated invitation accept page — deliberately outside proxy.ts's matcher),
 `/profile` (the signed-in person's own name and phone — global, not team-scoped, since
-those are `User` columns), and `/t/[teamId]/` (team home, settings, roster, members, the
+those are `User` columns — and the app's only sign-out, a server action wrapping Auth.js
+`signOut`), and `/t/[teamId]/` (team home, settings, roster, members, the
 owner-only returning-player picker at `roster/returning`, the coach-only bulk parent
 invite at `roster/invite`, the coach-only member directory, the coach-only roster entry
 detail at `roster/[entryId]`, the schedule at `schedule` / `schedule/[eventId]`, the

--- a/src/app/profile/actions.test.ts
+++ b/src/app/profile/actions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const signOut = vi.fn();
 const getCurrentUser = vi.fn();
@@ -40,6 +40,10 @@ import { signOutAction } from "./actions";
 beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("signOutAction", () => {

--- a/src/app/profile/actions.test.ts
+++ b/src/app/profile/actions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const signOut = vi.fn();
+const getCurrentUser = vi.fn();
+const updateProfile = vi.fn();
+
+vi.mock("@/auth", () => ({
+  signOut: (...args: unknown[]) => signOut(...args),
+}));
+
+vi.mock("@/lib/session", () => ({
+  getCurrentUser: (...args: unknown[]) => getCurrentUser(...args),
+}));
+
+vi.mock("@/lib/profile", () => ({
+  updateProfile: (...args: unknown[]) => updateProfile(...args),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// redirect() throws in Next; reproduce that so control flow matches production
+// and a "redirected" assertion can't pass by accident. Identified by message
+// prefix rather than a class, because vi.mock factories are hoisted above any
+// top-level declaration they'd reference.
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+  unstable_rethrow: (error: unknown) => {
+    if (error instanceof Error && error.message.startsWith("NEXT_REDIRECT:")) {
+      throw error;
+    }
+  },
+}));
+
+import { signOutAction } from "./actions";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("signOutAction", () => {
+  // `redirectTo: "/"` is load-bearing: dropping it makes Auth.js fall back to
+  // the Referer — /profile — which Proxy bounces to /signin, so the person
+  // who just signed out lands on a sign-in form and concludes it failed.
+  it("asks Auth.js to sign out and land on the signed-out home page", async () => {
+    // The real signOut ends by throwing Next's redirect; mirror that so the
+    // wrapper's unstable_rethrow path is what lets it escape.
+    signOut.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT:/");
+    });
+
+    await expect(signOutAction()).rejects.toThrow("NEXT_REDIRECT:/");
+    expect(signOut).toHaveBeenCalledWith({ redirectTo: "/" });
+  });
+
+  // The repo has no error.tsx, so an unhandled throw here would hand the
+  // app's only sign-out affordance a raw error page — while still signed in.
+  it("lands a failure back on /profile with an error instead of crashing", async () => {
+    signOut.mockRejectedValue(new Error("RESEND_API_KEY is not set"));
+
+    await expect(signOutAction()).rejects.toThrow(
+      "NEXT_REDIRECT:/profile?error=signout-failed",
+    );
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/src/app/profile/actions.ts
+++ b/src/app/profile/actions.ts
@@ -55,12 +55,25 @@ export async function updateProfileAction(formData: FormData) {
 /**
  * Sign out on this device.
  *
- * Auth.js handles both kinds of session the app creates: a session written by
- * the invite-accept action uses the same Session table and cookie name as one
- * from a magic link (see src/lib/session-cookie.ts), so `signOut` deletes the
- * row whichever path minted it. Only this device's session dies — every other
- * device holds its own Session row and cookie.
+ * Both sign-in paths share one Session table and cookie name — see
+ * src/lib/session-cookie.ts — so `signOut` finds the row whichever path
+ * minted it. The row delete is best-effort, not guaranteed: `@auth/core`
+ * logs a failed deleteSession and clears the cookie anyway, so a database
+ * blip here can leave a row to age out on its own. Only this device's
+ * session is touched — every other device holds its own row and cookie.
  */
 export async function signOutAction() {
-  await signOut({ redirectTo: "/" });
+  try {
+    await signOut({ redirectTo: "/" });
+  } catch (error) {
+    // Next implements redirect() by throwing, and signOut's success path
+    // ends in one; never swallow that.
+    unstable_rethrow(error);
+
+    // Everything else — a malformed AUTH_URL, an Auth.js config failure —
+    // is logged server-side. Without this the repo's lack of an error.tsx
+    // means the person gets a raw error page while still signed in.
+    console.error("Sign-out failed:", error);
+    redirect("/profile?error=signout-failed");
+  }
 }

--- a/src/app/profile/actions.ts
+++ b/src/app/profile/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect, unstable_rethrow } from "next/navigation";
 
+import { signOut } from "@/auth";
 import { normalizePhone } from "@/lib/phone";
 import { updateProfile } from "@/lib/profile";
 import { getCurrentUser } from "@/lib/session";
@@ -49,4 +50,17 @@ export async function updateProfileAction(formData: FormData) {
   revalidatePath("/t/[teamId]", "page");
   revalidatePath("/");
   redirect("/profile?saved=1");
+}
+
+/**
+ * Sign out on this device.
+ *
+ * Auth.js handles both kinds of session the app creates: a session written by
+ * the invite-accept action uses the same Session table and cookie name as one
+ * from a magic link (see src/lib/session-cookie.ts), so `signOut` deletes the
+ * row whichever path minted it. Only this device's session dies — every other
+ * device holds its own Session row and cookie.
+ */
+export async function signOutAction() {
+  await signOut({ redirectTo: "/" });
 }

--- a/src/app/profile/page.test.tsx
+++ b/src/app/profile/page.test.tsx
@@ -101,12 +101,19 @@ describe("ProfilePage", () => {
     expect(html).toContain("Your changes couldn&#x27;t be saved. Try again.");
   });
 
-  // The one sign-out affordance in the app — /profile is linked from the
-  // landing header and every team's nav, so it must actually be here.
-  it("offers a sign-out button", async () => {
+  // The one sign-out affordance in the app — /profile is reachable from the
+  // signed-in landing page's "Your profile" button and every team nav's
+  // Profile tab, so it must actually be here. renderToStaticMarkup emits no
+  // `action` attribute for a function action, so the closest observable claim
+  // is structural: a submit button labelled "Sign out" as the first child of
+  // its own form — a bare string match would still pass with the form gone
+  // and the button decorative.
+  it("offers a sign-out button wired as a form submit", async () => {
     const html = await render();
 
-    expect(html).toContain("Sign out");
+    expect(html).toMatch(
+      /<form[^>]*><button[^>]*type="submit"[^>]*>Sign out<\/button>/,
+    );
   });
 
   // A database error on the read must not render as "no number on file" —

--- a/src/app/profile/page.test.tsx
+++ b/src/app/profile/page.test.tsx
@@ -82,6 +82,15 @@ describe("ProfilePage", () => {
     await expect(render()).rejects.toThrow("NEXT_REDIRECT:/signin?callbackUrl=%2Fprofile");
   });
 
+  // ?error= is user-controlled; a prototype-chain key must fall through to
+  // the generic message rather than resolving an Object.prototype member
+  // into the tree, which is not a renderable child and crashes the page.
+  it("treats prototype-chain error keys as unknown errors", async () => {
+    const html = await render({ error: "__proto__" });
+
+    expect(html).toContain("Something went wrong.");
+  });
+
   it("surfaces a rejected phone number", async () => {
     const html = await render({ error: "invalid-phone" });
 

--- a/src/app/profile/page.test.tsx
+++ b/src/app/profile/page.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/lib/profile", () => ({
 
 vi.mock("./actions", () => ({
   updateProfileAction: vi.fn(),
+  signOutAction: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -98,6 +99,14 @@ describe("ProfilePage", () => {
 
     expect(html).not.toContain("Saved.");
     expect(html).toContain("Your changes couldn&#x27;t be saved. Try again.");
+  });
+
+  // The one sign-out affordance in the app — /profile is linked from the
+  // landing header and every team's nav, so it must actually be here.
+  it("offers a sign-out button", async () => {
+    const html = await render();
+
+    expect(html).toContain("Sign out");
   });
 
   // A database error on the read must not render as "no number on file" —

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -22,6 +22,7 @@ export const metadata = {
 const ERROR_MESSAGES: Record<string, string> = {
   "invalid-phone": "Phone number must be 32 characters or fewer.",
   "save-failed": "Your changes couldn't be saved. Try again.",
+  "signout-failed": "Signing out didn't work. Try again.",
 };
 
 /// The one place a person sees and fixes what the team has on file for them.
@@ -138,17 +139,15 @@ export default async function ProfilePage({
           </CardContent>
         </Card>
 
-        <div className="space-y-2">
-          <form action={signOutAction}>
-            <Button type="submit" variant="outline" className="w-full">
-              Sign out
-            </Button>
-          </form>
+        <form action={signOutAction} className="space-y-2">
+          <Button type="submit" variant="outline" className="w-full">
+            Sign out
+          </Button>
           <p className="text-center text-xs text-muted-foreground">
             Signs you out on this device only. Sign back in any time with an
             email link.
           </p>
-        </div>
+        </form>
       </div>
     </PageContainer>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -13,7 +13,7 @@ import {
 import { getProfile } from "@/lib/profile";
 import { getCurrentUser } from "@/lib/session";
 
-import { updateProfileAction } from "./actions";
+import { signOutAction, updateProfileAction } from "./actions";
 
 export const metadata = {
   title: "Your profile — Youth Baseball Team Manager",
@@ -137,6 +137,18 @@ export default async function ProfilePage({
             </form>
           </CardContent>
         </Card>
+
+        <div className="space-y-2">
+          <form action={signOutAction}>
+            <Button type="submit" variant="outline" className="w-full">
+              Sign out
+            </Button>
+          </form>
+          <p className="text-center text-xs text-muted-foreground">
+            Signs you out on this device only. Sign back in any time with an
+            email link.
+          </p>
+        </div>
       </div>
     </PageContainer>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -19,11 +19,15 @@ export const metadata = {
   title: "Your profile — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+// Null prototype: the key comes straight from the ?error= query param, and on
+// a plain object ?error=__proto__ or ?error=constructor would resolve an
+// Object.prototype member — truthy, so the fallback never fires — into a
+// non-renderable React child that crashes the page.
+const ERROR_MESSAGES: Record<string, string> = Object.assign(Object.create(null), {
   "invalid-phone": "Phone number must be 32 characters or fewer.",
   "save-failed": "Your changes couldn't be saved. Try again.",
   "signout-failed": "Signing out didn't work. Try again.",
-};
+});
 
 /// The one place a person sees and fixes what the team has on file for them.
 ///


### PR DESCRIPTION
## Summary

There was no way to log out anywhere in the app — `signOut` was exported from `src/auth.ts` but never used. This adds a Sign out button to `/profile`, backed by a server action wrapping Auth.js `signOut`, which deletes the current device's `Session` row and clears the cookie before landing on the signed-out home page.

## Key Decisions

- **Auth.js `signOut` over hand-rolled cookie clearing.** Clearing the cookie alone would leave a live 90-day `Session` row behind. `signOut` under the database strategy deletes the row by token, and it works for both kinds of session the app mints — magic-link and invite-accept — since both write the same `Session` table and cookie name (`src/lib/session-cookie.ts`).
- **Placement on `/profile`, not in the nav.** The profile page is the account screen and is at most one tap away from everywhere (the signed-in landing links it; `TeamNav` includes a Profile tab for every role). A persistent nav tab would spend permanent nav space on a once-a-season action.
- **`signOutAction` lives in the existing `src/app/profile/actions.ts`**, following the repo's one-`actions.ts`-per-segment convention rather than an inline `"use server"` closure.

## What's in Scope

- `signOutAction` server action (`signOut({ redirectTo: "/" })`) with the house-style try/`unstable_rethrow`/log wrapper, landing failures on `/profile?error=signout-failed`
- Sign out button + "this device only" caption on `/profile`
- Page test asserting the button is a submit wired inside its form, plus a co-located `actions.test.ts` pinning `redirectTo: "/"` and the failure path

### Out of Scope

- Remote revocation ("sign out other devices") — sessions on other devices keep their own row and cookie until expiry.

## Bugs Found and Fixed During Self-Review

A multi-angle self-review of the first commit surfaced these; all are fixed in the second commit:

- The page test asserted only the string "Sign out", which would stay green if the button were unwired from its form — it now asserts the submit-inside-form structure, and the new `actions.test.ts` pins `redirectTo: "/"` (dropping it would bounce the just-signed-out user to `/signin` via the Referer) and the failure redirect.
- The `signOutAction` doc comment claimed the row delete is unconditional; `@auth/core` actually treats it as best-effort (failure logged, cookie cleared anyway) — reworded.
- `signOutAction` was the only Auth.js-calling action without the try/`unstable_rethrow`/log wrapper its siblings use; a config-time throw would have produced a raw error page (the repo has no `error.tsx`) with the user still signed in.
- Two cosmetic nits: a test comment misplaced the landing page's profile link in a nonexistent header, and a wrapper `<div>` collapsed into the form.

The review also verified the mechanism is sound: row deletion covers both session origins, cookie naming agrees with `session-cookie.ts`, and redirecting to `/` cannot loop (proxy doesn't match `/`).

## Test Plan

- [ ] Run this repo's full check gate (see `AGENTS.md` → `## Commands`): `pnpm check` — lint, typecheck, and all 910 tests pass locally.
- [ ] Run `pnpm dev`, sign in, visit `/profile`, click **Sign out** — expect to land on `/` showing the signed-out welcome card, and the `Session` row for that token gone (`pnpm db:studio`).
- [ ] After signing out, navigate to a `/t/[teamId]` URL directly — expect a redirect to `/signin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCPSsBc1aYKci9zafpUV2x