### PR TITLE
Stop a hand-typed ?error= from crashing twelve pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,12 +352,14 @@ production — the dev command can prompt, generate new migrations, and reset th
   The prior question is whether the team has a chart at all: with none, every position a
   page prints is one nobody assigned, which is why `hasChartSet` (`chart-view.ts`) gates
   the line on team home and the whole panel on `/view` and `/readiness`.
-- **A `?error=` key is attacker-chosen, so its lookup table needs a null prototype.** On a
+- **A `?error=` key is attacker-chosen, so never build its lookup table by hand.** On a
   plain object literal `?error=constructor` resolves an `Object.prototype` member — truthy,
   so the `??` fallback never fires — and React throws "Functions are not valid as a React
-  child" on the way out. `/profile` and team home use
-  `Object.assign(Object.create(null), {…})`; the older `ERROR_MESSAGES` tables under
-  `schedule/` and `roster/` still don't and are worth hardening when next touched.
+  child" on the way out, crashing the page from a hand-typed URL. Every page goes through
+  `messageTable` / `messageFor` (`src/lib/error-messages.ts`), which null-prototypes the
+  table **and** refuses to return a non-string from the lookup — two layers, because
+  fifteen pages hand-rolling the first is precisely how three ended up hardened and twelve
+  did not. A new `?error=` page adds `messageTable({…})`, never `= {…}`.
 - Chart edits are permanent — no undo, no history. Patching the order because a kid is out
   makes that the order. This was chosen deliberately; flag it rather than silently adding
   per-game overrides.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,11 @@ production — the dev command can prompt, generate new migrations, and reset th
   table **and** refuses to return a non-string from the lookup — two layers, because
   fifteen pages hand-rolling the first is precisely how three ended up hardened and twelve
   did not. A new `?error=` page adds `messageTable({…})`, never `= {…}`.
+  `src/error-message-tables.test.ts` enforces it — it **parses** every file in `src/` and
+  fails on any element access whose index mentions `error`, in any spelling, after two
+  regex versions leaked five of them. It cannot see a helper that indexes the table under
+  another name, which is why `messageFor`'s own string check is the thing that actually
+  holds.
 - Chart edits are permanent — no undo, no history. Patching the order because a kid is out
   makes that the order. This was chosen deliberately; flag it rather than silently adding
   per-game overrides.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { getProfile } from "@/lib/profile";
 import { getCurrentUser } from "@/lib/session";
 
@@ -19,11 +20,8 @@ export const metadata = {
   title: "Your profile — Youth Baseball Team Manager",
 };
 
-// Null prototype: the key comes straight from the ?error= query param, and on
-// a plain object ?error=__proto__ or ?error=constructor would resolve an
-// Object.prototype member — truthy, so the fallback never fires — into a
-// non-renderable React child that crashes the page.
-const ERROR_MESSAGES: Record<string, string> = Object.assign(Object.create(null), {
+// messageTable, never a bare literal — see src/lib/error-messages.ts.
+const ERROR_MESSAGES = messageTable({
   "invalid-phone": "Phone number must be 32 characters or fewer.",
   "save-failed": "Your changes couldn't be saved. Try again.",
   "signout-failed": "Signing out didn't work. Try again.",
@@ -59,7 +57,7 @@ export default async function ProfilePage({
     redirect("/signin?callbackUrl=%2Fprofile");
   }
 
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
 
   return (
     <PageContainer>

--- a/src/app/signin/page.test.tsx
+++ b/src/app/signin/page.test.tsx
@@ -31,6 +31,24 @@ describe("SignInPage", () => {
     expect(screen.getByText(/invite-only/i)).toBeInTheDocument();
   });
 
+  // The ?error= key is whatever the URL says. On a bare object literal these
+  // resolve to inherited functions — truthy, so the fallback never fires — and
+  // React throws "Functions are not valid as a React child". This page is also
+  // the only one wording its own fallback, so it proves messageFor's third
+  // argument survives the trip.
+  it("falls back to its own wording for an inherited key", async () => {
+    for (const key of ["constructor", "__proto__", "toString"]) {
+      const { unmount } = render(
+        await SignInPage({ searchParams: Promise.resolve({ error: key }) }),
+      );
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /something went wrong signing you in/i,
+      );
+      unmount();
+    }
+  });
+
   it("shows no error by default", async () => {
     await renderPage();
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/card";
 
 import { requestSignInLink } from "./actions";
+import { messageFor, messageTable } from "@/lib/error-messages";
 
 export const metadata = {
   title: "Sign in — Youth Baseball Team Manager",
@@ -22,7 +23,7 @@ export const metadata = {
 /// reaches this page from a click — the send path always ends on
 /// /signin/check-email — but naming the reason would still leak whether an
 /// invitation exists, so both get the neutral wording.
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-email":
     "That doesn't look like an email address — check it and try again.",
   Verification:
@@ -31,7 +32,7 @@ const ERROR_MESSAGES: Record<string, string> = {
     "That sign-in link is no longer valid. Enter your email to try again, or ask your coach to send a new invite.",
   Configuration:
     "Something is wrong on our end, and it has been logged. Please try again in a few minutes.",
-};
+});
 
 const FALLBACK_ERROR_MESSAGE =
   "Something went wrong signing you in. Enter your email and try again.";
@@ -43,9 +44,7 @@ export default async function SignInPage({
 }) {
   const { error, callbackUrl } = await searchParams;
 
-  const errorMessage = error
-    ? (ERROR_MESSAGES[error] ?? FALLBACK_ERROR_MESSAGE)
-    : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error, FALLBACK_ERROR_MESSAGE);
 
   return (
     <PageContainer>

--- a/src/app/t/[teamId]/chart/page.tsx
+++ b/src/app/t/[teamId]/chart/page.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { getChart } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
@@ -20,7 +21,7 @@ export const metadata = {
   title: "Batting order — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-order": "That order couldn't be read. Reload and try again.",
   "unknown-entry":
     "The roster changed while you were editing. Reload and try again.",
@@ -43,7 +44,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   "chart-changed":
     "Another coach changed the batting order while you were editing — nothing was saved. The order below is theirs; make your changes again on top of it.",
   access: "You no longer have access to make this change.",
-};
+});
 
 /// The coach-only batting order editor (#10). Calls requireTeamAccess itself,
 /// independent of the layout — every page under /t/[teamId] does, since
@@ -93,9 +94,7 @@ export default async function ChartPage({
     battingOrder,
   }));
 
-  const errorMessage = error
-    ? (ERROR_MESSAGES[error] ?? "Something went wrong.")
-    : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
 
   return (
     <div className="mx-auto w-full max-w-md space-y-6">

--- a/src/app/t/[teamId]/chart/positions/page.tsx
+++ b/src/app/t/[teamId]/chart/positions/page.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { getChart } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
@@ -20,7 +21,7 @@ export const metadata = {
   title: "Positions — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-positions":
     "That diamond couldn't be read. Reload and try again.",
   "unknown-entry":
@@ -43,7 +44,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   "chart-changed":
     "Another coach changed the positions while you were editing — nothing was saved. The diamond below is theirs; make your changes again on top of it.",
   access: "You no longer have access to make this change.",
-};
+});
 
 /// The coach-only positions diamond (#11). Calls requireTeamAccess itself,
 /// independent of the layout — every page under /t/[teamId] does, since
@@ -91,9 +92,7 @@ export default async function PositionsPage({
     position,
   }));
 
-  const errorMessage = error
-    ? (ERROR_MESSAGES[error] ?? "Something went wrong.")
-    : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
 
   return (
     <div className="mx-auto w-full max-w-md space-y-6">

--- a/src/app/t/[teamId]/members/page.tsx
+++ b/src/app/t/[teamId]/members/page.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { listTeamMembers } from "@/lib/memberships";
 import { listTeamInvitations } from "@/lib/invitations";
@@ -19,13 +20,13 @@ export const metadata = {
   title: "Members — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-invite": "Enter a valid email and choose a role.",
   "invalid-role": "Choose a valid role.",
   "email-failed": "The invitation could not be sent. Try again.",
   "last-owner": "This team must always have at least one owner.",
   access: "You no longer have access to make this change.",
-};
+});
 
 const ROLE_OPTIONS = ["OWNER", "COACH", "PARENT"] as const;
 
@@ -60,7 +61,7 @@ export default async function MembersPage({
     isLiveInvitation(invitation, now),
   );
 
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
   const ownerCount = members.filter((member) => member.role === "OWNER").length;
 
   return (

--- a/src/app/t/[teamId]/messages/new/page.tsx
+++ b/src/app/t/[teamId]/messages/new/page.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { Role } from "@/generated/prisma/enums";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { listTeamMembers } from "@/lib/memberships";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 
@@ -28,11 +29,8 @@ export const metadata = {
 /// docs — the same coupling as roster/invite.
 export const maxDuration = 60;
 
-// Null prototype: the key comes straight from the ?error= query param, and
-// on a plain object ?error=__proto__ or ?error=constructor would resolve an
-// Object.prototype member instead of falling through to the fallback,
-// crashing the page on a non-renderable React child. Same fix as /profile.
-const ERROR_MESSAGES: Record<string, string> = Object.assign(Object.create(null), {
+// messageTable, never a bare literal — see src/lib/error-messages.ts.
+const ERROR_MESSAGES = messageTable({
   "invalid-audience": "Choose who this message goes to. Nothing was sent.",
   "invalid-subject": "Enter a subject — keep it under 200 characters.",
   "invalid-body": "Enter a message — keep it under 5,000 characters.",
@@ -76,9 +74,7 @@ export default async function NewMessagePage({
     ? (await listTeamMembers(teamId)).filter((m) => m.role === "PARENT")
     : [];
 
-  const errorMessage = error
-    ? (ERROR_MESSAGES[error] ?? "Something went wrong.")
-    : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
   const statusParts = [
     sent ? `Sent to ${sent} ${sent === "1" ? "person" : "people"}` : null,
     failed

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -20,6 +20,7 @@ import {
   type ChartViewEntry,
 } from "@/lib/chart-view";
 import { sortDirectory } from "@/lib/directory-rules";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { mapsUrl } from "@/lib/maps";
 import { listCoachContacts } from "@/lib/memberships";
 import { getChart } from "@/lib/roster";
@@ -38,11 +39,8 @@ import { rsvpAction } from "./schedule/actions";
 /// produce: from the event page a deleted event bounces to the schedule, where
 /// its absence explains itself.
 ///
-/// Null prototype, matching /profile: the key comes straight from the ?error=
-/// query param, and on a plain object ?error=constructor would resolve an
-/// Object.prototype member — truthy, so the fallback never fires — into a
-/// non-renderable React child that crashes the page.
-const ERROR_MESSAGES: Record<string, string> = Object.assign(Object.create(null), {
+/// messageTable, never a bare literal — see src/lib/error-messages.ts.
+const ERROR_MESSAGES = messageTable({
   "invalid-rsvp": "Choose a valid response.",
   "not-your-player": "You can only RSVP for your own kids.",
   "event-gone": "That event was just taken off the schedule.",
@@ -205,7 +203,7 @@ export default async function TeamHomePage({
   const coachContacts =
     role === "PARENT" ? sortDirectory(await listCoachContacts(teamId)) : [];
 
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
 
   return (
     <div className="space-y-6">

--- a/src/app/t/[teamId]/roster/[entryId]/page.tsx
+++ b/src/app/t/[teamId]/roster/[entryId]/page.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { getRosterEntry, type RosterEntryGuardian } from "@/lib/roster";
 
@@ -25,7 +26,7 @@ export const metadata = {
   title: "Player — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-name": "Player name is required.",
   "invalid-dob": "Enter a valid date, or leave it blank.",
   "invalid-jersey": "Jersey number must be a whole number between 0 and 99.",
@@ -35,7 +36,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   "email-failed": "The invitation could not be sent. Try again.",
   "not-a-guardian": "That person is not a guardian of this player.",
   access: "You no longer have access to make this change.",
-};
+});
 
 function toDateInputValue(date: Date | null): string {
   return date ? date.toISOString().slice(0, 10) : "";
@@ -89,7 +90,7 @@ export default async function RosterEntryPage({
     notFound();
   }
 
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
   const confirmingRemoval = confirm === "remove";
   // Unlinking confirms per guardian: ?confirm=unlink&guardian=<id> shows the
   // step on that row only, so the other rows keep their one-tap buttons.

--- a/src/app/t/[teamId]/roster/invite/page.tsx
+++ b/src/app/t/[teamId]/roster/invite/page.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { getRosterWithGuardians } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
@@ -29,13 +30,13 @@ export const metadata = {
 /// config docs.
 export const maxDuration = 60;
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-email": "One of the email addresses isn't valid. Nothing was sent.",
   "invalid-message": "The message is too long — keep it under 1,000 characters.",
   "no-emails": "Enter at least one email address.",
   "too-many": "That's too many invitations for one batch. Nothing was sent.",
   access: "You no longer have access to make this change.",
-};
+});
 
 /// Coach-only, like the chart editors: parents have no link here and minRole
 /// turns a pasted URL into a 404. Calls requireTeamAccess itself, independent
@@ -70,9 +71,7 @@ export default async function BulkInvitePage({
   );
   const covered = roster.filter((entry) => entry.guardianEmails.length > 0);
 
-  const errorMessage = error
-    ? (ERROR_MESSAGES[error] ?? "Something went wrong.")
-    : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
   const statusParts = [
     sent ? `${sent} invitation${sent === "1" ? "" : "s"} sent` : null,
     linked ? `${linked} already-member parent${linked === "1" ? "" : "s"} linked` : null,

--- a/src/app/t/[teamId]/roster/page.test.tsx
+++ b/src/app/t/[teamId]/roster/page.test.tsx
@@ -42,6 +42,23 @@ describe("Roster page", () => {
     expect(markup.indexOf("Ada")).toBeLessThan(markup.indexOf("Zed"));
   });
 
+  // One of the twelve pages that really did crash on ?error=constructor before
+  // the tables moved to messageTable: an inherited Object.prototype member is
+  // truthy, so the ?? fallback never fired and React was handed a function.
+  it("falls back rather than resolving an inherited member of the message table", async () => {
+    requireTeamAccess.mockResolvedValue({ role: "COACH", userId: "user-1" });
+    getRoster.mockResolvedValue([]);
+
+    for (const key of ["constructor", "__proto__", "toString"]) {
+      const result = await RosterPage({
+        params: Promise.resolve({ teamId: "team-1" }),
+        searchParams: Promise.resolve({ error: key }),
+      });
+
+      expect(renderToStaticMarkup(result)).toContain("Something went wrong.");
+    }
+  });
+
   it("passes the caller's role through to gate the add-player form", async () => {
     requireTeamAccess.mockResolvedValue({ role: "PARENT", userId: "user-1" });
     getRoster.mockResolvedValue([]);

--- a/src/app/t/[teamId]/roster/page.tsx
+++ b/src/app/t/[teamId]/roster/page.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { Role } from "@/generated/prisma/enums";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { getRoster } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
@@ -21,7 +22,7 @@ export const metadata = {
   title: "Roster — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-name": "Player name is required.",
   "invalid-dob": "Enter a valid date, or leave it blank.",
   "invalid-jersey": "Jersey number must be a whole number between 0 and 99.",
@@ -29,7 +30,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   "already-rostered": "That player is already on this team's roster.",
   "email-failed": "The player was added, but a notice email could not be sent.",
   access: "You no longer have access to make this change.",
-};
+});
 
 /// Calls requireTeamAccess itself, independent of the layout — every page
 /// under /t/[teamId] does, since layouts don't re-run on client navigation.
@@ -56,7 +57,7 @@ export default async function RosterPage({
   const roster = sortRoster(await getRoster(teamId));
   const canEdit = role !== "PARENT";
   const isOwner = role === "OWNER";
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
 
   return (
     <div className="space-y-6">

--- a/src/app/t/[teamId]/roster/returning/page.tsx
+++ b/src/app/t/[teamId]/roster/returning/page.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { listReturningCandidates } from "@/lib/roster";
 import { sortReturningCandidates } from "@/lib/returning-players";
@@ -19,13 +20,13 @@ export const metadata = {
   title: "Add returning player — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-jersey": "Jersey number must be a whole number between 0 and 99.",
   "jersey-taken": "That jersey number is already in use on this team.",
   "already-rostered": "That player is already on this team's roster.",
   "not-a-candidate": "That player is no longer available to add.",
   access: "You no longer have access to make this change.",
-};
+});
 
 function teamLabel(team: { name: string; season: string | null; archivedAt: Date | null }) {
   const season = team.season ? ` (${team.season})` : "";
@@ -61,7 +62,7 @@ export default async function ReturningPlayersPage({
     ? allCandidates.filter((candidate) => candidate.name.toLowerCase().includes(filter))
     : allCandidates;
 
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
 
   return (
     <div className="space-y-6">

--- a/src/app/t/[teamId]/schedule/[eventId]/page.tsx
+++ b/src/app/t/[teamId]/schedule/[eventId]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card";
 import type { Role } from "@/generated/prisma/enums";
 import { formatEventDateTime, instantToWallClock } from "@/lib/calendar";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { mapsUrl } from "@/lib/maps";
 import { getRoster } from "@/lib/roster";
 import { sortRoster } from "@/lib/roster-rules";
@@ -26,7 +27,7 @@ export const metadata = {
   title: "Event — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-type": "Choose either a game or a practice.",
   "invalid-datetime": "Enter a valid date and time.",
   "invalid-location": "Location is too long.",
@@ -35,7 +36,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   "invalid-rsvp": "Choose a valid response.",
   "not-your-player": "You can only RSVP for your own kids.",
   access: "You no longer have access to make this change.",
-};
+});
 
 const inputClass =
   "w-full rounded-md border border-border bg-background px-3 py-2 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-ring";
@@ -84,7 +85,7 @@ export default async function EventPage({
   );
 
   const canEdit = role !== "PARENT";
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
   const confirmingDelete = confirm === "delete";
   const heading =
     event.type === "GAME"

--- a/src/app/t/[teamId]/schedule/page.tsx
+++ b/src/app/t/[teamId]/schedule/page.tsx
@@ -24,6 +24,7 @@ import {
   WEEKDAY_LABELS,
   type CalendarMonth,
 } from "@/lib/calendar";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { mapsUrl } from "@/lib/maps";
 import {
   listEventsInMonthGrid,
@@ -39,14 +40,14 @@ export const metadata = {
   title: "Schedule — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-type": "Choose either a game or a practice.",
   "invalid-datetime": "Enter a valid date and time.",
   "invalid-location": "Location is too long.",
   "invalid-opponent": "Opponent is too long.",
   "invalid-notes": "Notes are too long.",
   access: "You no longer have access to make this change.",
-};
+});
 
 const TYPE_LABELS = { GAME: "Game", PRACTICE: "Practice" } as const;
 
@@ -105,7 +106,7 @@ export default async function SchedulePage({
       : [];
 
   const canEdit = role !== "PARENT";
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
 
   return (
     <div className="space-y-6">

--- a/src/app/t/[teamId]/settings/page.tsx
+++ b/src/app/t/[teamId]/settings/page.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { getTeamById } from "@/lib/teams";
 
@@ -18,10 +19,10 @@ export const metadata = {
   title: "Team settings — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-name": "Team name is required.",
   access: "You no longer have access to make this change.",
-};
+});
 
 /// Viewing this page requires OWNER, but the intent is "read" — an archived
 /// team must still let its owner reach this page to unarchive it. The
@@ -50,7 +51,7 @@ export default async function TeamSettingsPage({
     notFound();
   }
 
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
   const confirmingArchive = confirm === "archive" && !team.archivedAt;
 
   return (

--- a/src/app/t/new/page.tsx
+++ b/src/app/t/new/page.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
 import { isOwnerEmail } from "@/lib/owner";
 import { getCurrentUser } from "@/lib/session";
 
@@ -17,11 +18,11 @@ export const metadata = {
   title: "New team — Youth Baseball Team Manager",
 };
 
-const ERROR_MESSAGES: Record<string, string> = {
+const ERROR_MESSAGES = messageTable({
   "invalid-name": "Team name is required.",
   "create-failed": "Something went wrong creating the team. Try again.",
   access: "You don't have access to create a team.",
-};
+});
 
 /// /t/new is a sibling of /t/[teamId], not a child of it — there is no
 /// teamId yet to run requireTeamAccess against, so ownership is checked
@@ -39,7 +40,7 @@ export default async function NewTeamPage({
     notFound();
   }
 
-  const errorMessage = error ? (ERROR_MESSAGES[error] ?? "Something went wrong.") : null;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
 
   return (
     <div className="mx-auto w-full max-w-md">

--- a/src/error-message-tables.test.ts
+++ b/src/error-message-tables.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join, relative } from "node:path";
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -10,61 +11,135 @@ import { describe, expect, it } from "vitest";
  * by hand against the `?error=constructor` crash and twelve had not — not
  * because anyone judged them safe, but because the fix lived in a comment on
  * whichever file was open when it was found. A convention nothing enforces is
- * a convention half the codebase has never heard of.
+ * a convention half the codebase has never heard of. So `src/lib/error-messages.ts`
+ * makes the safe path the short one, and this makes the unsafe path fail the build.
  *
- * So `src/lib/error-messages.ts` makes the safe path the short one, and this
- * makes the unsafe path fail the build.
+ * **This parses; it does not pattern-match.** Two earlier versions matched text
+ * and both leaked. The first keyed on the identifier `ERROR_MESSAGES`, so a
+ * table named anything else sailed through. The second matched the substring
+ * `WORD[error]`, so `TABLE?.[error]`, `TABLE[error as keyof typeof TABLE]`,
+ * `TABLE[error ?? "x"]`, `TABLE[ error ]` and `TABLE[String(error)]` all
+ * escaped — five unsafe forms, found one review round at a time. That is what
+ * regexes do to a grammar: every round closes one hole and implies the next.
+ * A syntax tree ends the argument, because "an element access whose index
+ * expression mentions `error`" is a property of the parse, not of the spelling.
  *
- * **Both rules key on shape, never on an identifier.** An earlier version
- * matched the name `ERROR_MESSAGES`, which meant `const ERRORS = {…}` read as
- * `ERRORS[error]` sailed through green while AGENTS.md claimed the rule was
- * enforced — a guard that is worse than none, because it is believed. The two
- * rules also cover each other: an untyped literal escapes the declaration rule
- * and is caught by the lookup rule, which is the one that matters, since
- * indexing is where the crash happens.
- *
- * Scope is all of `src/`, not just `src/app/`: the same mistake in a component
- * or a plain module crashes the same page.
+ * **What this does and does not promise.** It catches indexing an object by the
+ * attacker-chosen key directly, in any spelling. It cannot see through a helper
+ * that takes the table and the key as parameters and indexes them under other
+ * names. That residue is deliberate and is why `messageFor` carries its own
+ * `typeof === "string"` check: the runtime guard is what holds, and this test
+ * exists to keep people on the path that has it — not to be the last line.
  *
  * **When this fails**: route the table through `messageTable` / `messageFor`.
- * Never widen a pattern to make a new file pass.
+ * Never widen a rule to make a new file pass.
  */
 
 const SRC = join(process.cwd(), "src");
 
-/// The module that implements the safe path is exempt from rules about
-/// hand-rolling it.
+/// The module implementing the safe path is exempt from rules about it.
 const IMPLEMENTATION = join("src", "lib", "error-messages.ts");
 
-function sourceFiles(dir: string): string[] {
+/// The attacker-chosen key. Everything below is about what may be done with a
+/// value of this name.
+const ERROR_PARAM = "error";
+
+type SourceFile = {
+  path: string;
+  ast: ts.SourceFile;
+};
+
+function sourcePaths(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const path = join(dir, entry.name);
-    if (entry.isDirectory()) return sourceFiles(path);
+    if (entry.isDirectory()) return sourcePaths(path);
     if (!/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) return [];
     return [path];
   });
 }
 
-const FILES = sourceFiles(SRC)
-  .map((path) => ({
-    path: relative(process.cwd(), path),
-    source: readFileSync(path, "utf8"),
-  }))
-  .filter((file) => file.path !== IMPLEMENTATION);
+const FILES: SourceFile[] = sourcePaths(SRC)
+  .map((absolute) => ({ absolute, path: relative(process.cwd(), absolute) }))
+  .filter((file) => file.path !== IMPLEMENTATION)
+  .map(({ absolute, path }) => ({
+    path,
+    ast: ts.createSourceFile(
+      path,
+      readFileSync(absolute, "utf8"),
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+      path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    ),
+  }));
 
-/// A file whose searchParams carry `?error=`. That query string is
-/// attacker-chosen, which is the whole reason these rules exist; a table keyed
-/// on anything else (a Prisma enum, say) is not in scope and is left alone.
-const READS_ERROR_PARAM = /\berror\?:\s*string/;
-const ERROR_READERS = FILES.filter((file) => READS_ERROR_PARAM.test(file.source));
+function walk(node: ts.Node, visit: (node: ts.Node) => void): void {
+  visit(node);
+  node.forEachChild((child) => walk(child, visit));
+}
 
-/// A bare object literal typed as a string map — the shape that carries
-/// Object.prototype with it. Name-agnostic by design.
-const BARE_STRING_MAP = /:\s*Record<string,\s*string>\s*=\s*\{/;
+function mentionsErrorParam(node: ts.Node): boolean {
+  let found = false;
+  walk(node, (child) => {
+    if (ts.isIdentifier(child) && child.text === ERROR_PARAM) found = true;
+  });
+  return found;
+}
 
-/// Indexing any table by the query param, whatever that table is called.
-/// `messageFor(TABLE, error)` does not match; `TABLE[error]` does.
-const INDEXED_BY_ERROR = /\w\[error\]/;
+/// `path:line`, so a failure names the offending line rather than only the file.
+function location(file: SourceFile, node: ts.Node): string {
+  const { line } = file.ast.getLineAndCharacterOfPosition(node.getStart(file.ast));
+  return `${file.path}:${line + 1}`;
+}
+
+function findAll(predicate: (node: ts.Node, file: SourceFile) => boolean): string[] {
+  return FILES.flatMap((file) => {
+    const hits: string[] = [];
+    walk(file.ast, (node) => {
+      if (predicate(node, file)) hits.push(location(file, node));
+    });
+    return hits;
+  });
+}
+
+/// `X[…]` — including `X?.[…]`, which parses to the same node kind.
+function indexesByErrorParam(node: ts.Node): boolean {
+  return ts.isElementAccessExpression(node) && mentionsErrorParam(node.argumentExpression);
+}
+
+/// A bare object literal typed as a string map: the shape that carries
+/// `Object.prototype` with it. `messageTable({…})` is a call, not a literal
+/// initializer, so it does not match.
+function declaresBareStringMap(node: ts.Node): boolean {
+  if (!ts.isVariableDeclaration(node)) return false;
+  if (!node.initializer || !ts.isObjectLiteralExpression(node.initializer)) return false;
+
+  const type = node.type;
+  if (!type || !ts.isTypeReferenceNode(type)) return false;
+  if (type.typeName.getText(type.getSourceFile()) !== "Record") return false;
+
+  return (
+    type.typeArguments?.length === 2 &&
+    type.typeArguments.every((argument) => argument.kind === ts.SyntaxKind.StringKeyword)
+  );
+}
+
+/// A file that takes `?error=` off the query string. Detected by the property
+/// in its searchParams type, which covers `error?: string`,
+/// `error: string | undefined`, and any other spelling of the annotation —
+/// unlike the substring match this replaced, which only saw the first.
+function readsErrorParam(file: SourceFile): boolean {
+  let found = false;
+  walk(file.ast, (node) => {
+    if (
+      (ts.isPropertySignature(node) || ts.isPropertyAssignment(node)) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === ERROR_PARAM
+    ) {
+      found = true;
+    }
+  });
+  return found;
+}
 
 describe("?error= message tables", () => {
   // A guard that silently matches nothing passes forever. The floors sit well
@@ -72,31 +147,32 @@ describe("?error= message tables", () => {
   // somebody legitimately deletes a page.
   it("can still see the files it is guarding", () => {
     expect(FILES.length).toBeGreaterThan(20);
-    expect(ERROR_READERS.length).toBeGreaterThanOrEqual(8);
+    expect(FILES.filter(readsErrorParam).length).toBeGreaterThanOrEqual(8);
+  });
+
+  // The rule that actually stops the crash. It does not care what the table is
+  // called, how it was built, or how the index is spelled.
+  it("indexes nothing by the ?error= query param", () => {
+    expect(findAll(indexesByErrorParam)).toEqual([]);
   });
 
   it("has no ?error= file declaring a bare string-map literal", () => {
-    const offenders = ERROR_READERS.filter((file) =>
-      BARE_STRING_MAP.test(file.source),
-    ).map((file) => file.path);
-
-    expect(offenders).toEqual([]);
-  });
-
-  // The rule that actually stops the crash: it does not care how the table was
-  // built, only that the attacker-chosen key never indexes it directly.
-  it("has no ?error= file indexing a table by the query param", () => {
-    const offenders = ERROR_READERS.filter((file) =>
-      INDEXED_BY_ERROR.test(file.source),
-    ).map((file) => file.path);
+    const offenders = findAll(
+      (node, file) => declaresBareStringMap(node) && readsErrorParam(file),
+    );
 
     expect(offenders).toEqual([]);
   });
 
   it("has nobody hand-rolling a null-prototype table now that messageTable exists", () => {
-    const offenders = FILES.filter((file) =>
-      file.source.includes("Object.assign(Object.create(null)"),
-    ).map((file) => file.path);
+    const offenders = findAll(
+      (node) =>
+        ts.isCallExpression(node) &&
+        node.expression.getText(node.getSourceFile()) === "Object.assign" &&
+        node.arguments.some((argument) =>
+          argument.getText(node.getSourceFile()).startsWith("Object.create(null)"),
+        ),
+    );
 
     expect(offenders).toEqual([]);
   });

--- a/src/error-message-tables.test.ts
+++ b/src/error-message-tables.test.ts
@@ -1,84 +1,102 @@
 import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 /**
  * Keeps every `?error=` page on the safe lookup, forever.
  *
- * Fifteen pages each declared their own `ERROR_MESSAGES` table. Three had been
- * hardened by hand against the `?error=constructor` crash and twelve had not —
- * not because anyone decided they were fine, but because the fix lived in a
- * comment on whichever file was open when it was discovered. That is the shape
- * of the problem: a convention nothing enforces is a convention half the
- * codebase is unaware of.
+ * Fifteen pages each declared their own message table. Three had been hardened
+ * by hand against the `?error=constructor` crash and twelve had not — not
+ * because anyone judged them safe, but because the fix lived in a comment on
+ * whichever file was open when it was found. A convention nothing enforces is
+ * a convention half the codebase has never heard of.
  *
- * So the convention is enforced here rather than trusted. `src/lib/error-messages.ts`
- * makes the safe path the short one; this makes the unsafe path fail the build.
+ * So `src/lib/error-messages.ts` makes the safe path the short one, and this
+ * makes the unsafe path fail the build.
  *
- * Deliberately narrow. It checks two things a machine can check without
- * understanding the page — that no page builds a message table from a bare
- * object literal, and that no page indexes one directly — and says nothing
- * about wording, which is the author's business. Not co-located, following
- * design-plan-drift.test.ts, because it guards every page at once and belongs
- * beside none of them.
+ * **Both rules key on shape, never on an identifier.** An earlier version
+ * matched the name `ERROR_MESSAGES`, which meant `const ERRORS = {…}` read as
+ * `ERRORS[error]` sailed through green while AGENTS.md claimed the rule was
+ * enforced — a guard that is worse than none, because it is believed. The two
+ * rules also cover each other: an untyped literal escapes the declaration rule
+ * and is caught by the lookup rule, which is the one that matters, since
+ * indexing is where the crash happens.
  *
- * **When this fails**: the page is declaring `= {…}` or reading `TABLE[key]`.
- * Route it through `messageTable` / `messageFor` instead. Never widen the
- * pattern to make a new page pass.
+ * Scope is all of `src/`, not just `src/app/`: the same mistake in a component
+ * or a plain module crashes the same page.
+ *
+ * **When this fails**: route the table through `messageTable` / `messageFor`.
+ * Never widen a pattern to make a new file pass.
  */
 
-const APP_DIR = join(process.cwd(), "src", "app");
+const SRC = join(process.cwd(), "src");
 
-function pageFiles(dir: string): string[] {
+/// The module that implements the safe path is exempt from rules about
+/// hand-rolling it.
+const IMPLEMENTATION = join("src", "lib", "error-messages.ts");
+
+function sourceFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const path = join(dir, entry.name);
-    if (entry.isDirectory()) return pageFiles(path);
-    return entry.name.endsWith(".tsx") && !entry.name.endsWith(".test.tsx")
-      ? [path]
-      : [];
+    if (entry.isDirectory()) return sourceFiles(path);
+    if (!/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) return [];
+    return [path];
   });
 }
 
-const FILES = pageFiles(APP_DIR).map((path) => ({
-  path: path.slice(process.cwd().length + 1),
-  source: readFileSync(path, "utf8"),
-}));
+const FILES = sourceFiles(SRC)
+  .map((path) => ({
+    path: relative(process.cwd(), path),
+    source: readFileSync(path, "utf8"),
+  }))
+  .filter((file) => file.path !== IMPLEMENTATION);
+
+/// A file whose searchParams carry `?error=`. That query string is
+/// attacker-chosen, which is the whole reason these rules exist; a table keyed
+/// on anything else (a Prisma enum, say) is not in scope and is left alone.
+const READS_ERROR_PARAM = /\berror\?:\s*string/;
+const ERROR_READERS = FILES.filter((file) => READS_ERROR_PARAM.test(file.source));
+
+/// A bare object literal typed as a string map — the shape that carries
+/// Object.prototype with it. Name-agnostic by design.
+const BARE_STRING_MAP = /:\s*Record<string,\s*string>\s*=\s*\{/;
+
+/// Indexing any table by the query param, whatever that table is called.
+/// `messageFor(TABLE, error)` does not match; `TABLE[error]` does.
+const INDEXED_BY_ERROR = /\w\[error\]/;
 
 describe("?error= message tables", () => {
-  it("finds the pages it is meant to be guarding", () => {
-    // A guard that silently matches nothing passes forever. This is the
-    // canary: if the app is restructured and this test stops seeing pages, it
-    // fails here rather than quietly approving everything.
-    const withTables = FILES.filter((f) => f.source.includes("ERROR_MESSAGES"));
-
+  // A guard that silently matches nothing passes forever. The floors sit well
+  // below today's counts on purpose: this fails when the scan breaks, not when
+  // somebody legitimately deletes a page.
+  it("can still see the files it is guarding", () => {
     expect(FILES.length).toBeGreaterThan(20);
-    expect(withTables.length).toBeGreaterThanOrEqual(15);
+    expect(ERROR_READERS.length).toBeGreaterThanOrEqual(8);
   });
 
-  it("declares no message table as a bare object literal", () => {
-    const offenders = FILES.filter((f) =>
-      /const \w*(?:ERROR_MESSAGES|MESSAGES)\b[^=]*=\s*\{/.test(f.source),
-    ).map((f) => f.path);
+  it("has no ?error= file declaring a bare string-map literal", () => {
+    const offenders = ERROR_READERS.filter((file) =>
+      BARE_STRING_MAP.test(file.source),
+    ).map((file) => file.path);
 
     expect(offenders).toEqual([]);
   });
 
-  it("hand-rolls no null-prototype table now that messageTable exists", () => {
-    const offenders = FILES.filter((f) =>
-      f.source.includes("Object.assign(Object.create(null)"),
-    ).map((f) => f.path);
+  // The rule that actually stops the crash: it does not care how the table was
+  // built, only that the attacker-chosen key never indexes it directly.
+  it("has no ?error= file indexing a table by the query param", () => {
+    const offenders = ERROR_READERS.filter((file) =>
+      INDEXED_BY_ERROR.test(file.source),
+    ).map((file) => file.path);
 
     expect(offenders).toEqual([]);
   });
 
-  // The second half of the fix. A null-prototyped table read with `TABLE[key]`
-  // is still one refactor away from being a plain literal read the same way;
-  // going through messageFor keeps the non-string guard in the path.
-  it("indexes no message table directly", () => {
-    const offenders = FILES.filter((f) => /ERROR_MESSAGES\[/.test(f.source)).map(
-      (f) => f.path,
-    );
+  it("has nobody hand-rolling a null-prototype table now that messageTable exists", () => {
+    const offenders = FILES.filter((file) =>
+      file.source.includes("Object.assign(Object.create(null)"),
+    ).map((file) => file.path);
 
     expect(offenders).toEqual([]);
   });

--- a/src/error-message-tables.test.ts
+++ b/src/error-message-tables.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Keeps every `?error=` page on the safe lookup, forever.
+ *
+ * Fifteen pages each declared their own `ERROR_MESSAGES` table. Three had been
+ * hardened by hand against the `?error=constructor` crash and twelve had not —
+ * not because anyone decided they were fine, but because the fix lived in a
+ * comment on whichever file was open when it was discovered. That is the shape
+ * of the problem: a convention nothing enforces is a convention half the
+ * codebase is unaware of.
+ *
+ * So the convention is enforced here rather than trusted. `src/lib/error-messages.ts`
+ * makes the safe path the short one; this makes the unsafe path fail the build.
+ *
+ * Deliberately narrow. It checks two things a machine can check without
+ * understanding the page — that no page builds a message table from a bare
+ * object literal, and that no page indexes one directly — and says nothing
+ * about wording, which is the author's business. Not co-located, following
+ * design-plan-drift.test.ts, because it guards every page at once and belongs
+ * beside none of them.
+ *
+ * **When this fails**: the page is declaring `= {…}` or reading `TABLE[key]`.
+ * Route it through `messageTable` / `messageFor` instead. Never widen the
+ * pattern to make a new page pass.
+ */
+
+const APP_DIR = join(process.cwd(), "src", "app");
+
+function pageFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return pageFiles(path);
+    return entry.name.endsWith(".tsx") && !entry.name.endsWith(".test.tsx")
+      ? [path]
+      : [];
+  });
+}
+
+const FILES = pageFiles(APP_DIR).map((path) => ({
+  path: path.slice(process.cwd().length + 1),
+  source: readFileSync(path, "utf8"),
+}));
+
+describe("?error= message tables", () => {
+  it("finds the pages it is meant to be guarding", () => {
+    // A guard that silently matches nothing passes forever. This is the
+    // canary: if the app is restructured and this test stops seeing pages, it
+    // fails here rather than quietly approving everything.
+    const withTables = FILES.filter((f) => f.source.includes("ERROR_MESSAGES"));
+
+    expect(FILES.length).toBeGreaterThan(20);
+    expect(withTables.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it("declares no message table as a bare object literal", () => {
+    const offenders = FILES.filter((f) =>
+      /const \w*(?:ERROR_MESSAGES|MESSAGES)\b[^=]*=\s*\{/.test(f.source),
+    ).map((f) => f.path);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("hand-rolls no null-prototype table now that messageTable exists", () => {
+    const offenders = FILES.filter((f) =>
+      f.source.includes("Object.assign(Object.create(null)"),
+    ).map((f) => f.path);
+
+    expect(offenders).toEqual([]);
+  });
+
+  // The second half of the fix. A null-prototyped table read with `TABLE[key]`
+  // is still one refactor away from being a plain literal read the same way;
+  // going through messageFor keeps the non-string guard in the path.
+  it("indexes no message table directly", () => {
+    const offenders = FILES.filter((f) => /ERROR_MESSAGES\[/.test(f.source)).map(
+      (f) => f.path,
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/lib/error-messages.test.ts
+++ b/src/lib/error-messages.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ERROR_MESSAGE,
+  messageFor,
+  messageTable,
+} from "@/lib/error-messages";
+
+const TABLE = messageTable({
+  "invalid-email": "That doesn't look like an email address.",
+  access: "You no longer have access to make this change.",
+});
+
+/// Every key a page can be handed from the query string, including the ones a
+/// plain object literal answers with an inherited member.
+const INHERITED_KEYS = [
+  "constructor",
+  "__proto__",
+  "toString",
+  "valueOf",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+];
+
+describe("messageTable", () => {
+  it("returns the message for a key it knows", () => {
+    expect(TABLE["access"]).toBe("You no longer have access to make this change.");
+  });
+
+  // The bug this module exists for: on `{}` these resolve to functions, which
+  // are truthy — so the `??` fallback never fires and React throws
+  // "Functions are not valid as a React child".
+  it("inherits nothing from Object.prototype", () => {
+    for (const key of INHERITED_KEYS) {
+      expect(TABLE[key]).toBeUndefined();
+    }
+
+    expect(Object.getPrototypeOf(TABLE)).toBeNull();
+  });
+
+  it("is frozen, since these are module-level constants shared across requests", () => {
+    expect(Object.isFrozen(TABLE)).toBe(true);
+  });
+});
+
+describe("messageFor", () => {
+  it("returns the message for a known key", () => {
+    expect(messageFor(TABLE, "access")).toBe(
+      "You no longer have access to make this change.",
+    );
+  });
+
+  // Null and the fallback are different answers: null is "nothing went wrong,
+  // render nothing", the fallback is "something failed and we don't recognise
+  // the code", which the reader still deserves to hear about.
+  it("returns null when there is no key at all", () => {
+    expect(messageFor(TABLE, undefined)).toBeNull();
+    expect(messageFor(TABLE, "")).toBeNull();
+  });
+
+  it("falls back for a key it does not know", () => {
+    expect(messageFor(TABLE, "nonsense")).toBe(DEFAULT_ERROR_MESSAGE);
+  });
+
+  it("falls back for every inherited key", () => {
+    for (const key of INHERITED_KEYS) {
+      expect(messageFor(TABLE, key)).toBe(DEFAULT_ERROR_MESSAGE);
+    }
+  });
+
+  it("takes a caller's own fallback, for pages that word it differently", () => {
+    expect(messageFor(TABLE, "nonsense", "Sign-in failed.")).toBe("Sign-in failed.");
+    expect(messageFor(TABLE, undefined, "Sign-in failed.")).toBeNull();
+  });
+
+  // The second layer. A plain literal declared by someone who never read this
+  // module still cannot put a function into React through this lookup.
+  it("refuses a non-string even from a table that skipped messageTable", () => {
+    const unsafe = { access: "fine" } as unknown as ReturnType<typeof messageTable>;
+
+    for (const key of INHERITED_KEYS) {
+      expect(messageFor(unsafe, key)).toBe(DEFAULT_ERROR_MESSAGE);
+    }
+    expect(messageFor(unsafe, "access")).toBe("fine");
+  });
+});

--- a/src/lib/error-messages.ts
+++ b/src/lib/error-messages.ts
@@ -1,0 +1,53 @@
+/// The `?error=…` lookup tables every page carries, in one place.
+///
+/// Two hazards, and this module answers both — deliberately, because either
+/// one alone leaves the other open:
+///
+/// 1. **The key is attacker-chosen.** It comes straight off the query string,
+///    so on a plain object literal `?error=constructor` resolves an
+///    `Object.prototype` member. That is truthy, so the `??` fallback never
+///    fires, and React throws "Functions are not valid as a React child" on the
+///    way out — a crashed page from a hand-typed URL. `messageTable` gives the
+///    object a null prototype, so there is nothing left to inherit.
+///
+/// 2. **The next table might skip step 1.** Fifteen pages declared their own
+///    before this module existed and three had been hardened by hand, which is
+///    exactly the split that lets the fix rot. So `messageFor` refuses to
+///    return anything that is not a string, and stays safe even against a plain
+///    literal added later by someone who never read this file.
+///
+/// Pure and DB-free, tested next door.
+
+export const DEFAULT_ERROR_MESSAGE = "Something went wrong.";
+
+/// Indexed as `string | undefined` rather than `string`: looking up an
+/// arbitrary key misses far more often than it hits, and typing the result as
+/// `string` is what hides the miss until it reaches the page.
+export type MessageTable = Readonly<Partial<Record<string, string>>>;
+
+/// Frozen as well as null-prototyped. Freezing guards nothing about the
+/// prototype problem above — it is here because these tables are module-level
+/// constants shared by every request the server handles.
+export function messageTable(entries: Record<string, string>): MessageTable {
+  return Object.freeze(Object.assign(Object.create(null), entries));
+}
+
+/**
+ * The sentence for `key`, or `null` when there is no key at all.
+ *
+ * The distinction matters to the caller: `null` means "no error to report, and
+ * render nothing", while the fallback means "something failed and we don't
+ * recognise the code" — which is still worth telling the reader about.
+ */
+export function messageFor(
+  table: MessageTable,
+  key: string | undefined,
+  fallback: string = DEFAULT_ERROR_MESSAGE,
+): string | null {
+  if (!key) {
+    return null;
+  }
+
+  const message = table[key];
+  return typeof message === "string" ? message : fallback;
+}


### PR DESCRIPTION
## Summary

`?error=constructor` on most pages resolved an `Object.prototype` member instead of missing. It's truthy, so the `?? "Something went wrong."` fallback never fired, and React was handed a function — `Functions are not valid as a React child`, a blank crashed page from nothing more than a URL someone typed. Follow-up to #63, where the same bug was found and fixed on team home alone.

The count was worse than the note in #63 suggested. It wasn't "the tables under `schedule/` and `roster/`" — **fifteen pages each declared their own `ERROR_MESSAGES`, three were hardened, and twelve were not.**

## Key Decisions

**The real defect was the arrangement, not the twelve tables.** The fix lived in a comment on whichever file someone had open when they hit it, so it protected pages that had already been visited and no others. Hardening twelve more by hand leaves exactly that arrangement with a larger number in it — and a sixteenth page tomorrow starts unprotected again. So the table *and* the lookup move to `src/lib/error-messages.ts` and every page routes through it, the three already-hardened ones included, so there is one idiom rather than two.

**Two layers, deliberately.** `messageTable` gives the object a null prototype so there's nothing to inherit. `messageFor` additionally refuses to return anything that isn't a string. The second exists because the first can be skipped: a bare literal added later by someone who never reads the module still cannot put a function into React through this lookup.

**The convention is enforced by parsing, after two text-matching versions leaked.** This took three rounds and the history is the argument, so it's worth stating plainly:

| Version | Rule | How it leaked |
|---|---|---|
| 1 | matched the identifier `ERROR_MESSAGES` | `const ERRORS = {…}` read as `ERRORS[error]` sailed through green |
| 2 | matched the substring `WORD[error]` | missed `TABLE?.[error]`, `TABLE[error as keyof typeof TABLE]`, `TABLE[error ?? "x"]`, `TABLE[ error ]`, `TABLE[String(error)]` |
| 3 (current) | walks the TypeScript AST | all of the above are one `ElementAccessExpression` once parsed |

Each version was fixed by a review round finding the next hole, which is what pattern-matching does to a grammar. The AST version ends that cycle for the direct-index case.

## What's in Scope

- `src/lib/error-messages.ts` — `messageTable`, `messageFor`, `DEFAULT_ERROR_MESSAGE`, with co-located tests
- All 15 pages converted; three now-duplicated rationale comments collapse to a pointer at the module
- `/signin` keeps its bespoke fallback wording via `messageFor`'s third argument
- `src/error-message-tables.test.ts` — parses every `.ts`/`.tsx` file in `src/` (not just `src/app`) and fails on: an element access whose index mentions `error`, a bare `Record<string, string>` literal in a file that reads `?error=`, or a hand-rolled `Object.assign(Object.create(null), …)`
- Render-level regression tests on two representative pages
- `AGENTS.md` — the gotcha described the three-hardened/twelve-not split as the status quo, and now names the enforcing test and its limits

### Out of Scope — two false positives ruled out rather than "fixed"

- **`ROLE_LABELS`** in `/directory` is keyed on `entry.role`, a Prisma enum from the database, never a query param.
- **`validatePositions`** in `chart.ts` checks every submitted key against `droppablePositions` before reading anything, and its reads are keyed by that internal list.

Neither is reachable from a URL. Converting them would have implied a vector that isn't there — and both are confirmed still unflagged by the current guard, along with `POSITION_LABELS[position]`, `ROLE_RANK[role]` and `RSVP_STYLE[state]`.

## What this does NOT guarantee

Stated here rather than left for a fourth review round to discover: the guard cannot see through a helper that takes the table and the key as parameters and indexes them under other names. That needs a type checker, not a parse. **`messageFor`'s runtime `typeof === "string"` check is the thing that actually holds**; the test exists to keep people on the path that has it, not to be the last line of defence. If a future change makes the guard look like proof, that's the moment to distrust it.

## Verification

- Reverting `roster/page.tsx` to a bare literal reproduced the original crash verbatim — `Functions are not valid as a React child` — confirming the bug was real on those pages, not theoretical.
- All seven unsafe index spellings I could construct are caught, including `(TABLE)[(error)]`.
- All three searchParams typings (`error?: string`, `error?: string | undefined`, `error: string | undefined`) are now detected; the old substring only saw the first two.
- Planting the same bug in `src/components/` and `src/lib/` is caught; under the original `src/app`-only scan, both were invisible.

## Test Plan

- [ ] CI: `check` and `build` green.
- [ ] `pnpm check` — **84 files, 1196 tests**, up from 1181.
- [ ] `pnpm dev`, then append `?error=constructor`, `?error=__proto__`, or `?error=toString` to any of `/signin`, `/t/new`, `/t/<id>`, `/t/<id>/roster`, `/t/<id>/schedule`, `/t/<id>/settings`, `/t/<id>/members`, `/t/<id>/chart` — each should render its ordinary fallback sentence, not a blank page.
- [ ] `?error=` with a real code (e.g. `/signin?error=Verification`) still shows its specific message, and a page with no `?error=` shows no alert at all.