### PR TITLE
Add List-Unsubscribe to broadcasts and day-of reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,14 +425,19 @@ production — the dev command can prompt, generate new migrations, and reset th
   whenever the draft builder normalized something — a stale `CENTER_FIELD` row under allPlay,
   or nine slots holding what used to be ten batters — and gating Save on the Cancel question
   leaves the coach looking at a change they cannot commit.
-- **`List-Unsubscribe` is set on exactly one send, and that is a claim, not an oversight.**
-  `sendEmail` takes an optional `listUnsubscribe` address and only the all-parents
-  broadcast passes one. RFC 2369 says the header describes a *list the recipient belongs
-  to*: an invitation goes to someone not on the team yet, and the other two message
-  shapes are one-to-one correspondence (a coach mailing one parent, a parent mailing the
-  staff). Adding it everywhere to quiet a deliverability report would be a lie in a
-  header. The value is a `mailto:` to the sending coach and deliberately **not** RFC 8058
-  one-click — one-click needs an unauthenticated HTTPS POST and a suppression store,
+- **`List-Unsubscribe` is set on two sends, and which two is a claim, not an oversight.**
+  `sendEmail` takes an optional `listUnsubscribe` address; the all-parents broadcast and
+  the day-of reminder cron pass one, and nothing else does. RFC 2369 says the header
+  describes a *list the recipient belongs to*: an invitation goes to someone not on the
+  team yet, and the two remaining message shapes are one-to-one correspondence (a coach
+  mailing one parent, a parent mailing the staff). Adding it everywhere to quiet a
+  deliverability report would be a lie in a header. The address differs by sender because
+  the senders differ: a broadcast has a human sending it, so it reuses that coach (the
+  same address as `Reply-To`), while the cron runs as the system and has to *choose* one —
+  `pickUnsubscribeContact` (`reminders.ts`) takes the team's owner over an assistant coach
+  and breaks ties on `userId`, so two runs of the same day name the same person. A team
+  with no staff address sends no header rather than one mailing nowhere. Deliberately
+  **not** RFC 8058 one-click — one-click needs an unauthenticated HTTPS POST and a suppression store,
   which is how a parent silently drops themselves off "tonight is cancelled". Routing it
   to a human who can ask why is the chosen trade; revisit only by deciding about that
   failure mode, not to chase a checkmark. Callers pass a bare address — `email.ts` owns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,6 +416,18 @@ production — the dev command can prompt, generate new migrations, and reset th
   whenever the draft builder normalized something — a stale `CENTER_FIELD` row under allPlay,
   or nine slots holding what used to be ten batters — and gating Save on the Cancel question
   leaves the coach looking at a change they cannot commit.
+- **`List-Unsubscribe` is set on exactly one send, and that is a claim, not an oversight.**
+  `sendEmail` takes an optional `listUnsubscribe` address and only the all-parents
+  broadcast passes one. RFC 2369 says the header describes a *list the recipient belongs
+  to*: an invitation goes to someone not on the team yet, and the other two message
+  shapes are one-to-one correspondence (a coach mailing one parent, a parent mailing the
+  staff). Adding it everywhere to quiet a deliverability report would be a lie in a
+  header. The value is a `mailto:` to the sending coach and deliberately **not** RFC 8058
+  one-click — one-click needs an unauthenticated HTTPS POST and a suppression store,
+  which is how a parent silently drops themselves off "tonight is cancelled". Routing it
+  to a human who can ask why is the chosen trade; revisit only by deciding about that
+  failure mode, not to chase a checkmark. Callers pass a bare address — `email.ts` owns
+  the angle-bracket framing so it exists in one tested place.
 - **The bulk invite action is the only place that sends in a loop, and three constants are
   coupled across two files.** `bulkInviteGuardiansAction` paces sends `MIN_SEND_INTERVAL_MS`
   (600ms) apart to stay under Resend's 2 req/s limit, caps a batch at `MAX_ROWS` (30), and

--- a/src/app/api/cron/reminders/route.test.ts
+++ b/src/app/api/cron/reminders/route.test.ts
@@ -40,6 +40,7 @@ function event(overrides: Partial<ReminderEvent> = {}): ReminderEvent {
     notes: null,
     roster: [{ playerId: "player-1", playerName: "Jimmy", guardians: [ANNA] }],
     rsvps: [],
+    unsubscribeEmail: "coach@example.com",
     ...overrides,
   };
 }
@@ -151,6 +152,35 @@ describe("GET /api/cron/reminders — sending", () => {
     expect(claimReminder).not.toHaveBeenCalled();
     expect(sendEmail).not.toHaveBeenCalled();
     expect(await response.json()).toMatchObject({ events: 0, sent: 0 });
+  });
+});
+
+describe("GET /api/cron/reminders — List-Unsubscribe", () => {
+  it("points the header at the team's staff contact", async () => {
+    loadTodaysReminderWork.mockResolvedValue(
+      work([event({ unsubscribeEmail: "owner@example.com" })]),
+    );
+
+    await get();
+
+    // Reminders are recurring every-family mail, so unlike the one-to-one
+    // sends they carry the header. email.ts frames it; the route passes an
+    // address.
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ listUnsubscribe: "owner@example.com" }),
+    );
+  });
+
+  it("omits the key when the team has no staff address", async () => {
+    loadTodaysReminderWork.mockResolvedValue(
+      work([event({ unsubscribeEmail: null })]),
+    );
+
+    await get();
+
+    // A header mailing nowhere is worse than none — and the email still goes.
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail.mock.calls[0][0]).not.toHaveProperty("listUnsubscribe");
   });
 });
 

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -192,6 +192,14 @@ export async function GET(request: Request) {
       const outcome = await sendEmail({
         to: payload.email,
         subject,
+        // Reminders are the app's only recurring, every-family mail, which is
+        // exactly what List-Unsubscribe describes. There is no human sender to
+        // point at — the cron runs as the system — so the address is the
+        // team's staff contact, chosen by `pickUnsubscribeContact`. A team
+        // with no staff address sends none rather than one mailing nowhere.
+        ...(payload.unsubscribeEmail
+          ? { listUnsubscribe: payload.unsubscribeEmail }
+          : {}),
         react: EventReminderEmail({
           teamName: payload.teamName,
           headline,

--- a/src/app/t/[teamId]/messages/new/actions.test.ts
+++ b/src/app/t/[teamId]/messages/new/actions.test.ts
@@ -156,6 +156,17 @@ describe("sendTeamMessageAction — coach broadcast", () => {
     expect(first.replyTo).toBe("coach@example.com");
   });
 
+  it("carries a List-Unsubscribe pointing at the sending coach", async () => {
+    await redirectUrlOf(sendTeamMessageAction(form(BROADCAST)));
+
+    // The broadcast is the only shape that is list mail, and the coach is
+    // the human who can actually act on the request. email.ts owns the
+    // RFC 2369 framing, so the action passes a bare address.
+    for (const call of sendEmail.mock.calls) {
+      expect(call[0].listUnsubscribe).toBe("coach@example.com");
+    }
+  });
+
   it("writes the row before sending, so a failed tail keeps the record", async () => {
     sendEmail
       .mockResolvedValueOnce({ ok: true })
@@ -196,6 +207,8 @@ describe("sendTeamMessageAction — coach to one parent", () => {
     expect(createMessage).not.toHaveBeenCalled();
     expect(sendEmail).toHaveBeenCalledTimes(1);
     expect(sendEmail.mock.calls[0][0].to).toBe("blake@example.com");
+    // One-to-one mail is not a list to leave.
+    expect(sendEmail.mock.calls[0][0]).not.toHaveProperty("listUnsubscribe");
   });
 
   it("rejects a target who is not a parent on this team, before sending", async () => {
@@ -235,6 +248,8 @@ describe("sendTeamMessageAction — parent to the coaching staff", () => {
       "coach@example.com",
     ]);
     expect(sendEmail.mock.calls[0][0].replyTo).toBe("alex@example.com");
+    // A parent writing the staff is correspondence, not a mailing list.
+    expect(sendEmail.mock.calls[0][0]).not.toHaveProperty("listUnsubscribe");
   });
 
   // Belt and suspenders: even if the requireTeamAccess gate were somehow

--- a/src/app/t/[teamId]/messages/new/actions.ts
+++ b/src/app/t/[teamId]/messages/new/actions.ts
@@ -61,7 +61,11 @@ const MIN_SEND_INTERVAL_MS = 600;
  * The broadcast row is written BEFORE the fan-out (the coach's copy survives
  * a half-failed send), and each recipient gets their own email — never a
  * shared To line, which would hand every parent the rest of the parents'
- * addresses. Reply-To is the sender, so answering works from the inbox.
+ * addresses. Reply-To is the sender, so answering works from the inbox, and
+ * the broadcast — the one shape that is genuinely list mail — also carries a
+ * List-Unsubscribe pointing at that same sender. Mailboxes read its absence
+ * on bulk-shaped mail as a spam signal, and the coach is the person who can
+ * actually act on the request.
  */
 export async function sendTeamMessageAction(formData: FormData) {
   const teamId = extractTeamId(formData);
@@ -172,6 +176,11 @@ export async function sendTeamMessageAction(formData: FormData) {
         to: recipient.email,
         subject: emailSubject,
         replyTo: senderEmail,
+        // Broadcasts only — the other two audiences are one-to-one mail, and
+        // a List-Unsubscribe on those would claim a list that isn't there.
+        ...(audience === "ALL_PARENTS"
+          ? { listUnsubscribe: senderEmail }
+          : {}),
         react: TeamMessageEmail({ teamName, senderName, body, teamUrl }),
       });
 

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -80,6 +80,21 @@ describe("sendEmail", () => {
     expect(send.mock.calls[0][0]).not.toHaveProperty("headers");
   });
 
+  it.each([
+    ["a CRLF injection attempt", "coach@example.com>\r\nBcc: victim@example.com"],
+    ["an embedded angle bracket", "coach@example.com>"],
+    ["whitespace", "coach @example.com"],
+    ["no at-sign", "not-an-address"],
+  ])("drops the header but still sends, given %s", async (_label, address) => {
+    const result = await sendEmail({ ...INPUT, listUnsubscribe: address });
+
+    // A malformed header value is header injection, not a cosmetic problem —
+    // and losing the email over it would be the worse failure.
+    expect(result.ok).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0]).not.toHaveProperty("headers");
+  });
+
   it("reports a Resend error as a failed send", async () => {
     send.mockResolvedValue({ error: { message: "rate limited" } });
 

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -58,6 +58,28 @@ describe("sendEmail", () => {
     expect(send.mock.calls[0][0]).not.toHaveProperty("replyTo");
   });
 
+  it("sends listUnsubscribe as an RFC 2369 mailto header", async () => {
+    await sendEmail({ ...INPUT, listUnsubscribe: "coach@example.com" });
+
+    // Angle brackets are not decoration — a bare address is not a valid
+    // header value, and callers pass the address, not the framing.
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          "List-Unsubscribe": "<mailto:coach@example.com?subject=Unsubscribe>",
+        },
+      }),
+    );
+  });
+
+  it("omits headers entirely when listUnsubscribe is not provided", async () => {
+    await sendEmail(INPUT);
+
+    // Same reasoning as replyTo above: an empty `headers` object is a
+    // different payload than none, and most sends are not list mail.
+    expect(send.mock.calls[0][0]).not.toHaveProperty("headers");
+  });
+
   it("reports a Resend error as a failed send", async () => {
     send.mockResolvedValue({ error: { message: "rate limited" } });
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -47,9 +47,34 @@ function requireEnv(name: string): string | null {
   return value ? value : null;
 }
 
-/// RFC 2369: the value is a URL in angle brackets. The address comes from a
-/// stored `User.email`, never from a form.
-function listUnsubscribeHeader(address: string): Record<string, string> {
+/// A bare addr-spec: no whitespace, no CR/LF, and none of the characters that
+/// would end the angle-bracket URL early. Deliberately narrower than the RFC
+/// 5322 grammar — quoted local parts are legal and this rejects them, which
+/// costs nothing here and keeps the pattern small enough to read.
+const BARE_ADDRESS = /^[^\s<>,;"\\]+@[^\s<>,;"\\]+$/;
+
+/// RFC 2369: the value is a URL in angle brackets.
+///
+/// Callers pass an address read back from a stored `User.email` — which a
+/// person typed at some point (`z.email()` guards the sign-in and bulk-invite
+/// forms), so it is validated at entry rather than trustworthy for merely
+/// being in the database. This is the second layer, and it is here because a
+/// comment cannot stop a CR/LF in a header value from becoming header
+/// injection: `email.ts` is the one place that frames the header, so it is the
+/// one place that has to check.
+///
+/// A suspect address yields no header rather than a malformed one, and the
+/// caller's email still goes out — matching how the rest of this module
+/// degrades. The address is not logged; it is someone's personal contact
+/// detail and the count of failures is what a maintainer needs.
+function listUnsubscribeHeader(address: string): Record<string, string> | null {
+  if (!BARE_ADDRESS.test(address)) {
+    console.error(
+      "Refusing to set List-Unsubscribe: the address is not a bare addr-spec",
+    );
+    return null;
+  }
+
   return { "List-Unsubscribe": `<mailto:${address}?subject=Unsubscribe>` };
 }
 
@@ -69,6 +94,10 @@ export async function sendEmail({
     return { ok: false, reason };
   }
 
+  const headers = listUnsubscribe
+    ? listUnsubscribeHeader(listUnsubscribe)
+    : null;
+
   try {
     const resend = new Resend(apiKey);
     const { error } = await resend.emails.send({
@@ -77,9 +106,7 @@ export async function sendEmail({
       subject,
       react,
       ...(replyTo ? { replyTo } : {}),
-      ...(listUnsubscribe
-        ? { headers: listUnsubscribeHeader(listUnsubscribe) }
-        : {}),
+      ...(headers ? { headers } : {}),
     });
 
     if (error) {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -8,6 +8,21 @@ import { Resend } from "resend";
 /// module scope, mirroring src/auth.ts's lazy config: the build must not
 /// require secrets, and a missing key should fail when someone actually
 /// tries to send, not at import time.
+///
+/// `List-Unsubscribe` is opt-in per send rather than applied to everything,
+/// because it is a claim about the mail and not a courtesy: RFC 2369 says
+/// the header describes a *list* the recipient belongs to. An invitation is
+/// addressed to someone who is not on the team yet, and the two one-to-one
+/// message shapes are ordinary correspondence — a coach mailing one parent,
+/// or a parent mailing the staff. Only the all-parents broadcast is list
+/// mail, and only it sets the header.
+///
+/// Deliberately mailto and not RFC 8058 one-click: one-click needs an
+/// unauthenticated HTTPS POST endpoint and somewhere to record the
+/// suppression, which would let a parent silently drop themselves off
+/// "tonight is cancelled". Routing an unsubscribe to a human who can ask
+/// why is the safer default for a team of twenty-five. Revisit only with a
+/// deliberate decision about that failure mode.
 
 export type SendEmailInput = {
   to: string;
@@ -17,6 +32,12 @@ export type SendEmailInput = {
   /// (the verified domain), so without this a recipient's reply mails a
   /// void — set it and the reply becomes ordinary person-to-person email.
   replyTo?: string;
+  /// An address a recipient can mail to stop receiving this kind of message,
+  /// set only by senders that fan one body out to a whole audience. Pass the
+  /// bare address; the RFC 2369 framing is this module's job, so callers do
+  /// not hand-build a mail header. Omitting it is the right call for
+  /// one-to-one and transactional mail — see the note above `sendEmail`.
+  listUnsubscribe?: string;
 };
 
 export type SendEmailResult = { ok: true } | { ok: false; reason: string };
@@ -26,11 +47,18 @@ function requireEnv(name: string): string | null {
   return value ? value : null;
 }
 
+/// RFC 2369: the value is a URL in angle brackets. The address comes from a
+/// stored `User.email`, never from a form.
+function listUnsubscribeHeader(address: string): Record<string, string> {
+  return { "List-Unsubscribe": `<mailto:${address}?subject=Unsubscribe>` };
+}
+
 export async function sendEmail({
   to,
   subject,
   react,
   replyTo,
+  listUnsubscribe,
 }: SendEmailInput): Promise<SendEmailResult> {
   const apiKey = requireEnv("RESEND_API_KEY");
   const from = requireEnv("EMAIL_FROM");
@@ -49,6 +77,9 @@ export async function sendEmail({
       subject,
       react,
       ...(replyTo ? { replyTo } : {}),
+      ...(listUnsubscribe
+        ? { headers: listUnsubscribeHeader(listUnsubscribe) }
+        : {}),
     });
 
     if (error) {

--- a/src/lib/reminder-data.test.ts
+++ b/src/lib/reminder-data.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const eventFindMany = vi.fn();
 const rosterFindMany = vi.fn();
+const membershipFindMany = vi.fn();
 const receiptCreate = vi.fn();
 const receiptDeleteMany = vi.fn();
 
@@ -9,6 +10,9 @@ vi.mock("@/lib/db", () => ({
   db: {
     event: { findMany: (...args: unknown[]) => eventFindMany(...args) },
     rosterEntry: { findMany: (...args: unknown[]) => rosterFindMany(...args) },
+    membership: {
+      findMany: (...args: unknown[]) => membershipFindMany(...args),
+    },
     reminderReceipt: {
       create: (...args: unknown[]) => receiptCreate(...args),
       deleteMany: (...args: unknown[]) => receiptDeleteMany(...args),
@@ -48,6 +52,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   eventFindMany.mockResolvedValue([]);
   rosterFindMany.mockResolvedValue([]);
+  membershipFindMany.mockResolvedValue([]);
   receiptCreate.mockResolvedValue({ id: "receipt-1" });
   receiptDeleteMany.mockResolvedValue({ count: 1 });
 });
@@ -199,5 +204,64 @@ describe("releaseReminder", () => {
     expect(logged).toHaveBeenCalled();
 
     logged.mockRestore();
+  });
+});
+
+describe("loadTodaysReminderWork — unsubscribe contact", () => {
+  it("resolves one staff address per team and attaches it to each event", async () => {
+    eventFindMany.mockResolvedValue([
+      { ...row("evt-1"), teamId: "team-1" },
+      { ...row("evt-2"), teamId: "team-2" },
+    ]);
+    membershipFindMany.mockResolvedValue([
+      {
+        teamId: "team-1",
+        userId: "u-coach",
+        role: "COACH",
+        user: { email: "coach@example.com" },
+      },
+      {
+        teamId: "team-1",
+        userId: "u-owner",
+        role: "OWNER",
+        user: { email: "owner@example.com" },
+      },
+      {
+        teamId: "team-2",
+        userId: "u-other",
+        role: "COACH",
+        user: { email: "other@example.com" },
+      },
+    ]);
+
+    const { events } = await loadTodaysReminderWork(NOW);
+
+    // Owner wins on team-1 even though the coach row came back first —
+    // pickUnsubscribeContact decides, not query order.
+    expect(events[0].unsubscribeEmail).toBe("owner@example.com");
+    expect(events[1].unsubscribeEmail).toBe("other@example.com");
+  });
+
+  it("reads only OWNER and COACH rows — a parent is never the contact", async () => {
+    eventFindMany.mockResolvedValue([row("evt-1")]);
+
+    await loadTodaysReminderWork(NOW);
+
+    expect(membershipFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          role: { in: ["OWNER", "COACH"] },
+        }),
+      }),
+    );
+  });
+
+  it("leaves the contact null when a team has no staff address", async () => {
+    eventFindMany.mockResolvedValue([row("evt-1")]);
+    membershipFindMany.mockResolvedValue([]);
+
+    const { events } = await loadTodaysReminderWork(NOW);
+
+    expect(events[0].unsubscribeEmail).toBeNull();
   });
 });

--- a/src/lib/reminder-data.ts
+++ b/src/lib/reminder-data.ts
@@ -1,6 +1,6 @@
 import { endOfDayInZone } from "./calendar";
 import { db } from "./db";
-import type { ReminderEvent } from "./reminders";
+import { pickUnsubscribeContact, type ReminderEvent } from "./reminders";
 
 /// The database half of day-of reminders (#47) — the loader and the receipt
 /// ledger. The decisions live next door in `reminders.ts`, which is pure;
@@ -96,7 +96,10 @@ export async function loadTodaysReminderWork(
   // doubleheader is two events on the same team, and the roster is the same
   // both times.
   const teamIds = [...new Set(events.map((event) => event.teamId))];
-  const rosterByTeamId = await loadRostersByTeamId(teamIds);
+  const [rosterByTeamId, unsubscribeByTeamId] = await Promise.all([
+    loadRostersByTeamId(teamIds),
+    loadUnsubscribeContactsByTeamId(teamIds),
+  ]);
 
   return {
     events: events.map((event) => ({
@@ -110,9 +113,55 @@ export async function loadTodaysReminderWork(
       notes: event.notes,
       roster: rosterByTeamId.get(event.teamId) ?? [],
       rsvps: event.rsvps,
+      unsubscribeEmail: unsubscribeByTeamId.get(event.teamId) ?? null,
     })),
     truncated,
   };
+}
+
+/**
+ * One staff address per team, for the reminder's List-Unsubscribe header.
+ *
+ * Grouped across the run like `loadRostersByTeamId`, and for the same reason:
+ * a doubleheader is two events on one team. `pickUnsubscribeContact` does the
+ * choosing, so which coach gets named is a tested decision rather than a
+ * side effect of query ordering.
+ *
+ * This reads `Membership` rather than the roster, which is the one place in
+ * the reminder path that does — and it is not a recipient lookup. Nobody here
+ * is mailed; the address only rides in a header so a parent's reply reaches a
+ * human. Errors propagate, matching the rest of this loader.
+ */
+async function loadUnsubscribeContactsByTeamId(
+  teamIds: readonly string[],
+): Promise<Map<string, string | null>> {
+  const staff = await db.membership.findMany({
+    where: { teamId: { in: [...teamIds] }, role: { in: ["OWNER", "COACH"] } },
+    select: {
+      teamId: true,
+      userId: true,
+      role: true,
+      user: { select: { email: true } },
+    },
+  });
+
+  const byTeamId = new Map<string, typeof staff>();
+  for (const row of staff) {
+    byTeamId.set(row.teamId, [...(byTeamId.get(row.teamId) ?? []), row]);
+  }
+
+  return new Map(
+    [...byTeamId].map(([teamId, rows]) => [
+      teamId,
+      pickUnsubscribeContact(
+        rows.map((row) => ({
+          userId: row.userId,
+          role: row.role as "OWNER" | "COACH",
+          email: row.user.email,
+        })),
+      ),
+    ]),
+  );
 }
 
 async function loadRostersByTeamId(

--- a/src/lib/reminders.test.ts
+++ b/src/lib/reminders.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildReminderBatch,
+  pickUnsubscribeContact,
   type ReminderEvent,
   type ReminderRosterEntry,
 } from "@/lib/reminders";
@@ -29,6 +30,7 @@ function event(overrides: Partial<ReminderEvent> = {}): ReminderEvent {
     notes: "Arrive 30 minutes early.",
     roster: [rosterEntry("player-1", "Jimmy", [ANNA])],
     rsvps: [],
+    unsubscribeEmail: "coach@example.com",
     ...overrides,
   };
 }
@@ -185,5 +187,70 @@ describe("buildReminderBatch", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0].kids).toHaveLength(1);
+  });
+});
+
+describe("pickUnsubscribeContact", () => {
+  const OWNER = {
+    userId: "u-owner",
+    role: "OWNER" as const,
+    email: "owner@example.com",
+  };
+  const COACH = {
+    userId: "u-coach",
+    role: "COACH" as const,
+    email: "coach@example.com",
+  };
+
+  it("prefers the owner over an assistant coach, whatever the input order", () => {
+    expect(pickUnsubscribeContact([COACH, OWNER])).toBe("owner@example.com");
+    expect(pickUnsubscribeContact([OWNER, COACH])).toBe("owner@example.com");
+  });
+
+  it("falls back to a coach when the team has no owner row", () => {
+    expect(pickUnsubscribeContact([COACH])).toBe("coach@example.com");
+  });
+
+  it("breaks a tie on userId so two runs name the same person", () => {
+    const b = { userId: "u-b", role: "COACH" as const, email: "b@example.com" };
+    const a = { userId: "u-a", role: "COACH" as const, email: "a@example.com" };
+
+    expect(pickUnsubscribeContact([b, a])).toBe("a@example.com");
+    expect(pickUnsubscribeContact([a, b])).toBe("a@example.com");
+  });
+
+  it("returns null rather than an address that mails nowhere", () => {
+    expect(pickUnsubscribeContact([])).toBeNull();
+    expect(
+      pickUnsubscribeContact([{ ...COACH, email: "" }]),
+    ).toBeNull();
+  });
+
+  it("skips a blank address but still finds a usable one", () => {
+    expect(pickUnsubscribeContact([{ ...OWNER, email: "" }, COACH])).toBe(
+      "coach@example.com",
+    );
+  });
+});
+
+describe("buildReminderBatch — unsubscribe contact", () => {
+  it("carries the event's contact onto every payload", () => {
+    const payloads = buildReminderBatch([
+      event({
+        roster: [rosterEntry("player-1", "Jimmy", [ANNA, BEN])],
+        unsubscribeEmail: "owner@example.com",
+      }),
+    ]);
+
+    expect(payloads).toHaveLength(2);
+    for (const payload of payloads) {
+      expect(payload.unsubscribeEmail).toBe("owner@example.com");
+    }
+  });
+
+  it("carries a null through rather than inventing one", () => {
+    const [payload] = buildReminderBatch([event({ unsubscribeEmail: null })]);
+
+    expect(payload.unsubscribeEmail).toBeNull();
   });
 });

--- a/src/lib/reminders.ts
+++ b/src/lib/reminders.ts
@@ -37,7 +37,50 @@ export type ReminderEvent = {
   roster: ReminderRosterEntry[];
   /// This event's RSVP rows. A player with no row is no-response.
   rsvps: { playerId: string; attending: boolean }[];
+  /// Where a parent's "stop sending me these" should land — see
+  /// `pickUnsubscribeContact`. Null when the team has no staff address, in
+  /// which case the reminder goes out with no List-Unsubscribe at all rather
+  /// than one pointing nowhere.
+  unsubscribeEmail: string | null;
 };
+
+/// A team's staff member, as far as picking an unsubscribe contact cares.
+export type ReminderCoachContact = {
+  userId: string;
+  role: "OWNER" | "COACH";
+  email: string;
+};
+
+/**
+ * Which human hears about it when a parent unsubscribes from reminders.
+ *
+ * Unlike a broadcast — which has an actual sender to point at — the reminder
+ * cron runs as the system, so the header needs a contact chosen rather than
+ * carried. The owner is preferred over an assistant coach because the request
+ * is really "take my family off this", which is a roster decision.
+ *
+ * Deterministic on purpose: a team can hold up to four staff, and the tie is
+ * broken on `userId` so two runs of the same day name the same person. An
+ * address that is empty is skipped rather than framed into a header that
+ * mails nowhere.
+ */
+export function pickUnsubscribeContact(
+  contacts: readonly ReminderCoachContact[],
+): string | null {
+  const usable = contacts.filter((contact) => contact.email);
+  if (usable.length === 0) {
+    return null;
+  }
+
+  const ranked = [...usable].sort((a, b) => {
+    if (a.role !== b.role) {
+      return a.role === "OWNER" ? -1 : 1;
+    }
+    return a.userId < b.userId ? -1 : 1;
+  });
+
+  return ranked[0].email;
+}
 
 export type ReminderRosterEntry = {
   playerId: string;
@@ -75,6 +118,9 @@ export type ReminderPayload = {
   opponent: string | null;
   notes: string | null;
   kids: ReminderKid[];
+  /// Carried through from the event so the cron can set List-Unsubscribe
+  /// without a second lookup per recipient.
+  unsubscribeEmail: string | null;
 };
 
 /**
@@ -153,5 +199,6 @@ function buildEventPayloads(event: ReminderEvent): ReminderPayload[] {
     opponent: event.opponent,
     notes: event.notes,
     kids,
+    unsubscribeEmail: event.unsubscribeEmail,
   }));
 }


### PR DESCRIPTION
## Summary

Team emails were landing in spam. A mail-tester run on the sending domain scored the message **10/10** with only two advisory flags: no DMARC record, and no `List-Unsubscribe` header. DMARC has been published separately (DNS-side, nothing in this repo). This PR closes the second flag on the two sends that are genuinely list mail — the all-parents broadcast, and the day-of reminder cron that arrived from #47 while this PR was open.

## Key Decisions

**The header is set on two sends, not on every email.** RFC 2369 says `List-Unsubscribe` describes *a list the recipient belongs to*. That is true of the all-parents broadcast and the reminder cron, and false of the rest: an invitation is addressed to someone who is not on the team yet, and the `INDIVIDUAL_PARENT` and `ALL_COACHES` shapes are one-to-one correspondence. Blanketing the header across all mail would quiet a deliverability report by putting a false claim in a header, which is a worse trade than an orange checkmark.

The practical consequence is worth stating plainly: **re-running mail-tester against an invitation will still show that flag orange.** That is the intended outcome, not an incomplete fix.

**The address differs between the two, because the senders differ.** A broadcast has a human sending it, so it reuses that coach — the same address already in `Reply-To`. The cron runs as the system with no sender at all, so the contact has to be *chosen*: `pickUnsubscribeContact` prefers the team's owner over an assistant coach (a request to stop reminding a family is really a roster decision) and breaks ties on `userId`, so two runs of the same day name the same person. It is pure and tested, so which coach gets named is a decision rather than a side effect of query ordering. A team with no staff address sends no header rather than one mailing nowhere — and the reminder still goes.

**The address is validated before it is framed, not trusted.** `User.email` is user input — `z.email()` guards the sign-in and bulk-invite forms and the value is then persisted — so being in the database is not what makes it safe. `listUnsubscribeHeader` tests it against a bare addr-spec pattern, because a CR/LF in a header value is header injection and no comment prevents that. A suspect address yields no header rather than a malformed one, and the email still sends.

**The value is a `mailto:`, deliberately not RFC 8058 one-click.** One-click unsubscribe requires an unauthenticated HTTPS POST endpoint and somewhere to record the suppression. For this app that means a parent can silently remove themselves from the only channel that carries "tonight is cancelled, don't drive to the field" — a real hazard for twenty-five families with no second notification path. Routing the unsubscribe to a human who can ask why is the safer default at this scale. The reasoning is in `AGENTS.md` so revisiting it is a deliberate decision about that failure mode rather than an accident while chasing a checkmark.

## What's in Scope

- `sendEmail` accepts an optional `listUnsubscribe` address, validates it, and emits it as `<mailto:addr?subject=Unsubscribe>`. The key is omitted entirely when absent or rejected — not an empty `headers` object — matching the existing `replyTo` handling. The RFC framing lives in this one place rather than at each call site.
- `sendTeamMessageAction` passes the sending coach's address for `ALL_PARENTS` only.
- `pickUnsubscribeContact` (pure, in `reminders.ts`) chooses one staff address per team; `loadTodaysReminderWork` resolves it once per team alongside the roster read, and the cron passes it through.
- Tests at every level: header framing, omission, and four rejected-address cases in `email.test.ts`; audience scoping in `messages/new/actions.test.ts`; contact selection in `reminders.test.ts`; per-team resolution in `reminder-data.test.ts`; the send payload in the cron's `route.test.ts`.
- `AGENTS.md` gotcha covering both senders and why the addresses differ.

### Out of Scope

- **The DMARC record** — DNS, not code. Already published.
- **RFC 8058 one-click unsubscribe.** Needs a suppression column, a migration, an unauthenticated route handler, recipient filtering, and a resubscribe affordance. That is a feature, and it needs a decision on the missed-cancellation hazard first. Reminders are the strongest future candidate — "stop reminding me about every practice" is reasonable in a way that "stop telling me games are cancelled" is not.
- **A `text/plain` alternative part.** Flagged as a suspect during diagnosis, then ruled out — mail-tester did not raise it and the message scored 10/10 on content.

## Bugs Found and Fixed During Review

- **A comment claimed a safety property the code did not enforce.** The first version of `listUnsubscribeHeader` was annotated "the address comes from a stored `User.email`, never from a form" — misleading, since `User.email` is user input validated at entry and then persisted. Copilot flagged the wording. Rewording alone would have left the safety resting on a comment, so the claim became a check: the address is now tested against a bare addr-spec pattern before interpolation, closing a header-injection path. Four regression cases (CRLF, embedded angle bracket, whitespace, missing at-sign) each assert the header is dropped and the send still succeeds; all four fail against the pre-fix code.

## Known Gaps / Follow-ups

- **Deliverability is not verified by this PR and cannot be from CI.** DMARC plus this header close both mechanical gaps, but the remaining variable is Gmail's sender-reputation model on a new, low-volume domain that sends in bursts. That improves with engagement, not configuration. Enrolling `send.corneliuses.com` in Google Postmaster Tools will show whether reputation actually climbs.
- The header's real-world rendering has not been checked against a live send — only the payload handed to Resend is asserted.
- `loadUnsubscribeContactsByTeamId` reads `Membership`, the one place in the reminder path that does. It is not a recipient lookup — nobody there is mailed — but it is worth knowing about if the reminder recipient rules ever change.

## Test Plan

- [ ] Run `pnpm check` — lint, typecheck, and tests. Passing locally at 1440 tests across 98 files, and green in CI on `74ff924`.
- [ ] Run `pnpm exec next build` — the half `pnpm check` does not cover. Green in CI.
- [ ] Confirm the new assertions are not vacuous. Three mutations, all verified during development:
      (a) delete the `...(payload.unsubscribeEmail ? …)` spread from the cron route → *"points the header at the team's staff contact"* fails;
      (b) replace the comparator body in `pickUnsubscribeContact` with `return 0` → *"prefers the owner over an assistant coach"*, *"breaks a tie on userId"*, and the loader's per-team test all fail;
      (c) widen `BARE_ADDRESS` to match anything → all four rejected-address cases fail.
- [ ] Edge cases checked: the two one-to-one audiences, the no-staff-address team, and every rejected address all assert the key is *absent*, not merely falsy; a team with no staff still sends its reminder.