### PR TITLE
Celebrate the parent's kid on team home with rookie-card hero cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,10 +345,14 @@ production — the dev command can prompt, generate new migrations, and reset th
   page-selected event, it does not authorize, and the event page still records a late
   answer on purpose. Anything else writing against a grace-window selection needs both
   halves.
-- **"Bench" is a claim about a player in neither column, and three pages have to agree.**
-  A kid batting third with no fielding spot is *in the order* — the view page's bench list
+- **"Substitute" is a claim about a player in neither column, and three pages have to
+  agree.** (The label was softened from "Bench" everywhere a person reads it — team home's
+  marquee, /view's Substitutes card, the positions editor's zone — but the code and its
+  comments still say bench/`isBenched`/`benchLabel` for the state itself.) A kid batting
+  third with no fielding spot is *in the order* — the view page's substitutes list
   filters on `battingOrder === null` and says so, and `chartRole`'s `benchLabel` applies
-  under the same condition. Printing "Bats 3rd · Bench" misdescribes a kid who is playing.
+  under the same condition. Printing "Bats 3rd · Substitute" misdescribes a kid who is
+  playing.
   The prior question is whether the team has a chart at all: with none, every position a
   page prints is one nobody assigned, which is why `hasChartSet` (`chart-view.ts`) gates
   the line on team home and the whole panel on `/view` and `/readiness`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,9 @@ docs/design/       # The design plan and its SVG mockups — kept in step with t
 (unauthenticated invitation accept page — deliberately outside proxy.ts's matcher),
 `/profile` (the signed-in person's own name and phone — global, not team-scoped, since
 those are `User` columns — and the app's only sign-out, a server action wrapping Auth.js
-`signOut`), and `/t/[teamId]/` (team home — the parent dashboard: each kid's chart line
-and the next three events, every one of them answerable in one tap — settings, roster,
+`signOut`), and `/t/[teamId]/` (team home — the parent dashboard: a player card per kid
+(`MiniDiamondHero` field art, jersey dot, slab name plate, chart-line marquee) and the
+next three events, every one of them answerable in one tap — settings, roster,
 members, the owner-only returning-player picker at `roster/returning`, the coach-only
 bulk parent invite at `roster/invite`, the coach-only member directory, the coach-only
 roster entry detail at `roster/[entryId]`, the schedule at `schedule` /
@@ -230,7 +231,7 @@ production — the dev command can prompt, generate new migrations, and reset th
   `prisma-client-api` were kept (from `github:prisma/skills`, MIT). **If anyone re-runs
   `prisma init`, remove the rest again.** `prisma-cli/SKILL.md` was edited locally to drop
   a dangling reference to the uninstalled `prisma-compute` skill.
-- **The two diamonds paint different fences, and that is the banana budget.** design-plan.md
+- **Three surfaces paint `FieldArt`, and their fences are the banana budget.** design-plan.md
   §2 allows exactly one Banana Yellow element per screen. `FieldArt` takes a `fence` prop
   because the wall is the loudest thing it paints: the positions editor spends its banana
   there, and `/view` spends its own on the guarded-player halo instead — but only for a
@@ -243,6 +244,18 @@ production — the dev command can prompt, generate new migrations, and reset th
   an allPlay board with 13+ players in the zone draws no ring, so a reader whose only
   guarded kid is there and has no batting slot sees a chalk fence and no banana at all.
   That needs an 18+ roster, past what this app is built for.
+
+  The third caller is **`MiniDiamondHero`** (team home's player cards), and it passes
+  `fence="chalk"` unconditionally — not a judgement call, a consequence of when it renders
+  at all: the hero is drawn only for a kid the chart seats, and that card has already spent
+  the banana on the halo and the marquee strip. Its crop is also so tight that the fence
+  is usually outside the viewBox entirely. Two things follow, and both are the `/view`
+  precedent rather than new rules. The treatment **follows the child**, so a parent with
+  two kids gets it twice — two haloed markers and two marquees — exactly as `/view` already
+  draws two halos, two row borders and two chips for that family. And a reader with **no**
+  guarded kid gets no banana at all on team home, which is deliberate: unlike `/view` there
+  is no field art to hand the yellow back to, and team home without a kid on it is one of
+  §7's calm pages, not a fun page missing its accent.
 - **Both diamonds shorten names through `buildDiamondNames` (`src/lib/diamond-names.ts`).**
   Never re-add a local `shortName`: the editor had one, so with two Avas on the roster
   `/view` drew "Ava C."/"Ava R." while the coach's board drew two chips both reading "Ava" —

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -228,11 +228,21 @@ section heading it sits under, the settings Archive/Unarchive controls, and the 
 header. A second word for one state is a worse card, however good the flourish.
 
 **Team home's player cards (post-ship addition)** — the parent's own kids stopped being a
-log line. Each guarded kid gets a rookie-card hero at the top of the dashboard: the jersey
+log line. Each guarded kid gets a rookie-card hero at the top of the dashboard, and its
+card art is **the kid standing on the real field**: `MiniDiamondHero` crops the painted
+`FieldArt` board to a wide strip framed on the kid's spot (`POSITION_COORDS`, or the
+outfield zone's centre for an allPlay kid with no named position), with the guarded halo
+ringing a marker that wears the kid's jersey number in the JerseyDot colours — the same
+field, coordinates, halo and step-up the lineup pages use, so the card is a close-up of
+the board the parent opens next, never a third diamond that could drift. A kid the chart
+puts on no field (a substitute, or a selective team's order-only batter) gets no field
+art rather than an invented spot. Below the art: the jersey
 number worn big on a `JerseyDot` (the component grew an `lg` cut for exactly this), the
 name in slab caps on a pinstripe band — a hero surface, which is where §5 allows
 pinstripes — and a marquee strip carrying `chartRole`'s line ("Bats 1st · 2B"), uppercased
-by CSS so the DOM keeps the exact sentence readiness and `/view` also print. Cards rise in
+by CSS so the DOM keeps the exact sentence readiness and `/view` also print. The hero's
+fence is always chalk: the halo and the marquee are one banana treatment of one child,
+the way `/view`'s halo, row border and chip are. Cards rise in
 with the same staggered `animate-rise` the lineup view announces rows with. **This
 screen's banana is the marquee**, and the budget follows the child exactly as it does on
 `/view`: a kid the chart seats gets Banana Yellow with a little star; the Substitute and

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -235,9 +235,9 @@ pinstripes — and a marquee strip carrying `chartRole`'s line ("Bats 1st · 2B"
 by CSS so the DOM keeps the exact sentence readiness and `/view` also print. Cards rise in
 with the same staggered `animate-rise` the lineup view announces rows with. **This
 screen's banana is the marquee**, and the budget follows the child exactly as it does on
-`/view`: a kid the chart seats gets Banana Yellow with a little star; Bench and
-no-chart-yet drop to quiet secondary stock, because a banana shouting an empty state is
-the wrong kind of loud — and a team-home screen with no guarded kid (a coach, say) simply
+`/view`: a kid the chart seats gets Banana Yellow with a little star; the Substitute and
+no-chart-yet states drop to quiet secondary stock, because a banana shouting an empty
+state is the wrong kind of loud — and a team-home screen with no guarded kid (a coach, say) simply
 has no banana, matching the calm-admin rule below rather than inventing a yellow thing to
 spend it on. `isBenched` in `chart-role.ts` is `chartRole`'s own bench condition, exported
 so the styling and the sentence cannot disagree.
@@ -275,7 +275,11 @@ The **bench** is its own card, below the diamond, holding only the players this 
 otherwise render nowhere — non-allPlay teams, and only kids in neither column. An allPlay
 team's unplaced players are the outfield zone two inches above, and a kid batting third
 without a fielding spot is already in the order; calling either group benched would
-misdescribe them.
+misdescribe them. The card — and every other surface a person reads — says **Substitutes**,
+never "Bench": the softer word, chosen for the family reading it, and shared with team
+home's marquee and the positions editor's zone so the state keeps one name. The code still
+calls the state bench (`isBenched`, `benchLabel`, the local variables); only the printed
+word softened.
 
 **Chart editors** — restraint zone; dnd-kit owns every dragged element (the AGENTS.md
 rule), so flair goes only into *static* styling: field art behind the position targets,

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -227,6 +227,21 @@ that is the app's existing vocabulary for this state, shared with the "Archived 
 section heading it sits under, the settings Archive/Unarchive controls, and the team
 header. A second word for one state is a worse card, however good the flourish.
 
+**Team home's player cards (post-ship addition)** — the parent's own kids stopped being a
+log line. Each guarded kid gets a rookie-card hero at the top of the dashboard: the jersey
+number worn big on a `JerseyDot` (the component grew an `lg` cut for exactly this), the
+name in slab caps on a pinstripe band — a hero surface, which is where §5 allows
+pinstripes — and a marquee strip carrying `chartRole`'s line ("Bats 1st · 2B"), uppercased
+by CSS so the DOM keeps the exact sentence readiness and `/view` also print. Cards rise in
+with the same staggered `animate-rise` the lineup view announces rows with. **This
+screen's banana is the marquee**, and the budget follows the child exactly as it does on
+`/view`: a kid the chart seats gets Banana Yellow with a little star; Bench and
+no-chart-yet drop to quiet secondary stock, because a banana shouting an empty state is
+the wrong kind of loud — and a team-home screen with no guarded kid (a coach, say) simply
+has no banana, matching the calm-admin rule below rather than inventing a yellow thing to
+spend it on. `isBenched` in `chart-role.ts` is `chartRole`'s own bench condition, exported
+so the styling and the sentence cannot disagree.
+
 **Schedule** — games become **ticket stubs** (sketch A): perforated edge, slab opponent
 name, Geist Mono date, RSVP tallies on the stub end. Practices print on plain cream stock
 with a clay dashed border — games must feel like the main event. Month grid keeps using

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -314,13 +314,15 @@ Via the existing `LazyMotion`/`m` setup only:
 
 - Page-level: the existing `Reveal` rise on card mount; lineup rows stagger in at ~40ms
   intervals via the `animate-rise` utility, an inline `animation-delay` per row.
-- `animate-step-up`: the lineup view's guarded marker rises once, on load, and settles.
+- `animate-step-up`: the guarded marker rises once, on load, and settles — on the lineup
+  view's diamond and on team home's `MiniDiamondHero`, which draws the same haloed marker.
   CSS too, and translate-only for a second reason on top of the one below — the banana halo
   already sits 2.5px inside the warning track, so a scale would push it onto the tan at the
   animation's peak and lose exactly the contrast the highlight is made of. It goes on an
   *inner* `<g>`, never the one carrying `transform="translate(x y)"`: a CSS transform
   overrides an SVG transform attribute, and animating that element drops the marker at the
-  origin.
+  origin. Both suites pin that placement, because the failure is silent — the marker simply
+  renders at the field's origin, with no error.
 - `animate-rise` is CSS, not Motion, and **translate-only** — no opacity, for the same
   reason `Reveal` has none: Motion serialises `initial` into the server-rendered markup,
   so a fade ships `opacity: 0` in the HTML and the lineup stays blank until the bundle

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
@@ -63,7 +63,9 @@ describe("PositionsEditor", () => {
     const zone = screen.getByRole("region", { name: "Outfield" });
     expect(zone).toHaveTextContent("Player-b");
     expect(zone).toHaveTextContent("Player-c");
-    expect(screen.queryByRole("region", { name: "Bench" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Substitutes" }),
+    ).not.toBeInTheDocument();
   });
 
   it("marks the catcher's empty spot with a filled circle under allPlay", () => {
@@ -113,7 +115,7 @@ describe("PositionsEditor", () => {
     );
   });
 
-  it("renders all nine targets and a Bench zone when allPlay is false", () => {
+  it("renders all nine targets and a Substitutes zone when allPlay is false", () => {
     render(
       <PositionsEditor
         teamId="team-1"
@@ -128,7 +130,7 @@ describe("PositionsEditor", () => {
     }
     expect(field).toHaveTextContent("Player-a");
 
-    const zone = screen.getByRole("region", { name: "Bench" });
+    const zone = screen.getByRole("region", { name: "Substitutes" });
     expect(zone).toHaveTextContent("Player-b");
   });
 

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
@@ -355,10 +355,13 @@ function Zone({
   allPlay: boolean;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: POSITION_POOL_ID });
-  const title = allPlay ? "Outfield" : "Bench";
+  // "Substitutes", never "Bench": the app-wide word for the state, chosen
+  // because a parent reads it too — the coach's zone here and the family's
+  // pages must not speak two dialects of the same idea.
+  const title = allPlay ? "Outfield" : "Substitutes";
   const empty = allPlay
     ? "Drag a player here to move them to the outfield."
-    : "Drag a player here to sit them out.";
+    : "Drag a player here to make them a substitute.";
 
   return (
     <section aria-label={title}>

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -248,13 +248,80 @@ describe("TeamHomePage your players", () => {
     getChart.mockResolvedValue([REESE]);
   });
 
-  it("summarises jersey, batting slot and position in one line", async () => {
+  it("shows the name, the jersey number worn big, and the chart line", async () => {
     const html = await render();
 
     expect(guardedRosteredPlayerIds).toHaveBeenCalledWith("team-1", "user-1");
     expect(html).toContain("Reese");
-    expect(html).toContain("#12");
+    // The jersey number rides in a JerseyDot, not as "#12" prose — the number
+    // itself is the card's celebration.
+    expect(html).toContain(">12<");
+    // chartRole's exact sentence stays in the DOM (the marquee uppercases by
+    // CSS only), so this page, readiness and /view keep saying the same thing.
     expect(html).toContain("Bats 3rd · SS");
+  });
+
+  it("leaves the jersey dot off a kid with no number rather than inventing one", async () => {
+    getChart.mockResolvedValue([{ ...REESE, jerseyNumber: null }]);
+
+    const html = await render();
+
+    expect(html).toContain("Reese");
+    expect(html).toContain("Bats 3rd · SS");
+  });
+
+  // Design-plan §2: one banana per screen, and on this screen — as on /view —
+  // the banana is the reader's own kid. The marquee goes yellow only for a kid
+  // the chart actually seats.
+  it("spends the screen's banana on a kid with a spot in the chart", async () => {
+    const html = await render();
+
+    expect(html).toContain("bg-banana");
+  });
+
+  it("keeps the banana in its pocket for a benched kid", async () => {
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sluggers",
+      season: "Fall 2026",
+      allPlay: false,
+      archivedAt: null,
+    });
+    getChart.mockResolvedValue([
+      { ...REESE, position: null, battingOrder: null },
+      { ...REESE, entryId: "entry-9", playerId: "player-9", playerName: "Kit" },
+    ]);
+
+    const html = await render();
+
+    expect(html).toContain("Bench");
+    expect(html).not.toContain("bg-banana");
+  });
+
+  it("keeps the banana in its pocket when no chart is set", async () => {
+    getChart.mockResolvedValue([
+      { ...REESE, battingOrder: null, position: null },
+      { ...REESE, entryId: "entry-9", playerId: "player-9", battingOrder: null, position: null },
+    ]);
+
+    const html = await render();
+
+    expect(html).not.toContain("bg-banana");
+  });
+
+  it("announces the cards with the staggered lineup rise", async () => {
+    guardedRosteredPlayerIds.mockResolvedValue(new Set(["player-1", "player-3"]));
+    getChart.mockResolvedValue([
+      REESE,
+      { ...REESE, entryId: "entry-3", playerId: "player-3", playerName: "Sam", jerseyNumber: 4 },
+    ]);
+
+    const html = await render();
+
+    expect(html).toContain("animate-rise");
+    // Staggered per card, like a lineup being read out — the second card waits
+    // its turn.
+    expect(html).toContain("animation-delay:40ms");
   });
 
   // The rule fieldedPositions exists for — and the reason chartRole is shared

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -48,6 +48,8 @@ vi.mock("next/navigation", () => ({
 }));
 
 import TeamHomePage from "./page";
+import { POSITION_COORDS } from "@/components/diamond-geometry";
+import { heroViewBox } from "@/components/MiniDiamondHero";
 
 /// 6:00 PM Central on 15 August 2026 (CDT, UTC-5).
 const GAME = {
@@ -307,6 +309,77 @@ describe("TeamHomePage your players", () => {
     const html = await render();
 
     expect(html).not.toContain("bg-banana");
+  });
+
+  // The mini-diamond hero: the kid standing on the painted field, cropped to
+  // their spot. The same FieldArt and coordinates the lineup pages draw, so
+  // the card is a close-up of the board the parent opens next.
+  it("puts a fielded kid on the painted field, cropped to their position", async () => {
+    getChart.mockResolvedValue([{ ...REESE, position: "SHORTSTOP" }]);
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sluggers",
+      season: "Fall 2026",
+      allPlay: false,
+      archivedAt: null,
+    });
+
+    const html = await render();
+
+    expect(html).toContain("fill-grass");
+    expect(html).toContain(`viewBox="${heroViewBox(POSITION_COORDS.SHORTSTOP)}"`);
+  });
+
+  it("frames an allPlay kid with no position in the outfield zone", async () => {
+    getChart.mockResolvedValue([{ ...REESE, position: null }]);
+
+    const html = await render();
+
+    // outfieldZoneCoords(1) is CENTER_FIELD's spot by construction.
+    expect(html).toContain("fill-grass");
+    expect(html).toContain(`viewBox="${heroViewBox(POSITION_COORDS.CENTER_FIELD)}"`);
+  });
+
+  // A selective team's kid who bats but doesn't field is celebrated (they're
+  // in the order) yet stands on no field — drawing them at a position would
+  // assert a spot nobody assigned, the same lie the big diamonds refuse.
+  it("draws no field for an order-only kid, but still celebrates them", async () => {
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sluggers",
+      season: "Fall 2026",
+      allPlay: false,
+      archivedAt: null,
+    });
+    getChart.mockResolvedValue([{ ...REESE, position: null }]);
+
+    const html = await render();
+
+    expect(html).toContain("bg-banana");
+    expect(html).not.toContain("fill-grass");
+  });
+
+  it("draws no field for a substitute or when no chart is set", async () => {
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sluggers",
+      season: "Fall 2026",
+      allPlay: false,
+      archivedAt: null,
+    });
+    // A substitute on a team that does have a chart (the teammate is placed).
+    getChart.mockResolvedValue([
+      { ...REESE, position: null, battingOrder: null },
+      { ...REESE, entryId: "entry-9", playerId: "player-9", playerName: "Kit" },
+    ]);
+    const substituteHtml = await render();
+
+    // No chart at all: with no spot assigned there is nothing to frame.
+    getChart.mockResolvedValue([{ ...REESE, position: null, battingOrder: null }]);
+    const noChartHtml = await render();
+
+    expect(substituteHtml).not.toContain("fill-grass");
+    expect(noChartHtml).not.toContain("fill-grass");
   });
 
   it("announces the cards with the staggered lineup rise", async () => {

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -279,7 +279,7 @@ describe("TeamHomePage your players", () => {
     expect(html).toContain("bg-banana");
   });
 
-  it("keeps the banana in its pocket for a benched kid", async () => {
+  it("keeps the banana in its pocket for a substitute", async () => {
     getTeamById.mockResolvedValue({
       id: "team-1",
       name: "Sluggers",
@@ -294,7 +294,7 @@ describe("TeamHomePage your players", () => {
 
     const html = await render();
 
-    expect(html).toContain("Bench");
+    expect(html).toContain("Substitute");
     expect(html).not.toContain("bg-banana");
   });
 
@@ -334,7 +334,7 @@ describe("TeamHomePage your players", () => {
     expect(html).toContain("Bats 3rd · OF");
   });
 
-  it("reads a null position as Bench on a selective team", async () => {
+  it("reads a null position as Substitute on a selective team", async () => {
     getTeamById.mockResolvedValue({
       id: "team-1",
       name: "Sluggers",
@@ -344,21 +344,23 @@ describe("TeamHomePage your players", () => {
     });
     getChart.mockResolvedValue([
       { ...REESE, position: null, battingOrder: null },
-      // A teammate who is placed: "Bench" is only meaningful on a team that
-      // has a chart to be left out of.
+      // A teammate who is placed: "Substitute" is only meaningful on a team
+      // that has a chart to be left out of.
       { ...REESE, entryId: "entry-9", playerId: "player-9", playerName: "Kit" },
     ]);
 
     const html = await render();
 
-    expect(html).toContain("Bench");
+    // The softer word, by request — never "Bench" on a page a family reads.
+    expect(html).toContain("Substitute");
+    expect(html).not.toContain("Bench");
   });
 
   // The view page's rule, which team home contradicted: a kid batting third
-  // with no fielding spot is in the order. Calling that Bench would both
-  // misdescribe a kid who is playing and disagree with /view, which lists them
-  // in the order and on no bench at all.
-  it("never calls a kid who is in the batting order benched", async () => {
+  // with no fielding spot is in the order. Calling that a substitute would
+  // both misdescribe a kid who is playing and disagree with /view, which lists
+  // them in the order and in no substitutes card at all.
+  it("never calls a kid who is in the batting order a substitute", async () => {
     getTeamById.mockResolvedValue({
       id: "team-1",
       name: "Sluggers",
@@ -371,7 +373,7 @@ describe("TeamHomePage your players", () => {
     const html = await render();
 
     expect(html).toContain("Bats 3rd");
-    expect(html).not.toContain("Bench");
+    expect(html).not.toContain("Substitute");
   });
 
   // /view renders "No chart set yet" for the same data. Printing OF for every
@@ -386,7 +388,7 @@ describe("TeamHomePage your players", () => {
 
     expect(html).toContain("No chart set yet");
     expect(html).not.toContain("OF");
-    expect(html).not.toContain("Bench");
+    expect(html).not.toContain("Substitute");
   });
 
   it("never shows another family's kid", async () => {

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { InstallPrompt } from "@/components/InstallPrompt";
+import { JerseyDot } from "@/components/JerseyDot";
 import { RSVP_STYLE } from "@/components/rsvp-style";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,7 +14,7 @@ import {
 } from "@/components/ui/card";
 import type { Role } from "@/generated/prisma/enums";
 import { formatEventDateTime } from "@/lib/calendar";
-import { chartRole } from "@/lib/chart-role";
+import { chartRole, isBenched } from "@/lib/chart-role";
 import {
   byJerseyThenName,
   hasChartSet,
@@ -58,6 +59,23 @@ const UPCOMING_LIMIT = 3;
 function eventHeading(event: ScheduleEvent): string {
   if (event.type !== "GAME") return "Practice";
   return event.opponent ? `Game vs ${event.opponent}` : "Game";
+}
+
+/// The little star on a player card's marquee strip. Decorative — the chart
+/// line beside it is the content — so it is aria-hidden like the pennant glyph
+/// on TeamCard. fill-current, so it inherits the marquee's text colour and
+/// never needs its own contrast audit.
+function StarGlyph() {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      aria-hidden="true"
+      focusable="false"
+      className="h-3.5 w-3.5 shrink-0 fill-current"
+    >
+      <path d="M10 1.5l2.47 5.36 5.86.62-4.37 3.96 1.2 5.77L10 14.3l-5.16 2.91 1.2-5.77-4.37-3.96 5.86-.62z" />
+    </svg>
+  );
 }
 
 /// The accessible name for one RSVP button.
@@ -235,25 +253,71 @@ export default async function TeamHomePage({
         </p>
       ) : null}
 
-      {/* Is my kid playing. One line each, above the events, so a parent with
-          one kid gets all three answers without scrolling. */}
+      {/* Is my kid playing — answered as a celebration, not a log line. Each
+          kid gets a rookie-card hero: the jersey number worn big, the name in
+          slab caps on a pinstripe band (a hero surface, which is where §5 says
+          pinstripes may go), and a marquee strip announcing the chart line.
+          Still first, above the events, so a parent with one kid gets all
+          three answers without scrolling — and now has something worth a
+          screenshot.
+
+          The marquee is THIS screen's one banana (design-plan.md §2), and the
+          budget follows the child the same way /view's halo does: a kid the
+          chart seats gets Banana Yellow; Bench and no-chart-yet drop to quiet
+          secondary stock, because a banana shouting an empty state is the
+          wrong kind of loud. `isBenched` is chartRole's own condition for
+          printing the bench label, so the styling and the sentence cannot
+          disagree. Nothing else on this page may go banana while these cards
+          do. */}
       {myKids.length > 0 ? (
-        <ul className="space-y-1">
-          {myKids.map((entry) => (
-            <li key={entry.entryId} className="text-sm">
-              <span className="font-medium text-foreground">{entry.playerName}</span>
-              {entry.jerseyNumber !== null ? (
-                <span className="text-muted-foreground"> · #{entry.jerseyNumber}</span>
-              ) : null}
-              <span className="text-muted-foreground">
-                {" · "}
-                {hasChart
-                  ? chartRole(entry, team.allPlay, { benchLabel: "Bench" })
-                  : "No chart set yet"}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <section className="space-y-2">
+          <h3 className="font-mono text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            {myKids.length === 1 ? "Your player" : "Your players"}
+          </h3>
+          <ul className="space-y-3">
+            {myKids.map((entry, index) => {
+              const roleLine = hasChart
+                ? chartRole(entry, team.allPlay, { benchLabel: "Bench" })
+                : "No chart set yet";
+              const celebrate = hasChart && !isBenched(entry, team.allPlay);
+
+              return (
+                <li
+                  key={entry.entryId}
+                  // The lineup-announcement rise, staggered per card at the
+                  // view page's 40ms cadence. CSS, translate-only, and
+                  // reduced-motion-gated in the utility itself.
+                  className="animate-rise"
+                  style={{ animationDelay: `${index * 40}ms` }}
+                >
+                  <article className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+                    <div className="flex items-center gap-3 bg-pinstripe px-4 py-4">
+                      {entry.jerseyNumber !== null ? (
+                        <JerseyDot number={entry.jerseyNumber} size="lg" />
+                      ) : null}
+                      <p className="font-display text-2xl uppercase leading-tight tracking-wide text-foreground">
+                        {entry.playerName}
+                      </p>
+                    </div>
+                    {/* Uppercased by CSS so the DOM keeps chartRole's exact
+                        sentence — the one the readiness page and /view agree
+                        on, and the one the page tests pin. */}
+                    <p
+                      className={`flex items-center gap-2 px-4 py-2 font-mono text-sm font-bold uppercase tracking-widest ${
+                        celebrate
+                          ? "bg-banana text-banana-foreground"
+                          : "bg-secondary text-secondary-foreground"
+                      }`}
+                    >
+                      {celebrate ? <StarGlyph /> : null}
+                      <span>{roleLine}</span>
+                    </p>
+                  </article>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
       ) : null}
 
       {/* When and where, and the answer, for each of the next few. Games *and*

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { JerseyDot } from "@/components/JerseyDot";
+import { MiniDiamondHero } from "@/components/MiniDiamondHero";
 import { RSVP_STYLE } from "@/components/rsvp-style";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,6 +24,7 @@ import {
 import { sortDirectory } from "@/lib/directory-rules";
 import { mapsUrl } from "@/lib/maps";
 import { listCoachContacts } from "@/lib/memberships";
+import { fieldedPositions } from "@/lib/positions";
 import { getChart } from "@/lib/roster";
 import { buildRsvpStateMapsByEvent } from "@/lib/rsvp";
 import { guardedRosteredPlayerIds, listRsvpsForEvents } from "@/lib/rsvps";
@@ -193,6 +195,13 @@ export default async function TeamHomePage({
   // team, Substitute on a selective one.
   const hasChart = hasChartSet(chartEntries);
 
+  // The spots this team actually fields — the player-card hero's framing
+  // question, asked once here rather than per kid. Same rule chartRole applies
+  // inside: a stale CENTER_FIELD or CATCHER row on an allPlay team is not a
+  // spot, so that kid frames in the outfield zone, where both big boards
+  // already draw them.
+  const fielded = fieldedPositions(team.allPlay);
+
   // Archived teams reject every write regardless of role, so the buttons are
   // hidden rather than shown and refused — AC 4. The summaries and any answer
   // already given stay: last season is still worth reading. `rsvpAction`
@@ -254,7 +263,10 @@ export default async function TeamHomePage({
       ) : null}
 
       {/* Is my kid playing — answered as a celebration, not a log line. Each
-          kid gets a rookie-card hero: the jersey number worn big, the name in
+          kid gets a rookie-card hero: the painted field cropped to their spot
+          (MiniDiamondHero — the same FieldArt and coordinates the lineup
+          pages draw, so this is a close-up of the board the parent opens
+          next, not a third diamond), the jersey number worn big, the name in
           slab caps on a pinstripe band (a hero surface, which is where §5 says
           pinstripes may go), and a marquee strip announcing the chart line.
           Still first, above the events, so a parent with one kid gets all
@@ -283,6 +295,21 @@ export default async function TeamHomePage({
                 : "No chart set yet";
               const celebrate = hasChart && !isBenched(entry, team.allPlay);
 
+              // Where the hero frames the kid, by the diamonds' own rules: a
+              // fielded position at its spot, anyone else on an allPlay team
+              // in the outfield zone (null), and no field art at all
+              // (undefined) for a kid the chart puts on no field — a
+              // selective team's substitute or order-only batter. The hero
+              // never asserts a spot nobody assigned, which is also why it is
+              // gated on `celebrate`: with no chart there is no spot, and a
+              // substitute's card stays quiet.
+              const heroPosition =
+                entry.position !== null && fielded.has(entry.position)
+                  ? entry.position
+                  : team.allPlay
+                    ? null
+                    : undefined;
+
               return (
                 <li
                   key={entry.entryId}
@@ -293,6 +320,12 @@ export default async function TeamHomePage({
                   style={{ animationDelay: `${index * 40}ms` }}
                 >
                   <article className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+                    {celebrate && heroPosition !== undefined ? (
+                      <MiniDiamondHero
+                        position={heroPosition}
+                        jerseyNumber={entry.jerseyNumber}
+                      />
+                    ) : null}
                     <div className="flex items-center gap-3 bg-pinstripe px-4 py-4">
                       {entry.jerseyNumber !== null ? (
                         <JerseyDot number={entry.jerseyNumber} size="lg" />

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -190,7 +190,7 @@ export default async function TeamHomePage({
   // than this parent's kids — "no chart set yet" is a fact about the team, and
   // it is what /view says for the same data. Without it every line below
   // asserts a definite spot nobody assigned: OF for every kid on an allPlay
-  // team, Bench on a selective one.
+  // team, Substitute on a selective one.
   const hasChart = hasChartSet(chartEntries);
 
   // Archived teams reject every write regardless of role, so the buttons are
@@ -263,10 +263,12 @@ export default async function TeamHomePage({
 
           The marquee is THIS screen's one banana (design-plan.md §2), and the
           budget follows the child the same way /view's halo does: a kid the
-          chart seats gets Banana Yellow; Bench and no-chart-yet drop to quiet
-          secondary stock, because a banana shouting an empty state is the
-          wrong kind of loud. `isBenched` is chartRole's own condition for
-          printing the bench label, so the styling and the sentence cannot
+          chart seats gets Banana Yellow; the Substitute and no-chart-yet
+          states drop to quiet secondary stock, because a banana shouting an
+          empty state is the wrong kind of loud. `isBenched` is chartRole's
+          own condition for printing the bench label ("Substitute" — the
+          app-wide word for the state; softer than "Bench" for the family
+          reading it), so the styling and the sentence cannot
           disagree. Nothing else on this page may go banana while these cards
           do. */}
       {myKids.length > 0 ? (
@@ -277,7 +279,7 @@ export default async function TeamHomePage({
           <ul className="space-y-3">
             {myKids.map((entry, index) => {
               const roleLine = hasChart
-                ? chartRole(entry, team.allPlay, { benchLabel: "Bench" })
+                ? chartRole(entry, team.allPlay, { benchLabel: "Substitute" })
                 : "No chart set yet";
               const celebrate = hasChart && !isBenched(entry, team.allPlay);
 

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -708,7 +708,9 @@ describe("ViewPage bench", () => {
 
     const html = await render();
 
-    expect(html).toContain("Bench");
+    // "Substitutes", not "Bench" — the softer word is the app-wide label for
+    // this state, shared with team home's marquee and the positions editor.
+    expect(html).toContain("Substitutes");
     expect(html).toContain("Eli Nakamura");
   });
 
@@ -717,7 +719,7 @@ describe("ViewPage bench", () => {
     guardedRosteredPlayerIds.mockResolvedValue(new Set(["eli"]));
 
     const html = await render();
-    const benchHtml = html.slice(html.indexOf("Bench"));
+    const benchHtml = html.slice(html.indexOf("Substitutes"));
 
     expect(benchHtml).toContain(YOUR_PLAYER_TEXT);
     expect(benchHtml).toContain(GUARDED_STYLE.rowClassName);
@@ -731,20 +733,20 @@ describe("ViewPage bench", () => {
 
     const html = await render();
 
-    expect(html).not.toContain("Bench");
+    expect(html).not.toContain("Substitutes");
     expect(html).toContain("Eli Nakamura");
   });
 
   it("draws no bench card when everyone is placed", async () => {
     const html = await render();
 
-    expect(html).not.toContain("Bench");
+    expect(html).not.toContain("Substitutes");
   });
 
   it("does not call a batter without a fielding spot benched", async () => {
     // Regression: `unassigned` holds anyone the diamond doesn't seat, which
     // includes a kid batting third who simply isn't fielding. Listing them
-    // under "Bench" would duplicate them *and* tell their parent they're
+    // under "Substitutes" would duplicate them *and* tell their parent they're
     // sitting when they're batting third.
     getChart.mockResolvedValue([
       {
@@ -765,7 +767,7 @@ describe("ViewPage bench", () => {
 
     const html = await render();
 
-    expect(html).not.toContain("Bench");
+    expect(html).not.toContain("Substitutes");
     // Still in the order, once.
     expect(html.split("Ben Ortiz")).toHaveLength(2);
   });
@@ -789,7 +791,7 @@ describe("ViewPage bench", () => {
     ]);
 
     const html = await render();
-    const benchHtml = html.slice(html.indexOf("Bench"));
+    const benchHtml = html.slice(html.indexOf("Substitutes"));
 
     expect(benchHtml).toContain("Eli Nakamura");
     expect(benchHtml).not.toContain("Ben Ortiz");
@@ -800,7 +802,7 @@ describe("ViewPage bench", () => {
     getChart.mockResolvedValue(benched);
 
     const html = await render();
-    const benchHtml = html.slice(html.indexOf("Bench"));
+    const benchHtml = html.slice(html.indexOf("Substitutes"));
 
     expect(benchHtml).not.toContain(">0<");
   });

--- a/src/app/t/[teamId]/view/page.tsx
+++ b/src/app/t/[teamId]/view/page.tsx
@@ -172,8 +172,8 @@ export default async function ViewPage({
   // diamond's zone, and calling them benched would tell those parents their kid
   // is sitting when the diamond two inches above shows them playing. Then
   // `battingOrder === null`, because a kid batting third with no fielding spot
-  // is already in the order — listing them again under "Bench" would both
-  // duplicate them and misdescribe them.
+  // is already in the order — listing them again under "Substitutes" would
+  // both duplicate them and misdescribe them.
   const bench = allPlay
     ? []
     : chart.unassigned.filter((player) => player.battingOrder === null);
@@ -286,7 +286,7 @@ export default async function ViewPage({
           {bench.length > 0 ? (
             <Card className="mt-6">
               <CardHeader>
-                <CardTitle className="text-lg">Bench</CardTitle>
+                <CardTitle className="text-lg">Substitutes</CardTitle>
                 <CardDescription>
                   Not in the batting order or the field chart right now.
                 </CardDescription>

--- a/src/components/JerseyDot.tsx
+++ b/src/components/JerseyDot.tsx
@@ -6,13 +6,20 @@
 export function JerseyDot({
   number,
   className = "",
+  size = "sm",
 }: {
   number: number | string;
   className?: string;
+  /// "lg" is the hero cut for team home's player card, where the number itself
+  /// is the celebration. A variant rather than caller-supplied `h-*`/`w-*`
+  /// classes because two conflicting Tailwind size utilities resolve by
+  /// stylesheet order, not by which one the caller appended last.
+  size?: "sm" | "lg";
 }) {
+  const sizeClassName = size === "lg" ? "h-12 w-12 text-xl" : "h-7 w-7 text-sm";
   return (
     <span
-      className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-foreground font-mono text-sm font-bold text-background ${className}`}
+      className={`inline-flex shrink-0 items-center justify-center rounded-full bg-foreground font-mono font-bold text-background ${sizeClassName} ${className}`}
     >
       {number}
     </span>

--- a/src/components/MiniDiamondHero.test.tsx
+++ b/src/components/MiniDiamondHero.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  DIAMOND_GEOMETRY,
+  FIELD_ART,
+  POSITION_COORDS,
+} from "@/components/diamond-geometry";
+import { GUARDED_STYLE } from "@/components/guarded-style";
+import { HERO_CROP, heroViewBox, MiniDiamondHero } from "@/components/MiniDiamondHero";
+
+describe("heroViewBox", () => {
+  it("frames the window on the given spot", () => {
+    // SECOND_BASE (232,252) sits far enough from every edge that no clamp
+    // fires: the window is simply centred.
+    const { x, y } = POSITION_COORDS.SECOND_BASE;
+
+    expect(heroViewBox({ x, y })).toBe(
+      `${x - HERO_CROP.width / 2} ${y - HERO_CROP.height / 2} ${HERO_CROP.width} ${HERO_CROP.height}`,
+    );
+  });
+
+  it("clamps at the board's edges instead of panning into blank space", () => {
+    // RIGHT_FIELD's centred window would run past x=400; LEFT_FIELD's past
+    // x=0. Both stop at the edge, leaving the marker off-centre in frame.
+    expect(heroViewBox(POSITION_COORDS.RIGHT_FIELD)).toBe(
+      `${DIAMOND_GEOMETRY.width - HERO_CROP.width} 75 ${HERO_CROP.width} ${HERO_CROP.height}`,
+    );
+    expect(heroViewBox(POSITION_COORDS.LEFT_FIELD)).toBe(
+      `0 75 ${HERO_CROP.width} ${HERO_CROP.height}`,
+    );
+  });
+
+  it("keeps the catcher's window on the board", () => {
+    // The deepest spot: y=452 centres to 397, still inside 520 - 110 = 410.
+    // If either the crop height or the catcher's coordinate moves, this is
+    // the case that silently pans past the bottom edge first.
+    const box = heroViewBox(POSITION_COORDS.CATCHER);
+    const [, y] = box.split(" ").map(Number);
+
+    expect(y + HERO_CROP.height).toBeLessThanOrEqual(DIAMOND_GEOMETRY.height);
+  });
+});
+
+describe("MiniDiamondHero", () => {
+  it("draws the painted field cropped to the kid's position", () => {
+    const html = renderToStaticMarkup(
+      <MiniDiamondHero position="SECOND_BASE" jerseyNumber={12} />,
+    );
+
+    expect(html).toContain(`viewBox="${heroViewBox(POSITION_COORDS.SECOND_BASE)}"`);
+    // The real field, not a new illustration.
+    expect(html).toContain("fill-grass");
+  });
+
+  it("frames the allPlay outfield kid at the zone's centre", () => {
+    const html = renderToStaticMarkup(
+      <MiniDiamondHero position={null} jerseyNumber={12} />,
+    );
+
+    // outfieldZoneCoords(1) is CENTER_FIELD's spot by construction.
+    expect(html).toContain(`viewBox="${heroViewBox(POSITION_COORDS.CENTER_FIELD)}"`);
+  });
+
+  it("wears the jersey number in the JerseyDot colours", () => {
+    const html = renderToStaticMarkup(
+      <MiniDiamondHero position="SECOND_BASE" jerseyNumber={12} />,
+    );
+
+    expect(html).toContain(">12</text>");
+    expect(html).toContain("fill-foreground");
+    expect(html).toContain("fill-background");
+  });
+
+  it("falls back to the position label when no number is on file", () => {
+    const withPosition = renderToStaticMarkup(
+      <MiniDiamondHero position="SHORTSTOP" jerseyNumber={null} />,
+    );
+    const inZone = renderToStaticMarkup(
+      <MiniDiamondHero position={null} jerseyNumber={null} />,
+    );
+
+    expect(withPosition).toContain(">SS</text>");
+    expect(inZone).toContain(">OF</text>");
+  });
+
+  // The halo and the fence share the class `fill-none stroke-banana` when the
+  // fence is yellow, so — as FieldArt's own suite records — telling them apart
+  // has to key on the radius. Here the fence must be chalk: the hero renders
+  // only for a kid the chart seats, whose card already spends the banana.
+  it("rings the kid in banana and keeps the fence chalk", () => {
+    const html = renderToStaticMarkup(
+      <MiniDiamondHero position="SECOND_BASE" jerseyNumber={12} />,
+    );
+
+    expect(html).toContain(
+      `r="${DIAMOND_GEOMETRY.haloRadius}" class="${GUARDED_STYLE.haloClassName}"`,
+    );
+    expect(html).toContain(`r="${FIELD_ART.fenceRadius}" class="fill-none stroke-chalk"`);
+    expect(html).not.toContain(`r="${FIELD_ART.fenceRadius}" class="fill-none stroke-banana"`);
+  });
+
+  // The documented SVG trap: a CSS transform overrides an SVG transform
+  // attribute, so animating the positioning <g> renders the marker at the
+  // field's origin — silently.
+  it("animates an inner group, never the one carrying the position", () => {
+    const { x, y } = POSITION_COORDS.SECOND_BASE;
+    const html = renderToStaticMarkup(
+      <MiniDiamondHero position="SECOND_BASE" jerseyNumber={12} />,
+    );
+
+    expect(html).toContain(`transform="translate(${x} ${y})"><g class="animate-step-up">`);
+  });
+
+  it("is decoration: hidden from assistive tech like FieldArt itself", () => {
+    const html = renderToStaticMarkup(
+      <MiniDiamondHero position="SECOND_BASE" jerseyNumber={12} />,
+    );
+
+    expect(html).toContain('aria-hidden="true"');
+  });
+});

--- a/src/components/MiniDiamondHero.tsx
+++ b/src/components/MiniDiamondHero.tsx
@@ -1,0 +1,131 @@
+import {
+  DIAMOND_GEOMETRY,
+  POSITION_COORDS,
+  outfieldZoneCoords,
+} from "@/components/diamond-geometry";
+import { FieldArt } from "@/components/FieldArt";
+import { GUARDED_STYLE } from "@/components/guarded-style";
+import type { Position } from "@/generated/prisma/enums";
+import { OUTFIELD_ZONE_LABEL, POSITION_LABELS } from "@/lib/positions";
+
+/// The crop window, in field units — a wide strip of the 400×520 board framed
+/// around one spot. Sized so the marker and its halo dominate the frame with
+/// enough grass, chalk and dirt around them to read as *the field*, not as an
+/// abstract circle: the halo reaches haloRadius + haloStrokeWidth/2 = 26.5
+/// from centre, so a 110-tall window leaves roughly a marker's height of
+/// context above and below.
+export const HERO_CROP = { width: 240, height: 110 } as const;
+
+/// The SVG viewBox for a hero framed on `center`, clamped to the board so the
+/// window never pans past the field's edge into blank space — a corner
+/// outfielder sits off-centre in their frame instead, which is also how a
+/// photographer would crop them.
+export function heroViewBox(center: { x: number; y: number }): string {
+  const x = clamp(center.x - HERO_CROP.width / 2, 0, DIAMOND_GEOMETRY.width - HERO_CROP.width);
+  const y = clamp(center.y - HERO_CROP.height / 2, 0, DIAMOND_GEOMETRY.height - HERO_CROP.height);
+  return `${x} ${y} ${HERO_CROP.width} ${HERO_CROP.height}`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Team home's player-card hero (#48 follow-up): the reader's own kid standing
+ * on the painted field, cropped to their spot. The whole point is that this is
+ * the *same* field the lineup pages draw — `FieldArt` and `POSITION_COORDS`,
+ * not a new illustration — so the card is a close-up of the board the parent
+ * opens next, never a third diamond that could drift.
+ *
+ * Where the kid stands follows the diamonds' own rules: a fielded position at
+ * its `POSITION_COORDS` spot, and everyone else on an allPlay team in the
+ * outfield zone — framed at `outfieldZoneCoords(1)`, the zone's dead-centre,
+ * because this kid has the hero's field to themselves. A player the chart
+ * seats nowhere gets no hero at all (the caller's decision): the diamond
+ * never draws a spot nobody assigned, and neither does its close-up.
+ *
+ * The marker wears the kid's **jersey number** in the JerseyDot colours rather
+ * than the position abbreviation the big boards use — on a card celebrating
+ * one child, the number is the identity and the marquee right below already
+ * names the position. With no number on file it falls back to the position
+ * label, from `POSITION_LABELS` as always. The halo is the guarded ring from
+ * /view, banana by the same trade: this card's field keeps a chalk fence so
+ * the yellow belongs to the kid.
+ *
+ * Decoration only — aria-hidden, like `FieldArt` itself: the card's text
+ * (name, number, marquee) is where every fact here exists as words.
+ */
+export function MiniDiamondHero({
+  position,
+  jerseyNumber,
+}: {
+  /// The kid's fielded position, or null for the allPlay outfield zone. The
+  /// caller — not this component — decides that a kid with no field spot on a
+  /// selective team renders no hero rather than an invented one.
+  position: Position | null;
+  jerseyNumber: number | null;
+}) {
+  const center = position ? POSITION_COORDS[position] : outfieldZoneCoords(1)[0];
+  const label = position ? POSITION_LABELS[position] : OUTFIELD_ZONE_LABEL;
+
+  return (
+    <svg
+      viewBox={heroViewBox(center)}
+      aria-hidden="true"
+      focusable="false"
+      className="block w-full"
+    >
+      {/* Chalk fence, unconditionally: this hero exists only for a kid the
+          chart seats, so the card's banana is already spent on them — the
+          halo here and the marquee below are one treatment of one child,
+          the way /view's halo, row border and chip are. */}
+      <FieldArt fence="chalk" />
+
+      {/* The outer <g> owns the positioning transform and must keep owning
+          it: a CSS transform overrides an SVG transform attribute, so the
+          step-up animation goes on the inner <g> — on the outer one it would
+          teleport the marker to the field's origin. */}
+      <g transform={`translate(${center.x} ${center.y})`}>
+        <g className="animate-step-up">
+          <circle
+            r={DIAMOND_GEOMETRY.haloRadius}
+            className={GUARDED_STYLE.haloClassName}
+            strokeWidth={DIAMOND_GEOMETRY.haloStrokeWidth}
+          />
+          {jerseyNumber !== null ? (
+            <>
+              {/* The JerseyDot motif, drawn in SVG at marker scale: a number
+                  on this team looks like the back of a shirt everywhere,
+                  including standing on the grass. */}
+              <circle r={DIAMOND_GEOMETRY.markerRadius} className="fill-foreground" />
+              <text
+                textAnchor="middle"
+                dy={6}
+                className="fill-background font-mono text-[17px] font-bold"
+              >
+                {jerseyNumber}
+              </text>
+            </>
+          ) : (
+            <>
+              {/* No number on file: the big boards' marker instead, so the
+                  fallback is a vocabulary the parent has already seen. */}
+              <circle
+                r={DIAMOND_GEOMETRY.markerRadius}
+                className="fill-card/80 stroke-muted-foreground"
+                strokeWidth={1.5}
+              />
+              <text
+                textAnchor="middle"
+                dy={4}
+                className="fill-foreground text-[11px] font-bold"
+              >
+                {label}
+              </text>
+            </>
+          )}
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/lib/chart-role.test.ts
+++ b/src/lib/chart-role.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { chartRole, ordinal } from "@/lib/chart-role";
+import { chartRole, isBenched, ordinal } from "@/lib/chart-role";
 
 const entry = (
   battingOrder: number | null,
@@ -83,5 +83,41 @@ describe("chartRole on an allPlay team", () => {
 
   it("prints OF alone for a player with no batting slot", () => {
     expect(chartRole(entry(null), allPlay)).toBe("OF");
+  });
+});
+
+describe("isBenched", () => {
+  it("is true only for a player in neither column on a selective team", () => {
+    expect(isBenched(entry(null), false)).toBe(true);
+    expect(isBenched(entry(3, "SHORTSTOP"), false)).toBe(false);
+    expect(isBenched(entry(3), false)).toBe(false);
+    expect(isBenched(entry(null, "SHORTSTOP"), false)).toBe(false);
+  });
+
+  it("is never true on an allPlay team — the leftover kids are the outfield", () => {
+    expect(isBenched(entry(null), true)).toBe(false);
+    expect(isBenched(entry(null, "CENTER_FIELD"), true)).toBe(false);
+  });
+
+  // The pin the export promises: isBenched true exactly when chartRole would
+  // print the bench label. Team home styles on the former and prints the
+  // latter, so a disagreement here is a banana marquee shouting "Bench" — or a
+  // playing kid rendered on quiet stock.
+  it("agrees with chartRole about when the bench label prints", () => {
+    const shapes = [
+      entry(null),
+      entry(3),
+      entry(null, "SHORTSTOP"),
+      entry(3, "SHORTSTOP"),
+      entry(null, "CATCHER"),
+      entry(null, "CENTER_FIELD"),
+    ];
+    for (const allPlay of [false, true]) {
+      for (const shape of shapes) {
+        expect(isBenched(shape, allPlay)).toBe(
+          chartRole(shape, allPlay, { benchLabel: "Bench" }) === "Bench",
+        );
+      }
+    }
   });
 });

--- a/src/lib/chart-role.test.ts
+++ b/src/lib/chart-role.test.ts
@@ -49,15 +49,19 @@ describe("chartRole on a selective team", () => {
   });
 
   it("prints the bench label when one is asked for — team home's shape", () => {
-    expect(chartRole(entry(null), allPlay, { benchLabel: "Bench" })).toBe("Bench");
+    expect(chartRole(entry(null), allPlay, { benchLabel: "Substitute" })).toBe(
+      "Substitute",
+    );
   });
 
-  // The view page's bench list filters on `battingOrder === null` for this
-  // reason, and says so: a kid batting third with no fielding spot is in the
-  // order. "Bats 4th · Bench" would misdescribe a kid who is playing, and
-  // disagree with the page a parent reads next.
+  // The view page's substitutes list filters on `battingOrder === null` for
+  // this reason, and says so: a kid batting third with no fielding spot is in
+  // the order. "Bats 4th · Substitute" would misdescribe a kid who is playing,
+  // and disagree with the page a parent reads next.
   it("never calls a player in the batting order benched", () => {
-    expect(chartRole(entry(4), allPlay, { benchLabel: "Bench" })).toBe("Bats 4th");
+    expect(chartRole(entry(4), allPlay, { benchLabel: "Substitute" })).toBe(
+      "Bats 4th",
+    );
   });
 });
 
@@ -73,7 +77,9 @@ describe("chartRole on an allPlay team", () => {
   // where both diamonds already draw that player.
   it("reads a null position as OF, never as bench", () => {
     expect(chartRole(entry(2), allPlay)).toBe("Bats 2nd · OF");
-    expect(chartRole(entry(2), allPlay, { benchLabel: "Bench" })).toBe("Bats 2nd · OF");
+    expect(chartRole(entry(2), allPlay, { benchLabel: "Substitute" })).toBe(
+      "Bats 2nd · OF",
+    );
   });
 
   it("reads a stale CENTER_FIELD or CATCHER row as OF", () => {
@@ -101,8 +107,8 @@ describe("isBenched", () => {
 
   // The pin the export promises: isBenched true exactly when chartRole would
   // print the bench label. Team home styles on the former and prints the
-  // latter, so a disagreement here is a banana marquee shouting "Bench" — or a
-  // playing kid rendered on quiet stock.
+  // latter, so a disagreement here is a banana marquee shouting "Substitute" —
+  // or a playing kid rendered on quiet stock.
   it("agrees with chartRole about when the bench label prints", () => {
     const shapes = [
       entry(null),
@@ -115,7 +121,7 @@ describe("isBenched", () => {
     for (const allPlay of [false, true]) {
       for (const shape of shapes) {
         expect(isBenched(shape, allPlay)).toBe(
-          chartRole(shape, allPlay, { benchLabel: "Bench" }) === "Bench",
+          chartRole(shape, allPlay, { benchLabel: "Substitute" }) === "Substitute",
         );
       }
     }

--- a/src/lib/chart-role.ts
+++ b/src/lib/chart-role.ts
@@ -76,3 +76,25 @@ export function chartRole(
 
   return parts.join(" · ");
 }
+
+/**
+ * The condition under which `chartRole` prints its `benchLabel`: the chart
+ * seats this player nowhere — neither in the batting order nor at a spot the
+ * team fields. Never true on an allPlay team, where everyone outside the
+ * infield is in the outfield.
+ *
+ * Exported so team home can *style* the bench state (quiet card stock) apart
+ * from the celebration (the banana marquee) without string-matching the label
+ * it just asked `chartRole` to print. Kept beside `chartRole` so the sentence
+ * and the styling decision cannot drift: `chart-role.test.ts` pins that the
+ * two agree on every shape of entry.
+ */
+export function isBenched(
+  entry: Pick<ChartViewEntry, "battingOrder" | "position">,
+  allPlay: boolean,
+): boolean {
+  if (entry.battingOrder !== null) return false;
+  if (allPlay) return false;
+  const fielded = fieldedPositions(allPlay);
+  return entry.position === null || !fielded.has(entry.position);
+}

--- a/src/lib/chart-role.ts
+++ b/src/lib/chart-role.ts
@@ -23,8 +23,9 @@ export function ordinal(n: number): string {
 
 export type ChartRoleOptions = {
   /**
-   * What to print when this team fields no spot for the player — "Bench" on
-   * team home, nothing at all on the readiness page.
+   * What to print when this team fields no spot for the player — "Substitute"
+   * on team home (the app-wide word for the state; softer than "Bench" for
+   * the family reading it), nothing at all on the readiness page.
    *
    * Opt-in rather than always on, because the two callers are answering
    * different questions. Readiness lists a player the coach already knows is
@@ -34,9 +35,9 @@ export type ChartRoleOptions = {
    * failed to load, not as "on the bench".
    *
    * Applied only to a player who is in **neither** column, matching the filter
-   * the view page's bench list already uses: a kid batting third with no
-   * fielding spot is in the order, and "Bats 3rd · Bench" would contradict the
-   * page a parent reads next — and misdescribe a kid who is playing.
+   * the view page's substitutes list already uses: a kid batting third with no
+   * fielding spot is in the order, and "Bats 3rd · Substitute" would contradict
+   * the page a parent reads next — and misdescribe a kid who is playing.
    *
    * Never reached on an allPlay team: everyone outside that infield is in the
    * outfield, which is what the next save writes.


### PR DESCRIPTION
## What

The team home dashboard's "your kid" section was one muted gray sentence — accurate, and no fun at all. Each guarded kid now gets a **player hero card** whose card art is the kid standing on the real field:

- **`MiniDiamondHero`** — the painted `FieldArt` board cropped to a wide strip framed on the kid's spot, with the guarded banana halo ringing a marker that wears their jersey number in the JerseyDot colours. Same field, coordinates, halo, and step-up animation the lineup pages use, so the card is a close-up of the board the parent opens next — never a third diamond that could drift.
- Below the art: the jersey number worn big on a `JerseyDot` (new `lg` cut), the name in Alfa Slab caps on a pinstripe hero band, and a marquee strip announcing the chart line ("★ BATS 1ST · 2B").
- Cards rise in with the same staggered `animate-rise` the lineup view announces rows with — translate-only and `prefers-reduced-motion`-gated.

## Design decisions

- **The banana follows the child** (design-plan §2), exactly as on `/view`: a kid the chart seats gets the yellow halo + marquee (one treatment of one child, like `/view`'s halo + row + chip); the hero's fence is always chalk to pay for it. Substitute and no-chart states drop to quiet secondary stock — the banana never shouts an empty state — and a team-home view with no guarded kid has no banana at all.
- **The hero never asserts a spot nobody assigned.** Framing follows the diamonds' own rules: a fielded position at its `POSITION_COORDS` spot; anyone else on an allPlay team at the outfield zone's centre (`outfieldZoneCoords(1)`); no field art for a substitute or an order-only batter. The crop clamps at the board's edges so a corner outfielder sits off-centre in frame instead of the window panning into blank space.
- **The celebration can't lie.** New `isBenched` export in `chart-role.ts` is `chartRole`'s own bench condition, with a test pinning that the styling and the printed sentence always agree. The marquee uppercases by CSS only, so the DOM keeps `chartRole`'s exact line — team home, readiness, and `/view` keep saying the same thing.
- **"Bench" softened to "Substitute"** everywhere a person reads it — team home's marquee, `/view`'s card title (now "Substitutes"), and the positions editor's drag zone — one word for one state, per the same rule that keeps "Archived" to a single term. Code internals keep the bench-family names (`isBenched`, `benchLabel`) since they name the condition, not the copy.
- AGENTS.md's gotcha and the design plan (a drift-tested as-built record) are updated to match.

## Testing

`pnpm check` green: lint, typecheck, 83 test files / 1,203 tests. New pins: hero viewBox framing and edge clamping; halo-vs-fence told apart by radius (they share a class); step-up on the inner `<g>`, never the positioning one (the documented CSS-vs-SVG transform trap); field art present for placed kids and absent for substitute / order-only / no-chart; banana present only for a placed kid; staggered rise; `isBenched`↔`chartRole` agreement across every entry shape. Existing pins (no invented positions, in-the-order kids never called substitutes, no other family's kid, sibling sort) all kept.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcnCvkUZYFyR9uYjwpYfQo