### PR TITLE
RSVP edge cases and invitation onboarding polish

### DIFF
--- a/src/app/invite/[token]/actions.test.ts
+++ b/src/app/invite/[token]/actions.test.ts
@@ -105,8 +105,9 @@ describe("acceptInvitationAction", () => {
   it("grants the membership, writes a session cookie, and lands on the team", async () => {
     expect(await destinationOf(form("tok-1"))).toBe("/t/team-1");
 
-    // The address comes from the invitation row, never from the form.
-    expect(resolveInvitedUser).toHaveBeenCalledWith("sam@example.com", NOW);
+    // The address comes from the invitation row, never from the form; no
+    // name was offered, so none is passed.
+    expect(resolveInvitedUser).toHaveBeenCalledWith("sam@example.com", NOW, null);
     expect(acceptInvitations).toHaveBeenCalledWith(
       "user-1",
       "sam@example.com",
@@ -124,6 +125,28 @@ describe("acceptInvitationAction", () => {
         expires: EXPIRES,
       },
     );
+  });
+
+  it("passes a trimmed optional name through to resolveInvitedUser", async () => {
+    const data = form("tok-1");
+    data.set("name", "  Sam Rivera  ");
+
+    await destinationOf(data);
+
+    expect(resolveInvitedUser).toHaveBeenCalledWith(
+      "sam@example.com",
+      NOW,
+      "Sam Rivera",
+    );
+  });
+
+  it("treats a blank name as not provided", async () => {
+    const data = form("tok-1");
+    data.set("name", "   ");
+
+    await destinationOf(data);
+
+    expect(resolveInvitedUser).toHaveBeenCalledWith("sam@example.com", NOW, null);
   });
 
   it("writes the unprefixed cookie name over plain HTTP", async () => {

--- a/src/app/invite/[token]/actions.ts
+++ b/src/app/invite/[token]/actions.ts
@@ -45,6 +45,12 @@ export async function acceptInvitationAction(formData: FormData) {
     throw new Error("Invalid invitation token");
   }
 
+  // Optional, and blank means "not now" — /profile edits it later. Truncated
+  // rather than rejected past the input's own maxLength, because a name is
+  // never a reason to fail an acceptance.
+  const rawName = String(formData.get("name") ?? "").trim();
+  const name = rawName === "" ? null : rawName.slice(0, 200);
+
   // Set only once everything below has succeeded, so any failure leaves the
   // parent on the invite page with an error rather than at a team URL they
   // have no session for.
@@ -68,7 +74,7 @@ export async function acceptInvitationAction(formData: FormData) {
       redirect(`/invite/${token}`);
     }
 
-    const user = await resolveInvitedUser(invitation.email, now);
+    const user = await resolveInvitedUser(invitation.email, now, name);
 
     // Order matters. This is the same idempotent write Auth.js runs from
     // `events.signIn`, and it goes first: if the session insert below fails,

--- a/src/app/invite/[token]/page.test.tsx
+++ b/src/app/invite/[token]/page.test.tsx
@@ -49,6 +49,17 @@ describe("Invite page", () => {
     expect(markup).toContain("Invitation not found");
   });
 
+  // Neither failure state may dead-end: a revoked or expired invitation often
+  // belongs to someone whose Membership already exists, so sign-in works.
+  it("offers a way out of the unknown-token state", async () => {
+    getInvitationByToken.mockResolvedValue(null);
+
+    const markup = await render("bad-token");
+
+    expect(markup).toContain("/signin");
+    expect(markup).toContain("Go to sign in");
+  });
+
   it("shows an already-accepted state and a link to sign in", async () => {
     getInvitationByToken.mockResolvedValue({
       teamId: "team-1",
@@ -78,6 +89,23 @@ describe("Invite page", () => {
     const markup = await render("tok-1");
 
     expect(markup).toContain("Invitation expired");
+    expect(markup).toContain("Go to sign in");
+  });
+
+  it("asks for an optional name on the live invitation form", async () => {
+    getInvitationByToken.mockResolvedValue({
+      teamId: "team-1",
+      teamName: "Cubs",
+      email: "sam@example.com",
+      role: "PARENT",
+      expiresAt: new Date(NOW.getTime() + 1000),
+      acceptedAt: null,
+    });
+
+    const markup = await render("tok-1");
+
+    expect(markup).toContain("Your name (optional)");
+    expect(markup).toContain('name="name"');
   });
 
   it("shows the accept form for a live invitation, with the email masked", async () => {

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -54,8 +54,15 @@ export default async function InvitePage({
       <PageContainer>
         <StatusCard
           title="Invitation not found"
-          description="This invitation link isn't valid. Ask your coach to check the address and send a new one."
-        />
+          description="This invitation link isn't valid. Ask your coach to check the address and send a new one — or, if you've been on this team before, sign in the regular way."
+        >
+          {/* Never a dead end: a revoked invitation usually belongs to
+              someone whose Membership already exists (linkGuardian grants it
+              at link time), so the sign-in page will let them in. */}
+          <Button asChild variant="outline" className="w-full">
+            <Link href="/signin">Go to sign in</Link>
+          </Button>
+        </StatusCard>
       </PageContainer>
     );
   }
@@ -80,8 +87,12 @@ export default async function InvitePage({
       <PageContainer>
         <StatusCard
           title="Invitation expired"
-          description="This invitation has expired. Ask your coach to send a new one."
-        />
+          description="This invitation has expired. Ask your coach to send a new one — or try signing in, since your spot on the team may already be set up."
+        >
+          <Button asChild variant="outline" className="w-full">
+            <Link href="/signin">Go to sign in</Link>
+          </Button>
+        </StatusCard>
       </PageContainer>
     );
   }
@@ -105,8 +116,35 @@ export default async function InvitePage({
               </p>
             ) : null}
 
-            <form action={acceptInvitationAction}>
+            <form action={acceptInvitationAction} className="space-y-4">
               <input type="hidden" name="token" value={token} />
+
+              {/* The one chance to ask — nothing else in the app prompts for
+                  a name, so skipping this leaves the coach's directory
+                  showing a bare email address. Optional: the button works
+                  with it blank, and /profile can fill it in later. */}
+              <div className="space-y-2">
+                <label
+                  htmlFor="name"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  Your name (optional)
+                </label>
+                <input
+                  id="name"
+                  name="name"
+                  type="text"
+                  autoComplete="name"
+                  maxLength={200}
+                  placeholder="Your name"
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+                <p className="text-xs text-muted-foreground">
+                  So your coaches see a name, not just an email address. You
+                  can add or change it any time from your profile.
+                </p>
+              </div>
+
               <Button type="submit" className="w-full">
                 Accept invitation
               </Button>

--- a/src/app/t/[teamId]/schedule/[eventId]/page.test.tsx
+++ b/src/app/t/[teamId]/schedule/[eventId]/page.test.tsx
@@ -6,6 +6,7 @@ const getEvent = vi.fn();
 const getRoster = vi.fn();
 const listEventRsvps = vi.fn();
 const guardedRosteredPlayerIds = vi.fn();
+const getTeamById = vi.fn();
 
 vi.mock("@/lib/team-access", () => ({
   requireTeamAccess: (...args: unknown[]) => requireTeamAccess(...args),
@@ -25,6 +26,10 @@ vi.mock("@/lib/rsvps", () => ({
   guardedRosteredPlayerIds: (...args: unknown[]) => guardedRosteredPlayerIds(...args),
 }));
 
+vi.mock("@/lib/teams", () => ({
+  getTeamById: (...args: unknown[]) => getTeamById(...args),
+}));
+
 vi.mock("../actions", () => ({
   updateEventAction: vi.fn(),
   deleteEventAction: vi.fn(),
@@ -42,12 +47,17 @@ import { TeamAccessError } from "@/lib/team-access";
 const game = {
   id: "event-1",
   type: "GAME" as const,
-  // 6:00 PM Central on 15 August 2026 (CDT, UTC-5).
+  // 6:00 PM Central on 15 August 2026 (CDT, UTC-5). In the past relative to
+  // any real test run, so RSVP-button tests use futureGame below.
   startsAt: new Date("2026-08-15T23:00:00Z"),
   location: "Field 3",
   opponent: "Hawks",
   notes: "Bring water",
 };
+
+/// RSVPs close for past events, so tests asserting live RSVP controls pin a
+/// date that stays in the future.
+const futureGame = { ...game, startsAt: new Date("2100-08-15T23:00:00Z") };
 
 async function render(searchParams: Record<string, string> = {}) {
   const { default: EventPage } = await import("./page");
@@ -76,6 +86,12 @@ beforeEach(() => {
   getRoster.mockResolvedValue([]);
   listEventRsvps.mockResolvedValue([]);
   guardedRosteredPlayerIds.mockResolvedValue(new Set());
+  getTeamById.mockResolvedValue({
+    id: "team-1",
+    name: "Sharks",
+    allPlay: true,
+    archivedAt: null,
+  });
 });
 
 describe("EventPage access", () => {
@@ -252,6 +268,7 @@ describe("EventPage attendance", () => {
   });
 
   it("offers Going / Not going toggles only for players the caller guards", async () => {
+    getEvent.mockResolvedValue(futureGame);
     getRoster.mockResolvedValue(roster);
     guardedRosteredPlayerIds.mockResolvedValue(new Set(["ava"]));
 
@@ -263,6 +280,76 @@ describe("EventPage attendance", () => {
     const benFormCount = html.split('value="ben"').length - 1;
     expect(avaFormCount).toBe(2);
     expect(benFormCount).toBe(0);
+  });
+
+  it("adds a Clear button once a guarded player has a response", async () => {
+    getEvent.mockResolvedValue(futureGame);
+    getRoster.mockResolvedValue(roster);
+    guardedRosteredPlayerIds.mockResolvedValue(new Set(["ava"]));
+    listEventRsvps.mockResolvedValue([{ playerId: "ava", attending: true }]);
+
+    const html = await render();
+
+    // Going + Not going + Clear = three rsvpAction forms for Ava.
+    expect(html.split('value="ava"').length - 1).toBe(3);
+    expect(html).toContain("Clear");
+    expect(html).toContain('value="clear"');
+  });
+
+  it("offers no Clear button while a player is still at no-response", async () => {
+    getEvent.mockResolvedValue(futureGame);
+    getRoster.mockResolvedValue(roster);
+    guardedRosteredPlayerIds.mockResolvedValue(new Set(["ava"]));
+
+    const html = await render();
+
+    expect(html).not.toContain('value="clear"');
+  });
+
+  it("closes RSVPs for a past event, keeping the states visible", async () => {
+    // The shared fixture's 2026 date is already past.
+    getRoster.mockResolvedValue(roster);
+    guardedRosteredPlayerIds.mockResolvedValue(new Set(["ava"]));
+    listEventRsvps.mockResolvedValue([{ playerId: "ava", attending: true }]);
+
+    const html = await render();
+
+    expect(html).toContain("This event has already happened, so RSVPs are closed.");
+    // The state badge stays; the buttons go.
+    expect(html).toContain("Going");
+    expect(html.split('value="ava"').length - 1).toBe(0);
+  });
+
+  it("closes RSVPs on an archived team and says why", async () => {
+    getEvent.mockResolvedValue(futureGame);
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sharks",
+      allPlay: true,
+      archivedAt: new Date("2026-08-01"),
+    });
+    getRoster.mockResolvedValue(roster);
+    guardedRosteredPlayerIds.mockResolvedValue(new Set(["ava"]));
+
+    const html = await render();
+
+    expect(html).toContain("This team is archived and read-only");
+    expect(html.split('value="ava"').length - 1).toBe(0);
+  });
+
+  it("hides the edit and delete controls on an archived team", async () => {
+    getEvent.mockResolvedValue(futureGame);
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sharks",
+      allPlay: true,
+      archivedAt: new Date("2026-08-01"),
+    });
+
+    const html = await render();
+
+    expect(html).not.toContain("Edit event");
+    expect(html).not.toContain("Delete event");
   });
 
   it("lists players in the same order as the roster page, not database order", async () => {

--- a/src/app/t/[teamId]/schedule/[eventId]/page.tsx
+++ b/src/app/t/[teamId]/schedule/[eventId]/page.tsx
@@ -11,7 +11,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { Role } from "@/generated/prisma/enums";
-import { formatEventDateTime, instantToWallClock } from "@/lib/calendar";
+import {
+  formatEventDateTime,
+  instantToWallClock,
+  startOfDayInZone,
+} from "@/lib/calendar";
 import { mapsUrl } from "@/lib/maps";
 import { getRoster } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
@@ -19,6 +23,7 @@ import { buildRsvpStateMap } from "@/lib/rsvp";
 import { guardedRosteredPlayerIds, listEventRsvps } from "@/lib/rsvps";
 import { getEvent } from "@/lib/schedule";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
+import { getTeamById } from "@/lib/teams";
 
 import { deleteEventAction, rsvpAction, updateEventAction } from "../actions";
 
@@ -34,6 +39,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   "invalid-notes": "Notes are too long.",
   "invalid-rsvp": "Choose a valid response.",
   "not-your-player": "You can only RSVP for your own kids.",
+  "event-past": "This event has already happened — RSVPs are closed.",
   access: "You no longer have access to make this change.",
 };
 
@@ -70,10 +76,11 @@ export default async function EventPage({
     notFound();
   }
 
-  const [rosterEntries, rsvpRows, guardedPlayerIds] = await Promise.all([
+  const [rosterEntries, rsvpRows, guardedPlayerIds, team] = await Promise.all([
     getRoster(teamId),
     listEventRsvps(teamId, eventId),
     guardedRosteredPlayerIds(teamId, userId),
+    getTeamById(teamId),
   ]);
   // Same order as the roster page — getRoster has no orderBy, so without this
   // the same team lists in a different (and unstable) order on each page.
@@ -83,7 +90,16 @@ export default async function EventPage({
     rsvpRows,
   );
 
-  const canEdit = role !== "PARENT";
+  // Both gates that silently swallowed writes now suppress the controls
+  // instead: an archived team rejects every mutation (edit and delete
+  // included), and RSVPs close once the event's day is over — the same
+  // start-of-today boundary the schedule's Upcoming/Past split uses, and the
+  // same check rsvpAction enforces server-side.
+  const archived = Boolean(team?.archivedAt);
+  const rsvpOpen =
+    !archived && event.startsAt >= startOfDayInZone(new Date());
+
+  const canEdit = role !== "PARENT" && !archived;
   const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
   const confirmingDelete = confirm === "delete";
   const heading =
@@ -147,7 +163,17 @@ export default async function EventPage({
             either way.
           </CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-3">
+          {archived ? (
+            <p className="text-sm text-muted-foreground">
+              This team is archived and read-only — RSVPs are closed.
+            </p>
+          ) : !rsvpOpen ? (
+            <p className="text-sm text-muted-foreground">
+              This event has already happened, so RSVPs are closed.
+            </p>
+          ) : null}
+
           {roster.length === 0 ? (
             <p className="text-sm text-muted-foreground">No players on the roster yet.</p>
           ) : (
@@ -157,7 +183,7 @@ export default async function EventPage({
                 // `no-response` is styled distinct from `declined` — it means
                 // the family hasn't answered, not that they said no. See rsvp.ts.
                 const badge = RSVP_STYLE[state];
-                const canRsvp = guardedPlayerIds.has(entry.player.id);
+                const canRsvp = rsvpOpen && guardedPlayerIds.has(entry.player.id);
 
                 return (
                   <li
@@ -198,6 +224,23 @@ export default async function EventPage({
                             Not going
                           </Button>
                         </form>
+                        {state !== "no-response" ? (
+                          // The way back to "No response" — without it, one
+                          // mis-tap into either button is permanent.
+                          <form action={rsvpAction}>
+                            <input type="hidden" name="teamId" value={teamId} />
+                            <input type="hidden" name="eventId" value={event.id} />
+                            <input
+                              type="hidden"
+                              name="playerId"
+                              value={entry.player.id}
+                            />
+                            <input type="hidden" name="response" value="clear" />
+                            <Button type="submit" size="sm" variant="ghost">
+                              Clear
+                            </Button>
+                          </form>
+                        ) : null}
                       </div>
                     ) : null}
                   </li>

--- a/src/app/t/[teamId]/schedule/actions.test.ts
+++ b/src/app/t/[teamId]/schedule/actions.test.ts
@@ -7,6 +7,7 @@ const updateEvent = vi.fn();
 const deleteEvent = vi.fn();
 const guardedRosteredPlayerIds = vi.fn();
 const upsertRsvp = vi.fn();
+const clearRsvp = vi.fn();
 
 vi.mock("@/lib/team-access", () => ({
   requireTeamAccess: (...args: unknown[]) => requireTeamAccess(...args),
@@ -23,6 +24,7 @@ vi.mock("@/lib/schedule", () => ({
 vi.mock("@/lib/rsvps", () => ({
   guardedRosteredPlayerIds: (...args: unknown[]) => guardedRosteredPlayerIds(...args),
   upsertRsvp: (...args: unknown[]) => upsertRsvp(...args),
+  clearRsvp: (...args: unknown[]) => clearRsvp(...args),
 }));
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
@@ -86,7 +88,9 @@ beforeEach(() => {
   getEvent.mockResolvedValue({
     id: "event-1",
     type: "GAME",
-    startsAt: new Date("2026-08-15T23:00:00Z"),
+    // Far future: rsvpAction rejects past events, and these tests assert the
+    // happy path. The past-event case pins its own date.
+    startsAt: new Date("2100-08-15T23:00:00Z"),
     location: "Field 3",
     opponent: "Hawks",
     notes: null,
@@ -316,6 +320,35 @@ describe("rsvpAction", () => {
     const url = await redirectUrlOf(() => rsvpAction(rsvpForm));
 
     expect(url).toBe("/t/team-1/schedule/event-1?saved=1");
+  });
+
+  it("deletes the row for a clear response, returning the family to no-response", async () => {
+    clearRsvp.mockResolvedValue(undefined);
+
+    const url = await redirectUrlOf(() =>
+      rsvpAction(form({ ...Object.fromEntries(rsvpForm), response: "clear" })),
+    );
+
+    expect(clearRsvp).toHaveBeenCalledWith("event-1", "player-1");
+    expect(upsertRsvp).not.toHaveBeenCalled();
+    expect(url).toBe("/t/team-1/schedule/event-1?saved=1");
+  });
+
+  it("refuses to RSVP an event whose day has passed, without writing", async () => {
+    getEvent.mockResolvedValue({
+      id: "event-1",
+      type: "GAME",
+      startsAt: new Date("2020-08-15T23:00:00Z"),
+      location: "Field 3",
+      opponent: "Hawks",
+      notes: null,
+    });
+
+    const url = await redirectUrlOf(() => rsvpAction(rsvpForm));
+
+    expect(url).toBe("/t/team-1/schedule/event-1?error=event-past");
+    expect(upsertRsvp).not.toHaveBeenCalled();
+    expect(clearRsvp).not.toHaveBeenCalled();
   });
 
   it("rejects a response value outside the enum, without writing", async () => {

--- a/src/app/t/[teamId]/schedule/actions.ts
+++ b/src/app/t/[teamId]/schedule/actions.ts
@@ -4,8 +4,8 @@ import { revalidatePath } from "next/cache";
 import { redirect, unstable_rethrow } from "next/navigation";
 import { z } from "zod";
 
-import { wallClockToInstant } from "@/lib/calendar";
-import { guardedRosteredPlayerIds, upsertRsvp } from "@/lib/rsvps";
+import { startOfDayInZone, wallClockToInstant } from "@/lib/calendar";
+import { clearRsvp, guardedRosteredPlayerIds, upsertRsvp } from "@/lib/rsvps";
 import {
   createEvent,
   deleteEvent,
@@ -221,7 +221,11 @@ export async function deleteEventAction(formData: FormData) {
   redirect(`/t/${teamId}/schedule`);
 }
 
-const rsvpResponseSchema = z.enum(["attending", "declined"]);
+/// "clear" returns the family to no-response — deleting the row, not writing
+/// a third value. Without it, one mis-tap into Going or Not going is
+/// permanent: the tri-state model has an absent-row state the UI could
+/// otherwise never reach again.
+const rsvpResponseSchema = z.enum(["attending", "declined", "clear"]);
 
 /**
  * Prove the caller may write to this team, that the event they named is on
@@ -269,7 +273,20 @@ export async function rsvpAction(formData: FormData) {
     // Write against the id `getEvent` resolved, not the raw form field — same
     // convention as the roster actions deriving playerId from getRosterEntry.
     const event = await requireGuardedEvent(teamId, eventId, playerId);
-    await upsertRsvp(event.id, playerId, parsedResponse.data === "attending");
+
+    // RSVPs close once the event's day has passed — the same start-of-today
+    // boundary that moves it from Upcoming to Past on the schedule, so a
+    // family can still respond to tonight's game after first pitch, but
+    // last month's attendance can't be rewritten from the "Show past" list.
+    if (event.startsAt < startOfDayInZone(new Date())) {
+      redirect(`/t/${teamId}/schedule/${eventId}?error=event-past`);
+    }
+
+    if (parsedResponse.data === "clear") {
+      await clearRsvp(event.id, playerId);
+    } else {
+      await upsertRsvp(event.id, playerId, parsedResponse.data === "attending");
+    }
   } catch (error) {
     unstable_rethrow(error);
     if (error instanceof TeamAccessError) {

--- a/src/lib/invitations.test.ts
+++ b/src/lib/invitations.test.ts
@@ -13,6 +13,8 @@ const upsertGuardianPlayer = vi.fn();
 const deleteGuardianPlayer = vi.fn();
 const findUniqueGuardianPlayer = vi.fn();
 const updateUser = vi.fn();
+const findFirstUser = vi.fn();
+const createUser = vi.fn();
 const transaction = vi.fn();
 
 vi.mock("./db", () => ({
@@ -32,6 +34,8 @@ vi.mock("./db", () => ({
     user: {
       upsert: (...args: unknown[]) => upsertUser(...args),
       update: (...args: unknown[]) => updateUser(...args),
+      findFirst: (...args: unknown[]) => findFirstUser(...args),
+      create: (...args: unknown[]) => createUser(...args),
     },
     guardianPlayer: {
       upsert: (...args: unknown[]) => upsertGuardianPlayer(...args),
@@ -49,6 +53,7 @@ import {
   linkGuardian,
   listTeamInvitations,
   loadSignInContext,
+  resolveInvitedUser,
   setGuardianPhone,
   unlinkGuardian,
 } from "./invitations";
@@ -452,6 +457,68 @@ describe("setGuardianPhone", () => {
     findUniqueGuardianPlayer.mockResolvedValue(null);
 
     await expect(setGuardianPhone("player-1", "user-1", "555-1234")).rejects.toThrow();
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveInvitedUser", () => {
+  it("creates a new user carrying the offered name", async () => {
+    findFirstUser.mockResolvedValue(null);
+    createUser.mockResolvedValue({ id: "user-2", email: "sam@example.com" });
+
+    const user = await resolveInvitedUser("Sam@Example.com", NOW, "Sam Rivera");
+
+    expect(createUser).toHaveBeenCalledWith({
+      data: {
+        email: "sam@example.com",
+        emailVerified: NOW,
+        name: "Sam Rivera",
+      },
+      select: { id: true, email: true },
+    });
+    expect(user).toEqual({ id: "user-2", email: "sam@example.com" });
+  });
+
+  it("fills a blank name on an existing user, alongside verification", async () => {
+    findFirstUser.mockResolvedValue({
+      id: "user-2",
+      email: "sam@example.com",
+      emailVerified: null,
+      name: null,
+    });
+    updateUser.mockResolvedValue({});
+
+    await resolveInvitedUser("sam@example.com", NOW, "Sam Rivera");
+
+    expect(updateUser).toHaveBeenCalledWith({
+      where: { id: "user-2" },
+      data: { emailVerified: NOW, name: "Sam Rivera" },
+    });
+  });
+
+  it("never overwrites a name the person already has", async () => {
+    findFirstUser.mockResolvedValue({
+      id: "user-2",
+      email: "sam@example.com",
+      emailVerified: NOW,
+      name: "Samantha Rivera",
+    });
+
+    await resolveInvitedUser("sam@example.com", NOW, "Sam");
+
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing for a verified user when no name is offered", async () => {
+    findFirstUser.mockResolvedValue({
+      id: "user-2",
+      email: "sam@example.com",
+      emailVerified: NOW,
+      name: null,
+    });
+
+    await resolveInvitedUser("sam@example.com", NOW);
+
     expect(updateUser).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/invitations.ts
+++ b/src/lib/invitations.ts
@@ -113,19 +113,30 @@ export async function acceptInvitations(
 export async function resolveInvitedUser(
   email: string,
   now: Date = new Date(),
+  name: string | null = null,
 ): Promise<{ id: string; email: string }> {
   const address = normalizeEmail(email);
 
   const existing = await db.user.findFirst({
     where: { email: { equals: address, mode: "insensitive" } },
-    select: { id: true, email: true, emailVerified: true },
+    select: { id: true, email: true, emailVerified: true, name: true },
   });
 
   if (existing) {
+    // The name only ever fills a blank. An existing name was either typed by
+    // the person at /profile or seen and kept by them — a returning parent
+    // re-accepting an invitation must not overwrite it.
+    const data: { emailVerified?: Date; name?: string } = {};
     if (existing.emailVerified === null) {
+      data.emailVerified = now;
+    }
+    if (name !== null && existing.name === null) {
+      data.name = name;
+    }
+    if (Object.keys(data).length > 0) {
       await db.user.update({
         where: { id: existing.id },
-        data: { emailVerified: now },
+        data,
       });
     }
 
@@ -133,7 +144,7 @@ export async function resolveInvitedUser(
   }
 
   return db.user.create({
-    data: { email: address, emailVerified: now },
+    data: { email: address, emailVerified: now, name },
     select: { id: true, email: true },
   });
 }

--- a/src/lib/rsvps.test.ts
+++ b/src/lib/rsvps.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const findManyRsvps = vi.fn();
 const upsertRsvpMock = vi.fn();
+const deleteManyRsvps = vi.fn();
 const findManyGuardianPlayers = vi.fn();
 
 vi.mock("./db", () => ({
@@ -9,6 +10,7 @@ vi.mock("./db", () => ({
     rsvp: {
       findMany: (...args: unknown[]) => findManyRsvps(...args),
       upsert: (...args: unknown[]) => upsertRsvpMock(...args),
+      deleteMany: (...args: unknown[]) => deleteManyRsvps(...args),
     },
     guardianPlayer: {
       findMany: (...args: unknown[]) => findManyGuardianPlayers(...args),
@@ -16,7 +18,12 @@ vi.mock("./db", () => ({
   },
 }));
 
-import { guardedRosteredPlayerIds, listEventRsvps, upsertRsvp } from "./rsvps";
+import {
+  clearRsvp,
+  guardedRosteredPlayerIds,
+  listEventRsvps,
+  upsertRsvp,
+} from "./rsvps";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -93,5 +100,23 @@ describe("upsertRsvp", () => {
       create: { eventId: "event-1", playerId: "ava", attending: true },
       update: { attending: true },
     });
+  });
+});
+
+describe("clearRsvp", () => {
+  it("deletes the row for exactly this event and player", async () => {
+    deleteManyRsvps.mockResolvedValue({ count: 1 });
+
+    await clearRsvp("event-1", "player-1");
+
+    expect(deleteManyRsvps).toHaveBeenCalledWith({
+      where: { eventId: "event-1", playerId: "player-1" },
+    });
+  });
+
+  it("is a no-op rather than an error when no row exists", async () => {
+    deleteManyRsvps.mockResolvedValue({ count: 0 });
+
+    await expect(clearRsvp("event-1", "player-1")).resolves.toBeUndefined();
   });
 });

--- a/src/lib/rsvps.ts
+++ b/src/lib/rsvps.ts
@@ -55,3 +55,17 @@ export async function upsertRsvp(
     update: { attending },
   });
 }
+
+/// Returns the family to "no response" — a real modelled state (the absent
+/// row), which a mis-tap into Going or Not going could otherwise never reach
+/// again. `deleteMany` rather than `delete` so clearing an already-clear
+/// response is a no-op instead of a P2025. Same trust contract as
+/// `upsertRsvp`: callers have already proven event and guardianship.
+export async function clearRsvp(
+  eventId: string,
+  playerId: string,
+): Promise<void> {
+  await db.rsvp.deleteMany({
+    where: { eventId, playerId },
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #52, closing out the two remaining small-fix bundles from the August 2026 UX audit: the RSVP mechanics' dead ends (no way back to "No response", past events accepting RSVPs, archived teams showing controls that fail on submit) and the invitation flow's rough edges (dead-end error pages, no chance to give a name).

**Stacked on #52** — based against `claude/app-ux-parents-coaches-c9qk59` because both touch the event page; GitHub will retarget this to `main` once #52 merges.

## Key Decisions

- **"Clear" deletes the Rsvp row rather than writing a third value.** "No response" is already modelled as the absent row (`buildRsvpStateMap`), so the fix is a `deleteMany` (`clearRsvp` in `src/lib/rsvps.ts`) — idempotent, no schema change, and the tri-state vocabulary in `rsvp-style.ts` stays frozen at three states.
- **The RSVP cutoff reuses the schedule's own boundary** — start of today in `APP_TIMEZONE` (`startOfDayInZone`), the same line that moves an event from Upcoming to Past. A family can still respond to tonight's game after first pitch, but last month's attendance can't be rewritten from the "Show past" list. Enforced server-side in `rsvpAction` and mirrored in the page render.
- **Archived teams suppress controls instead of failing them.** The event page now loads the team and hides RSVP buttons and the edit/delete cards when `archivedAt` is set, with a plain "archived and read-only" note — previously the buttons rendered and every submit failed with "You no longer have access to make this change," which misdescribes the cause.
- **The invitation name only ever fills a blank.** `resolveInvitedUser` gains an optional `name` that is written on user creation or when the existing name is null, and never overwrites — a returning parent re-accepting an invitation keeps whatever they set at `/profile`. Acceptance never fails over a name (blank means "not now", over-long is truncated).

## What's in Scope

- `clearRsvp` + "Clear" button on the event page (renders only once a response exists)
- Past-event RSVP guard (`?error=event-past`) and "RSVPs are closed" page state
- Archived-team awareness on the event page (RSVP + coach controls suppressed, notice shown)
- "Go to sign in" exits on the invalid-token and expired invitation pages
- Optional name field on the invitation accept form, threaded through `acceptInvitationAction` → `resolveInvitedUser`
- 17 new tests across `rsvps`, `invitations`, both actions files, and both pages (950 passing)

### Out of Scope

- Coach-recorded absences (#54), readiness effective order + editor decline badges (#55), broadcast messaging (#56), ICS calendar feed (#57), one-level chart undo (#58)
- A first-visit name nudge for parents who skip the field — `/profile` remains the fallback

## Known Gaps / Follow-ups

- No live database here, so verification is through the co-located tests (static render + action redirect assertions) rather than a browser walkthrough. All changes are server-rendered forms with no new client components.

## Test Plan

- [ ] Run this repo's full check gate (see `AGENTS.md` → `## Commands`): `pnpm check` — lint, typecheck, and 950 tests pass locally.
- [ ] On a future event as a parent: tap "Going", confirm a "Clear" button appears, tap it, confirm the kid returns to "No response".
- [ ] Open a past event from "Show past": state badges render, buttons don't, and the card says RSVPs are closed. Submitting a forged RSVP form against it redirects with "This event has already happened — RSVPs are closed."
- [ ] Archive a team, open one of its events: no RSVP buttons, no Edit/Delete cards, and an "archived and read-only" note.
- [ ] Open an invalid and an expired invitation link: both offer "Go to sign in".
- [ ] Accept a fresh invitation with a name typed: the directory shows the name immediately; accept another as an existing user with a profile name and confirm it is not overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PexUzh3JT9Jd2Kcymwwi4m