### PR TITLE
UX quick wins: map links, next-game card link, destructive-action confirms

### DIFF
--- a/src/app/t/[teamId]/roster/[entryId]/page.test.tsx
+++ b/src/app/t/[teamId]/roster/[entryId]/page.test.tsx
@@ -90,6 +90,71 @@ describe("Roster entry page", () => {
     expect(markup).toContain("555-1234");
   });
 
+  it("asks for confirmation before removing a player", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
+    getRosterEntry.mockResolvedValue(BASE_ENTRY);
+
+    const { default: RosterEntryPage } = await import("./page");
+    const markup = renderToStaticMarkup(
+      await RosterEntryPage({
+        params: Promise.resolve({ teamId: "team-1", entryId: "entry-1" }),
+        searchParams: Promise.resolve({}),
+      }),
+    );
+
+    expect(markup).toContain("confirm=remove");
+    expect(markup).not.toContain("Yes, remove them");
+  });
+
+  it("names the player in the removal confirm step", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
+    getRosterEntry.mockResolvedValue(BASE_ENTRY);
+
+    const { default: RosterEntryPage } = await import("./page");
+    const markup = renderToStaticMarkup(
+      await RosterEntryPage({
+        params: Promise.resolve({ teamId: "team-1", entryId: "entry-1" }),
+        searchParams: Promise.resolve({ confirm: "remove" }),
+      }),
+    );
+
+    expect(markup).toContain("Yes, remove them");
+    expect(markup).toContain("Remove Ada from this roster?");
+  });
+
+  it("asks for per-guardian confirmation before unlinking", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
+    getRosterEntry.mockResolvedValue(ENTRY_WITH_GUARDIAN);
+
+    const { default: RosterEntryPage } = await import("./page");
+    const markup = renderToStaticMarkup(
+      await RosterEntryPage({
+        params: Promise.resolve({ teamId: "team-1", entryId: "entry-1" }),
+        searchParams: Promise.resolve({}),
+      }),
+    );
+
+    // & renders as &amp; in static markup.
+    expect(markup).toContain("confirm=unlink&amp;guardian=user-9");
+    expect(markup).not.toContain("Yes, unlink");
+  });
+
+  it("confirms an unlink on the named guardian's row only", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
+    getRosterEntry.mockResolvedValue(ENTRY_WITH_GUARDIAN);
+
+    const { default: RosterEntryPage } = await import("./page");
+    const markup = renderToStaticMarkup(
+      await RosterEntryPage({
+        params: Promise.resolve({ teamId: "team-1", entryId: "entry-1" }),
+        searchParams: Promise.resolve({ confirm: "unlink", guardian: "user-9" }),
+      }),
+    );
+
+    expect(markup).toContain("Yes, unlink");
+    expect(markup).toContain("Unlink Sam from Ada?");
+  });
+
   // The route is coach-and-above like /directory: the page is the roster
   // admin surface and carries every linked guardian's contact details, so a
   // parent gets a 404 — and the guardian data is never even fetched.

--- a/src/app/t/[teamId]/roster/[entryId]/page.tsx
+++ b/src/app/t/[teamId]/roster/[entryId]/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
@@ -63,10 +64,16 @@ export default async function RosterEntryPage({
   searchParams,
 }: {
   params: Promise<{ teamId: string; entryId: string }>;
-  searchParams: Promise<{ error?: string; saved?: string; invited?: string }>;
+  searchParams: Promise<{
+    error?: string;
+    saved?: string;
+    invited?: string;
+    confirm?: string;
+    guardian?: string;
+  }>;
 }) {
   const { teamId, entryId } = await params;
-  const { error, saved, invited } = await searchParams;
+  const { error, saved, invited, confirm, guardian } = await searchParams;
 
   try {
     await requireTeamAccess(teamId, { intent: "read", minRole: "COACH" });
@@ -83,6 +90,10 @@ export default async function RosterEntryPage({
   }
 
   const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const confirmingRemoval = confirm === "remove";
+  // Unlinking confirms per guardian: ?confirm=unlink&guardian=<id> shows the
+  // step on that row only, so the other rows keep their one-tap buttons.
+  const unlinkingGuardianId = confirm === "unlink" ? (guardian ?? null) : null;
 
   return (
     <div className="mx-auto w-full max-w-md space-y-6">
@@ -206,16 +217,41 @@ export default async function RosterEntryPage({
                           </Button>
                         </form>
                       ) : null}
-                      <form action={unlinkGuardianAction}>
-                        <input type="hidden" name="teamId" value={teamId} />
-                        <input type="hidden" name="entryId" value={entryId} />
-                        <input type="hidden" name="userId" value={guardian.id} />
-                        <Button type="submit" variant="outline" size="sm">
-                          Unlink
+                      {unlinkingGuardianId !== guardian.id ? (
+                        <Button asChild variant="outline" size="sm">
+                          <Link
+                            href={`/t/${teamId}/roster/${entryId}?confirm=unlink&guardian=${guardian.id}`}
+                          >
+                            Unlink
+                          </Link>
                         </Button>
-                      </form>
+                      ) : null}
                     </div>
                   </div>
+                  {unlinkingGuardianId === guardian.id ? (
+                    <div className="space-y-3 border-t border-border pt-3">
+                      <p role="alert" className="text-sm text-destructive">
+                        Unlink {guardian.name ?? guardian.email} from{" "}
+                        {entry.player.name}? They keep their team access, but
+                        can no longer RSVP for this player.
+                      </p>
+                      <div className="flex gap-2">
+                        <form action={unlinkGuardianAction}>
+                          <input type="hidden" name="teamId" value={teamId} />
+                          <input type="hidden" name="entryId" value={entryId} />
+                          <input type="hidden" name="userId" value={guardian.id} />
+                          <Button type="submit" variant="destructive" size="sm">
+                            Yes, unlink
+                          </Button>
+                        </form>
+                        <Button asChild variant="outline" size="sm">
+                          <Link href={`/t/${teamId}/roster/${entryId}`}>
+                            Cancel
+                          </Link>
+                        </Button>
+                      </div>
+                    </div>
+                  ) : null}
                   <form
                     action={setGuardianPhoneAction}
                     className="flex items-end gap-2 border-t border-border pt-3"
@@ -281,13 +317,35 @@ export default async function RosterEntryPage({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form action={removeRosterEntryAction}>
-            <input type="hidden" name="teamId" value={teamId} />
-            <input type="hidden" name="entryId" value={entryId} />
-            <Button type="submit" variant="destructive">
-              Remove player
+          {/* Confirms like event deletion — removal also drops the entry's
+              jersey number, batting slot, and position, none of which can be
+              recovered by re-adding the player. */}
+          {confirmingRemoval ? (
+            <div className="space-y-3">
+              <p role="alert" className="text-sm text-destructive">
+                Remove {entry.player.name} from this roster? Their jersey
+                number, batting slot, and position on this team go with them.
+              </p>
+              <div className="flex gap-2">
+                <form action={removeRosterEntryAction}>
+                  <input type="hidden" name="teamId" value={teamId} />
+                  <input type="hidden" name="entryId" value={entryId} />
+                  <Button type="submit" variant="destructive">
+                    Yes, remove them
+                  </Button>
+                </form>
+                <Button asChild variant="outline">
+                  <Link href={`/t/${teamId}/roster/${entryId}`}>Cancel</Link>
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Button asChild variant="destructive">
+              <Link href={`/t/${teamId}/roster/${entryId}?confirm=remove`}>
+                Remove player
+              </Link>
             </Button>
-          </form>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/app/t/[teamId]/schedule/[eventId]/page.test.tsx
+++ b/src/app/t/[teamId]/schedule/[eventId]/page.test.tsx
@@ -294,3 +294,20 @@ describe("EventPage attendance", () => {
     expect(guardedRosteredPlayerIds).toHaveBeenCalledWith("team-1", "user-1");
   });
 });
+
+describe("EventPage location", () => {
+  it("links the location to a map", async () => {
+    const html = await render();
+
+    expect(html).toContain("https://maps.google.com/?q=Field%203");
+  });
+
+  it("shows a quiet placeholder when no location is set", async () => {
+    getEvent.mockResolvedValue({ ...game, location: null });
+
+    const html = await render();
+
+    expect(html).toContain("No location set.");
+    expect(html).not.toContain("maps.google.com");
+  });
+});

--- a/src/app/t/[teamId]/schedule/[eventId]/page.tsx
+++ b/src/app/t/[teamId]/schedule/[eventId]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card";
 import type { Role } from "@/generated/prisma/enums";
 import { formatEventDateTime, instantToWallClock } from "@/lib/calendar";
+import { mapsUrl } from "@/lib/maps";
 import { getRoster } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
 import { buildRsvpStateMap } from "@/lib/rsvp";
@@ -105,7 +106,18 @@ export default async function EventPage({
         </CardHeader>
         <CardContent className="space-y-1 text-sm">
           {event.location ? (
-            <p className="text-foreground">{event.location}</p>
+            <p className="text-foreground">
+              {/* Coach email and phone are already mailto:/tel: links; the
+                  location a parent has to drive to deserves the same. */}
+              <a
+                href={mapsUrl(event.location)}
+                target="_blank"
+                rel="noreferrer"
+                className="underline underline-offset-2 hover:text-primary"
+              >
+                {event.location}
+              </a>
+            </p>
           ) : (
             <p className="text-muted-foreground">No location set.</p>
           )}

--- a/src/app/t/[teamId]/schedule/page.test.tsx
+++ b/src/app/t/[teamId]/schedule/page.test.tsx
@@ -259,3 +259,13 @@ describe("SchedulePage feedback", () => {
     expect(await render({ added: "1" })).toContain("Event added.");
   });
 });
+
+describe("SchedulePage practice locations", () => {
+  it("links a practice's location to a map in the list view", async () => {
+    listUpcomingEvents.mockResolvedValue([practice]);
+
+    const html = await render({ view: "list" });
+
+    expect(html).toContain("https://maps.google.com/?q=Field%201");
+  });
+});

--- a/src/app/t/[teamId]/schedule/page.tsx
+++ b/src/app/t/[teamId]/schedule/page.tsx
@@ -24,6 +24,7 @@ import {
   WEEKDAY_LABELS,
   type CalendarMonth,
 } from "@/lib/calendar";
+import { mapsUrl } from "@/lib/maps";
 import {
   listEventsInMonthGrid,
   listPastEvents,
@@ -398,7 +399,18 @@ function PracticeCard({
             </span>
           </Link>
           {event.location ? (
-            <p className="mt-1 text-sm text-muted-foreground">{event.location}</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {/* Unlike the game ticket, the location here sits outside the
+                  event link, so it can be a map link without nesting anchors. */}
+              <a
+                href={mapsUrl(event.location)}
+                target="_blank"
+                rel="noreferrer"
+                className="underline underline-offset-2 hover:text-primary"
+              >
+                {event.location}
+              </a>
+            </p>
           ) : null}
         </CardContent>
       </Card>

--- a/src/app/t/[teamId]/settings/page.test.tsx
+++ b/src/app/t/[teamId]/settings/page.test.tsx
@@ -1,24 +1,78 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const requireTeamAccess = vi.fn();
+const getTeamById = vi.fn();
 
 vi.mock("@/lib/team-access", () => ({
-  requireTeamAccess: vi.fn().mockResolvedValue({ role: "OWNER", userId: "user-1" }),
+  requireTeamAccess: (...args: unknown[]) => requireTeamAccess(...args),
   TeamAccessError: class TeamAccessError extends Error {},
 }));
 
 vi.mock("@/lib/teams", () => ({
-  getTeamById: vi.fn().mockResolvedValue({
-    id: "team-1",
-    name: "Sharks",
-    season: "2026",
-    allPlay: true,
-    archivedAt: null,
-    createdAt: new Date("2026-07-28"),
-  }),
+  getTeamById: (...args: unknown[]) => getTeamById(...args),
 }));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+const ACTIVE_TEAM = {
+  id: "team-1",
+  name: "Sharks",
+  season: "2026",
+  allPlay: true,
+  archivedAt: null,
+  createdAt: new Date("2026-07-28"),
+};
+
+async function render(searchParams: Record<string, string> = {}) {
+  const { default: TeamSettingsPage } = await import("./page");
+  return renderToStaticMarkup(
+    await TeamSettingsPage({
+      params: Promise.resolve({ teamId: "team-1" }),
+      searchParams: Promise.resolve(searchParams),
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireTeamAccess.mockResolvedValue({ role: "OWNER", userId: "user-1" });
+  getTeamById.mockResolvedValue(ACTIVE_TEAM);
+});
 
 describe("Team settings page", () => {
   it("should export a default function", async () => {
     const { default: TeamSettingsPage } = await import("./page");
     expect(typeof TeamSettingsPage).toBe("function");
+  });
+
+  it("asks for confirmation before offering the archive button", async () => {
+    const html = await render();
+
+    expect(html).toContain("confirm=archive");
+    expect(html).not.toContain("Yes, archive it");
+  });
+
+  it("warns that archiving locks the owner out too, once confirming", async () => {
+    const html = await render({ confirm: "archive" });
+
+    expect(html).toContain("Yes, archive it");
+    expect(html).toContain("read-only for everyone");
+  });
+
+  it("never shows the archive confirm step on an archived team", async () => {
+    getTeamById.mockResolvedValue({
+      ...ACTIVE_TEAM,
+      archivedAt: new Date("2026-08-01"),
+    });
+
+    const html = await render({ confirm: "archive" });
+
+    expect(html).toContain("Unarchive team");
+    expect(html).not.toContain("Yes, archive it");
   });
 });

--- a/src/app/t/[teamId]/settings/page.tsx
+++ b/src/app/t/[teamId]/settings/page.tsx
@@ -31,10 +31,10 @@ export default async function TeamSettingsPage({
   searchParams,
 }: {
   params: Promise<{ teamId: string }>;
-  searchParams: Promise<{ error?: string; saved?: string }>;
+  searchParams: Promise<{ error?: string; saved?: string; confirm?: string }>;
 }) {
   const { teamId } = await params;
-  const { error, saved } = await searchParams;
+  const { error, saved, confirm } = await searchParams;
 
   try {
     await requireTeamAccess(teamId, { intent: "read", minRole: "OWNER" });
@@ -51,6 +51,7 @@ export default async function TeamSettingsPage({
   }
 
   const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const confirmingArchive = confirm === "archive" && !team.archivedAt;
 
   return (
     <div className="mx-auto w-full max-w-md space-y-6">
@@ -141,12 +142,39 @@ export default async function TeamSettingsPage({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form action={team.archivedAt ? unarchiveTeamAction : archiveTeamAction}>
-            <input type="hidden" name="teamId" value={teamId} />
-            <Button type="submit" variant={team.archivedAt ? "default" : "destructive"}>
-              {team.archivedAt ? "Unarchive team" : "Archive team"}
+          {/* Archiving locks out every write for every role, so it confirms
+              like event deletion does. Unarchiving undoes exactly that and
+              needs no ceremony. */}
+          {team.archivedAt ? (
+            <form action={unarchiveTeamAction}>
+              <input type="hidden" name="teamId" value={teamId} />
+              <Button type="submit">Unarchive team</Button>
+            </form>
+          ) : confirmingArchive ? (
+            <div className="space-y-3">
+              <p role="alert" className="text-sm text-destructive">
+                Archive this team? It becomes read-only for everyone — you
+                included — until it&rsquo;s unarchived.
+              </p>
+              <div className="flex gap-2">
+                <form action={archiveTeamAction}>
+                  <input type="hidden" name="teamId" value={teamId} />
+                  <Button type="submit" variant="destructive">
+                    Yes, archive it
+                  </Button>
+                </form>
+                <Button asChild variant="outline">
+                  <Link href={`/t/${teamId}/settings`}>Cancel</Link>
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Button asChild variant="destructive">
+              <Link href={`/t/${teamId}/settings?confirm=archive`}>
+                Archive team
+              </Link>
             </Button>
-          </form>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -412,3 +412,27 @@ describe("ViewPage chart rendering", () => {
     expect(html).not.toContain("RSVP is just for planning");
   });
 });
+
+describe("ViewPage next-game card", () => {
+  it("links to the game's event page, where RSVP lives", async () => {
+    const html = await render();
+
+    expect(html).toContain("/t/team-1/schedule/event-1");
+    expect(html).toContain("Game details");
+  });
+
+  it("links the location to a map", async () => {
+    const html = await render();
+
+    expect(html).toContain("https://maps.google.com/?q=Field%203");
+  });
+
+  it("offers neither when there is no upcoming game", async () => {
+    nextGame.mockResolvedValue(null);
+
+    const html = await render();
+
+    expect(html).not.toContain("Game details");
+    expect(html).not.toContain("maps.google.com");
+  });
+});

--- a/src/app/t/[teamId]/view/page.tsx
+++ b/src/app/t/[teamId]/view/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/card";
 import { buildChartView } from "@/lib/chart-view";
 import { formatEventDateTime } from "@/lib/calendar";
+import { mapsUrl } from "@/lib/maps";
 import { getChart } from "@/lib/roster";
 import { buildRsvpStateMap } from "@/lib/rsvp";
 import { listEventRsvps } from "@/lib/rsvps";
@@ -94,11 +95,25 @@ export default async function ViewPage({
               {formatEventDateTime(game.startsAt)}
             </CardDescription>
           </CardHeader>
-          {game.location ? (
-            <CardContent>
-              <p className="text-sm text-foreground">{game.location}</p>
-            </CardContent>
-          ) : null}
+          <CardContent className="space-y-3">
+            {game.location ? (
+              <p className="text-sm text-foreground">
+                <a
+                  href={mapsUrl(game.location)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2 hover:text-primary"
+                >
+                  {game.location}
+                </a>
+              </p>
+            ) : null}
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/t/${teamId}/schedule/${game.id}`}>
+                Game details &amp; RSVP
+              </Link>
+            </Button>
+          </CardContent>
         </Card>
       ) : (
         <Card>

--- a/src/lib/maps.test.ts
+++ b/src/lib/maps.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+
+import { mapsUrl } from "./maps";
+
+describe("mapsUrl", () => {
+  it("builds a Google Maps search for the location text", () => {
+    expect(mapsUrl("Field 3")).toBe("https://maps.google.com/?q=Field%203");
+  });
+
+  it("encodes characters that would break the query string", () => {
+    expect(mapsUrl("Rogers Park, 400 N Main & 5th")).toBe(
+      "https://maps.google.com/?q=Rogers%20Park%2C%20400%20N%20Main%20%26%205th",
+    );
+  });
+});

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -1,0 +1,9 @@
+/// Event locations are free text the coach typed — "Field 3, Rogers Park" —
+/// not coordinates, so the best any map can do is a search. The universal
+/// query URL works everywhere without knowing the device: Android and desktop
+/// open Google Maps, and iOS opens it in the browser (or the app when
+/// installed) with a one-tap path into Apple Maps. A `geo:` URI or an Apple
+/// Maps URL would each strand the other platform.
+export function mapsUrl(location: string): string {
+  return `https://maps.google.com/?q=${encodeURIComponent(location)}`;
+}


### PR DESCRIPTION
## Summary

Ships the three "quick win" findings from the August 2026 UX audit (Dugout Report P6, P7, C6): event locations become map links, the Lineup page's next-game card now links to the event it describes, and the three unguarded destructive actions (archive team, remove player, unlink guardian) gain the same confirmation step event deletion already has.

## Key Decisions

- **Map links use the universal Google Maps query URL** (`https://maps.google.com/?q=…`), built by a new pure helper `src/lib/maps.ts`. Locations are free text the coach typed, not coordinates, so a search is the best any map can do; this URL works on Android, desktop, and iOS alike, where a `geo:` URI or Apple Maps URL would each strand the other platform.
- **The game ticket's location stays plain text.** In the schedule list, a game's location renders inside the card-wide link to the event page, and HTML forbids nested anchors. Practices keep their location outside the link, so they got the map link; for games, the event detail page carries it.
- **Confirmations reuse the `?confirm=` query-param pattern** from event deletion rather than introducing client-side dialogs — no new client components, works without JS, and keeps the app's one existing confirmation vocabulary. Unlink confirms per guardian row (`?confirm=unlink&guardian=<id>`) so other rows keep their one-tap buttons. Unarchiving does not confirm: it only undoes the lock.
- **Confirmation copy states the actual cost** ("read-only for everyone — you included", "their jersey number, batting slot, and position on this team go with them") instead of a generic "are you sure."

## What's in Scope

- `src/lib/maps.ts` + tests — pure `mapsUrl()` helper
- Map-linked locations: event detail page, schedule list practice cards, view page next-game card
- View page next-game card: "Game details &amp; RSVP" button linking to `/schedule/[eventId]`
- Confirm steps: archive team (settings), remove player and unlink guardian (roster entry page)
- Page tests for all of the above (933 tests passing)

### Out of Scope

- One-tap RSVP from the home page and kid highlighting — tracked in #48 and #49
- Bench section on the view page — #50
- Coach flow improvements (schedule entry, nav labels, form feedback) — #51
- Notification emails and PWA setup — #45, #46, #47

## Known Gaps / Follow-ups

- No live database in this environment, so the flows were verified through the co-located page tests (static render assertions), not a browser walkthrough. The changes are all server-rendered markup with no new client components, so test coverage maps closely to runtime behavior.

## Test Plan

- [ ] Run this repo's full check gate (see `AGENTS.md` → `## Commands`): `pnpm check` — lint, typecheck, and 933 tests pass locally.
- [ ] `pnpm dev`, open a team's Lineup page with an upcoming game: the next-game card shows the location as an underlined link opening Google Maps in a new tab, and a "Game details & RSVP" button that lands on the event page.
- [ ] On the event page, the location line is a map link; an event with no location still reads "No location set."
- [ ] Settings → "Archive team" now requires a second tap ("Yes, archive it"); Cancel returns to settings; an archived team shows only "Unarchive team" even with `?confirm=archive` in the URL.
- [ ] Roster → player page: "Remove player" and each guardian's "Unlink" require a named confirmation; confirming one guardian's unlink leaves the other rows' buttons untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PexUzh3JT9Jd2Kcymwwi4m

---
_Generated by [Claude Code](https://claude.ai/code/session_01PexUzh3JT9Jd2Kcymwwi4m)_