### PR TITLE
Let the owner remove members, and stop long addresses crushing the row

### DIFF
--- a/src/app/t/[teamId]/members/actions.test.ts
+++ b/src/app/t/[teamId]/members/actions.test.ts
@@ -184,6 +184,19 @@ describe("removeMemberAction", () => {
     expect(url).toBe("/");
   });
 
+  it("still sends self-removal home when the row was already gone", async () => {
+    // Two tabs racing: the second call finds nothing to delete and reports
+    // false, but the caller's membership is just as gone. Keying the redirect
+    // on `removed` would 404 the very person who just left the team.
+    removeMember.mockResolvedValue(false);
+
+    const url = await redirectUrlOf(() =>
+      removeMemberAction(form({ teamId: "team-1", userId: "owner-1" })),
+    );
+
+    expect(url).toBe("/");
+  });
+
   it("throws on a missing user id rather than guessing", async () => {
     await expect(
       removeMemberAction(form({ teamId: "team-1" })),

--- a/src/app/t/[teamId]/members/actions.test.ts
+++ b/src/app/t/[teamId]/members/actions.test.ts
@@ -5,6 +5,7 @@ const createInvitation = vi.fn();
 const getTeamInvitation = vi.fn();
 const revokeInvitation = vi.fn();
 const setMemberRole = vi.fn();
+const removeMember = vi.fn();
 const sendEmail = vi.fn();
 
 vi.mock("@/lib/team-access", () => ({
@@ -20,6 +21,7 @@ vi.mock("@/lib/invitations", () => ({
 
 vi.mock("@/lib/memberships", () => ({
   setMemberRole: (...args: unknown[]) => setMemberRole(...args),
+  removeMember: (...args: unknown[]) => removeMember(...args),
   LastOwnerError: class LastOwnerError extends Error {},
 }));
 
@@ -47,7 +49,9 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { TeamAccessError } from "@/lib/team-access";
+import { LastOwnerError } from "@/lib/memberships";
 import {
+  removeMemberAction,
   resendInvitationAction,
   revokeInvitationAction,
   setMemberRoleAction,
@@ -94,6 +98,7 @@ beforeEach(() => {
     expiresAt: new Date("2026-05-15"),
   });
   setMemberRole.mockResolvedValue(undefined);
+  removeMember.mockResolvedValue(true);
   sendEmail.mockResolvedValue({ ok: true });
 });
 
@@ -109,6 +114,80 @@ describe("setMemberRoleAction", () => {
 
     expect(url).toBe("/t/team-1/members?role-saved=1");
     expect(setMemberRole).toHaveBeenCalledWith("team-1", "user-2", "COACH");
+  });
+});
+
+describe("removeMemberAction", () => {
+  it("removes the member and says so", async () => {
+    const url = await redirectUrlOf(() =>
+      removeMemberAction(form({ teamId: "team-1", userId: "user-2" })),
+    );
+
+    expect(url).toBe("/t/team-1/members?removed=1");
+    expect(removeMember).toHaveBeenCalledWith("team-1", "user-2");
+  });
+
+  it("requires owner access with write intent", async () => {
+    // Write intent is what makes an archived team reject this, owner or not.
+    await redirectUrlOf(() =>
+      removeMemberAction(form({ teamId: "team-1", userId: "user-2" })),
+    );
+
+    expect(requireTeamAccess).toHaveBeenCalledWith("team-1", {
+      intent: "write",
+      minRole: "OWNER",
+    });
+  });
+
+  it("redirects to the access error when the caller is not an owner", async () => {
+    requireTeamAccess.mockRejectedValue(
+      new TeamAccessError("denied", "insufficient-role"),
+    );
+
+    const url = await redirectUrlOf(() =>
+      removeMemberAction(form({ teamId: "team-1", userId: "user-2" })),
+    );
+
+    expect(url).toBe("/t/team-1/members?error=access");
+    expect(removeMember).not.toHaveBeenCalled();
+  });
+
+  it("reports the last-owner refusal instead of crashing", async () => {
+    removeMember.mockRejectedValue(new LastOwnerError());
+
+    const url = await redirectUrlOf(() =>
+      removeMemberAction(form({ teamId: "team-1", userId: "owner-1" })),
+    );
+
+    expect(url).toBe("/t/team-1/members?error=last-owner");
+  });
+
+  it("does not claim success when nothing was removed", async () => {
+    // A second tab may have removed the row a moment ago; the list re-renders
+    // and shows the truth either way.
+    removeMember.mockResolvedValue(false);
+
+    const url = await redirectUrlOf(() =>
+      removeMemberAction(form({ teamId: "team-1", userId: "user-2" })),
+    );
+
+    expect(url).toBe("/t/team-1/members");
+  });
+
+  it("sends an owner who removed themselves to the team list", async () => {
+    // requireTeamAccess resolves the caller as owner-1; removing that same
+    // membership means the members page can no longer be read.
+    const url = await redirectUrlOf(() =>
+      removeMemberAction(form({ teamId: "team-1", userId: "owner-1" })),
+    );
+
+    expect(url).toBe("/");
+  });
+
+  it("throws on a missing user id rather than guessing", async () => {
+    await expect(
+      removeMemberAction(form({ teamId: "team-1" })),
+    ).rejects.toThrow("Invalid user ID");
   });
 });
 

--- a/src/app/t/[teamId]/members/actions.ts
+++ b/src/app/t/[teamId]/members/actions.ts
@@ -11,7 +11,7 @@ import {
   getTeamInvitation,
   revokeInvitation,
 } from "@/lib/invitations";
-import { LastOwnerError, setMemberRole } from "@/lib/memberships";
+import { LastOwnerError, removeMember, setMemberRole } from "@/lib/memberships";
 import { getTeamById } from "@/lib/teams";
 import { sendEmail } from "@/lib/email";
 import { InvitationEmail } from "@/emails/InvitationEmail";
@@ -158,6 +158,56 @@ export async function setMemberRoleAction(formData: FormData) {
   // successful save was indistinguishable from a click that did nothing — the
   // select simply re-rendered showing the value it already showed (C7).
   redirect(`/t/${teamId}/members?role-saved=1`);
+}
+
+/**
+ * Remove one member from this team.
+ *
+ * Deletes only the Membership row — `removeMember` documents why the person,
+ * their family links, and their kids' roster spots all survive. The last-owner
+ * guard lives in the same transaction as the delete, so this action just
+ * translates its refusal into the error the page already knows how to say.
+ *
+ * An owner may remove themselves when another owner remains; the redirect
+ * then goes to `/`, because the members page they were standing on is one
+ * they no longer have access to read.
+ */
+export async function removeMemberAction(formData: FormData) {
+  const teamId = extractTeamId(formData);
+  const userId = String(formData.get("userId") ?? "").trim();
+  if (!userId) {
+    throw new Error("Invalid user ID");
+  }
+
+  let removed: boolean;
+  let callerId: string;
+  try {
+    ({ userId: callerId } = await requireTeamAccess(teamId, {
+      intent: "write",
+      minRole: "OWNER",
+    }));
+    removed = await removeMember(teamId, userId);
+  } catch (error) {
+    unstable_rethrow(error);
+    if (error instanceof TeamAccessError) {
+      redirect(`/t/${teamId}/members?error=access`);
+    }
+    if (error instanceof LastOwnerError) {
+      redirect(`/t/${teamId}/members?error=last-owner`);
+    }
+    throw error;
+  }
+
+  if (removed && userId === callerId) {
+    // Self-removal succeeded, so the caller can no longer read the page this
+    // would otherwise land on.
+    redirect("/");
+  }
+
+  revalidatePath("/t/[teamId]/members", "page");
+  // Like revokeInvitationAction: a row a second tab already removed is not
+  // this click's removal, so don't claim it.
+  redirect(`/t/${teamId}/members${removed ? "?removed=1" : ""}`);
 }
 
 function extractInvitationId(formData: FormData): string {

--- a/src/app/t/[teamId]/members/actions.ts
+++ b/src/app/t/[teamId]/members/actions.ts
@@ -170,7 +170,9 @@ export async function setMemberRoleAction(formData: FormData) {
  *
  * An owner may remove themselves when another owner remains; the redirect
  * then goes to `/`, because the members page they were standing on is one
- * they no longer have access to read.
+ * they no longer have access to read. That is one-way from inside the app —
+ * a remaining owner has to invite them back — which is why the confirm step
+ * says so in the second person on the caller's own row.
  */
 export async function removeMemberAction(formData: FormData) {
   const teamId = extractTeamId(formData);
@@ -198,9 +200,11 @@ export async function removeMemberAction(formData: FormData) {
     throw error;
   }
 
-  if (removed && userId === callerId) {
-    // Self-removal succeeded, so the caller can no longer read the page this
-    // would otherwise land on.
+  // Keyed on identity, NOT on `removed`. Two tabs racing means the second
+  // call finds the row already gone and reports removed=false — but the
+  // caller's membership is just as gone either way, so falling through to the
+  // members page would 404 the very person who just left the team.
+  if (userId === callerId) {
     redirect("/");
   }
 

--- a/src/app/t/[teamId]/members/page.test.tsx
+++ b/src/app/t/[teamId]/members/page.test.tsx
@@ -45,9 +45,37 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+const TWO_MEMBERS = [
+  {
+    userId: "user-1",
+    role: "OWNER" as const,
+    name: "Sam",
+    email: "sam@example.com",
+    phone: null,
+  },
+  {
+    userId: "user-2",
+    role: "PARENT" as const,
+    name: null,
+    email: "test-svjpa8fcr@srv1.mail-tester.com",
+    phone: null,
+  },
+];
+
 describe("Members page", () => {
   it("should export a default function", async () => {
     expect(typeof MembersPage).toBe("function");
+  });
+
+  it("is owner-only even to read", async () => {
+    // Unlike the roster, members and invitations are not something every
+    // parent — or coach — needs to see.
+    await renderPage();
+
+    expect(requireTeamAccess).toHaveBeenCalledWith("team-1", {
+      intent: "read",
+      minRole: "OWNER",
+    });
   });
 
   it("shows only live invitations as pending", async () => {
@@ -105,6 +133,61 @@ describe("Members page", () => {
     const ownerFormEnd = markup.indexOf("</form>", ownerRowIndex);
     const ownerForm = markup.slice(ownerRowIndex, ownerFormEnd);
     expect(ownerForm).toContain("disabled");
+  });
+});
+
+describe("MembersPage removal", () => {
+  beforeEach(() => {
+    listTeamMembers.mockResolvedValue(TWO_MEMBERS);
+  });
+
+  it("offers a Remove step per member, but never for the last owner", async () => {
+    const markup = await renderPage();
+
+    // The parent's row links into the confirm step for exactly that member.
+    expect(markup).toContain(
+      "/t/team-1/members?confirm=remove&amp;member=user-2",
+    );
+    // Sam is the only owner — same rule that disables their role select.
+    expect(markup).not.toContain("member=user-1");
+  });
+
+  it("confirms before removing, on the named row only", async () => {
+    const markup = await renderPage({ confirm: "remove", member: "user-2" });
+
+    expect(markup).toContain("Remove test-svjpa8fcr@srv1.mail-tester.com");
+    expect(markup).toContain("Yes, remove them");
+    expect(markup).toContain("are not deleted");
+  });
+
+  it("does not show the confirm step without the param", async () => {
+    const markup = await renderPage();
+
+    expect(markup).not.toContain("Yes, remove them");
+  });
+
+  it("confirms a completed removal", async () => {
+    const markup = await renderPage({ removed: "1" });
+
+    expect(markup).toContain("Member removed.");
+    expect(markup).toContain('role="status"');
+  });
+
+  it("lets a long unspaced address break instead of pushing controls off screen", async () => {
+    // The row is stacked now, but the address itself still needs break-all —
+    // an email is one long token, and break-words won't split it until it has
+    // already overflowed the card (the screenshot bug).
+    const markup = await renderPage();
+
+    // Second occurrence: the first is the name line falling back to the email
+    // for a member with no name (break-words there), the second is the email
+    // line proper.
+    const address = "test-svjpa8fcr@srv1.mail-tester.com";
+    const emailIndex = markup.indexOf(address, markup.indexOf(address) + 1);
+    expect(emailIndex).toBeGreaterThan(-1);
+    const tagStart = markup.lastIndexOf("<p", emailIndex);
+    const emailTag = markup.slice(tagStart, emailIndex);
+    expect(emailTag).toContain("break-all");
   });
 });
 

--- a/src/app/t/[teamId]/members/page.test.tsx
+++ b/src/app/t/[teamId]/members/page.test.tsx
@@ -166,6 +166,35 @@ describe("MembersPage removal", () => {
     expect(markup).not.toContain("Yes, remove them");
   });
 
+  it("addresses you in the second person on your own row", async () => {
+    // requireTeamAccess resolves the reader as user-1. Every other removal an
+    // owner can undo by re-inviting; removing yourself takes away the page
+    // holding the invite form, so the copy has to say that plainly.
+    listTeamMembers.mockResolvedValue([
+      ...TWO_MEMBERS,
+      {
+        userId: "user-3",
+        role: "OWNER" as const,
+        name: "Second Owner",
+        email: "owner2@example.com",
+        phone: null,
+      },
+    ]);
+
+    const markup = await renderPage({ confirm: "remove", member: "user-1" });
+
+    expect(markup).toContain("Remove yourself from this team?");
+    expect(markup).toContain("only another owner can add you back");
+    expect(markup).not.toContain("Remove Sam from this team?");
+  });
+
+  it("keeps the third-person copy for everyone else", async () => {
+    const markup = await renderPage({ confirm: "remove", member: "user-2" });
+
+    expect(markup).toContain("They lose");
+    expect(markup).not.toContain("Remove yourself");
+  });
+
   it("confirms a completed removal", async () => {
     const markup = await renderPage({ removed: "1" });
 

--- a/src/app/t/[teamId]/members/page.tsx
+++ b/src/app/t/[teamId]/members/page.tsx
@@ -1,6 +1,8 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { SubmitButton } from "@/components/SubmitButton";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -18,6 +20,7 @@ import { listTeamInvitations } from "@/lib/invitations";
 import { isLiveInvitation } from "@/lib/invitation-token";
 
 import {
+  removeMemberAction,
   resendInvitationAction,
   revokeInvitationAction,
   setMemberRoleAction,
@@ -44,6 +47,9 @@ export default async function MembersPage({
     "role-saved"?: string;
     revoked?: string;
     resent?: string;
+    removed?: string;
+    confirm?: string;
+    member?: string;
   }>;
 }) {
   const { teamId } = await params;
@@ -53,6 +59,9 @@ export default async function MembersPage({
     "role-saved": roleSaved,
     revoked,
     resent,
+    removed,
+    confirm,
+    member,
   } = await searchParams;
 
   try {
@@ -88,8 +97,13 @@ export default async function MembersPage({
           ? "Invitation withdrawn."
           : resent
             ? "Invitation sent again — the previous link no longer works."
-            : null;
-  const ownerCount = members.filter((member) => member.role === "OWNER").length;
+            : removed
+              ? "Member removed."
+              : null;
+  const ownerCount = members.filter((m) => m.role === "OWNER").length;
+  // Removal confirms per row, like guardian unlinking on the roster entry
+  // page: ?confirm=remove&member=<userId> opens the step on that row only.
+  const removingMemberId = confirm === "remove" ? (member ?? null) : null;
 
   return (
     <div className="space-y-6">
@@ -109,44 +123,105 @@ export default async function MembersPage({
         </CardHeader>
         <CardContent>
           <ul className="space-y-2">
-            {members.map((member) => {
-              const isLastOwner = member.role === "OWNER" && ownerCount <= 1;
+            {members.map((teamMember) => {
+              const isLastOwner =
+                teamMember.role === "OWNER" && ownerCount <= 1;
+              const displayName = teamMember.name ?? teamMember.email;
               return (
+                // Identity on its own row, controls on the row beneath. The
+                // old side-by-side flex row gave the text no room to shrink
+                // (no min-w-0), so a long address pushed the Save button off
+                // the edge of a phone screen instead of wrapping.
                 <li
-                  key={member.userId}
-                  className="flex items-center justify-between gap-4 rounded-md border border-border p-3"
+                  key={teamMember.userId}
+                  className="space-y-3 rounded-md border border-border p-3"
                 >
-                  <div>
-                    <p className="text-sm font-medium text-foreground">
-                      {member.name ?? member.email}
+                  <div className="min-w-0">
+                    <p className="break-words text-sm font-medium text-foreground">
+                      {displayName}
                     </p>
-                    <p className="text-sm text-muted-foreground">{member.email}</p>
+                    {/* break-all, not break-words: an address is one long
+                        unspaced token, and break-words won't split it until
+                        it has already overflowed the card. */}
+                    <p className="break-all text-sm text-muted-foreground">
+                      {teamMember.email}
+                    </p>
                   </div>
-                  <form action={setMemberRoleAction} className="flex items-center gap-2">
-                    <input type="hidden" name="teamId" value={teamId} />
-                    <input type="hidden" name="userId" value={member.userId} />
-                    <select
-                      name="role"
-                      defaultValue={member.role}
-                      disabled={isLastOwner}
-                      aria-label={`Role for ${member.name ?? member.email}`}
-                      className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground disabled:opacity-50"
+                  <div className="flex flex-wrap items-center gap-2">
+                    <form
+                      action={setMemberRoleAction}
+                      className="flex items-center gap-2"
                     >
-                      {ROLE_OPTIONS.map((role) => (
-                        <option key={role} value={role}>
-                          {ROLE_LABELS[role]}
-                        </option>
-                      ))}
-                    </select>
-                    <SubmitButton
-                      variant="outline"
-                      size="sm"
-                      disabled={isLastOwner}
-                      pendingLabel="Saving…"
-                    >
-                      Save
-                    </SubmitButton>
-                  </form>
+                      <input type="hidden" name="teamId" value={teamId} />
+                      <input
+                        type="hidden"
+                        name="userId"
+                        value={teamMember.userId}
+                      />
+                      <select
+                        name="role"
+                        defaultValue={teamMember.role}
+                        disabled={isLastOwner}
+                        aria-label={`Role for ${displayName}`}
+                        className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground disabled:opacity-50"
+                      >
+                        {ROLE_OPTIONS.map((role) => (
+                          <option key={role} value={role}>
+                            {ROLE_LABELS[role]}
+                          </option>
+                        ))}
+                      </select>
+                      <SubmitButton
+                        variant="outline"
+                        size="sm"
+                        disabled={isLastOwner}
+                        pendingLabel="Saving…"
+                      >
+                        Save
+                      </SubmitButton>
+                    </form>
+                    {/* No Remove for the last owner: the same rule that
+                        disables their role select — a team must always have
+                        an owner, and removeMember enforces it again. */}
+                    {!isLastOwner && removingMemberId !== teamMember.userId ? (
+                      <Button asChild variant="outline" size="sm">
+                        <Link
+                          href={`/t/${teamId}/members?confirm=remove&member=${teamMember.userId}`}
+                        >
+                          Remove
+                        </Link>
+                      </Button>
+                    ) : null}
+                  </div>
+                  {removingMemberId === teamMember.userId && !isLastOwner ? (
+                    <div className="space-y-3 border-t border-border pt-3">
+                      <p role="alert" className="text-sm text-destructive">
+                        Remove {displayName} from this team? They lose access
+                        to this team&apos;s pages. Their account, family links,
+                        and any kids on the roster are not deleted.
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        <form action={removeMemberAction}>
+                          <input type="hidden" name="teamId" value={teamId} />
+                          <input
+                            type="hidden"
+                            name="userId"
+                            value={teamMember.userId}
+                          />
+                          <SubmitButton
+                            variant="destructive"
+                            size="sm"
+                            pendingLabel="Removing…"
+                          >
+                            Yes, remove them
+                          </SubmitButton>
+                        </form>
+                        <Button asChild variant="outline" size="sm">
+                          <Link href={`/t/${teamId}/members`}>Cancel</Link>
+                        </Button>
+                      </div>
+                    </div>
+                  ) : null}
                 </li>
               );
             })}
@@ -170,7 +245,7 @@ export default async function MembersPage({
                   className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border p-3"
                 >
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-foreground">
+                    <p className="break-all text-sm font-medium text-foreground">
                       {invitation.email}
                     </p>
                     <p className="text-xs text-muted-foreground">

--- a/src/app/t/[teamId]/members/page.tsx
+++ b/src/app/t/[teamId]/members/page.tsx
@@ -64,8 +64,15 @@ export default async function MembersPage({
     member,
   } = await searchParams;
 
+  // The caller's own id, so the removal confirm can address them in the
+  // second person on their own row — leaving the team is the one removal
+  // here the person cannot undo for themselves.
+  let callerId: string;
   try {
-    await requireTeamAccess(teamId, { intent: "read", minRole: "OWNER" });
+    ({ userId: callerId } = await requireTeamAccess(teamId, {
+      intent: "read",
+      minRole: "OWNER",
+    }));
   } catch (caught) {
     if (caught instanceof TeamAccessError) {
       notFound();
@@ -195,10 +202,27 @@ export default async function MembersPage({
                   </div>
                   {removingMemberId === teamMember.userId && !isLastOwner ? (
                     <div className="space-y-3 border-t border-border pt-3">
+                      {/* Second person on your own row, and a plainer
+                          warning: every other removal an owner can undo by
+                          re-inviting, but removing yourself takes away the
+                          page holding the invite form. Only another owner —
+                          or the database — can put you back. */}
                       <p role="alert" className="text-sm text-destructive">
-                        Remove {displayName} from this team? They lose access
-                        to this team&apos;s pages. Their account, family links,
-                        and any kids on the roster are not deleted.
+                        {teamMember.userId === callerId ? (
+                          <>
+                            Remove yourself from this team? You lose access to
+                            it immediately, and only another owner can add you
+                            back. Your account, family links, and any kids on
+                            the roster are not deleted.
+                          </>
+                        ) : (
+                          <>
+                            Remove {displayName} from this team? They lose
+                            access to this team&apos;s pages. Their account,
+                            family links, and any kids on the roster are not
+                            deleted.
+                          </>
+                        )}
                       </p>
                       <div className="flex flex-wrap gap-2">
                         <form action={removeMemberAction}>

--- a/src/lib/memberships.test.ts
+++ b/src/lib/memberships.test.ts
@@ -4,16 +4,18 @@ const findManyMemberships = vi.fn();
 const findUniqueMembership = vi.fn();
 const countMemberships = vi.fn();
 const updateMembership = vi.fn();
+const deleteMembership = vi.fn();
 const transaction = vi.fn();
 
-// setMemberRole runs its check-and-update inside an interactive transaction,
-// so the mock `tx` handed to the callback needs the same membership methods
-// as `db` itself.
+// setMemberRole and removeMember run their check-and-write inside an
+// interactive transaction, so the mock `tx` handed to the callback needs the
+// same membership methods as `db` itself.
 const tx = {
   membership: {
     findUnique: (...args: unknown[]) => findUniqueMembership(...args),
     count: (...args: unknown[]) => countMemberships(...args),
     update: (...args: unknown[]) => updateMembership(...args),
+    delete: (...args: unknown[]) => deleteMembership(...args),
   },
 };
 
@@ -24,6 +26,7 @@ vi.mock("./db", () => ({
       findUnique: (...args: unknown[]) => findUniqueMembership(...args),
       count: (...args: unknown[]) => countMemberships(...args),
       update: (...args: unknown[]) => updateMembership(...args),
+      delete: (...args: unknown[]) => deleteMembership(...args),
     },
     $transaction: (...args: unknown[]) => transaction(...args),
   },
@@ -34,6 +37,7 @@ import {
   listCoachContacts,
   listDirectory,
   listTeamMembers,
+  removeMember,
   setMemberRole,
 } from "./memberships";
 
@@ -269,5 +273,53 @@ describe("setMemberRole", () => {
 
     expect(countMemberships).not.toHaveBeenCalled();
     expect(updateMembership).toHaveBeenCalled();
+  });
+});
+
+describe("removeMember", () => {
+  it("deletes exactly the (userId, teamId) row inside a Serializable transaction", async () => {
+    findUniqueMembership.mockResolvedValue({ role: "PARENT" });
+
+    await expect(removeMember("team-1", "user-2")).resolves.toBe(true);
+
+    expect(transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: "Serializable",
+    });
+    expect(deleteMembership).toHaveBeenCalledWith({
+      where: { userId_teamId: { userId: "user-2", teamId: "team-1" } },
+    });
+  });
+
+  it("returns false when no membership exists, deleting nothing", async () => {
+    // Already removed in another tab. The caller uses this to avoid claiming
+    // a deletion that never happened.
+    findUniqueMembership.mockResolvedValue(null);
+
+    await expect(removeMember("team-1", "user-2")).resolves.toBe(false);
+    expect(deleteMembership).not.toHaveBeenCalled();
+  });
+
+  it("refuses to remove the team's only owner", async () => {
+    findUniqueMembership.mockResolvedValue({ role: "OWNER" });
+    countMemberships.mockResolvedValue(0);
+
+    await expect(removeMember("team-1", "user-1")).rejects.toThrow(
+      LastOwnerError,
+    );
+    expect(deleteMembership).not.toHaveBeenCalled();
+  });
+
+  it("removes an owner when another owner remains", async () => {
+    findUniqueMembership.mockResolvedValue({ role: "OWNER" });
+    countMemberships.mockResolvedValue(1);
+
+    await expect(removeMember("team-1", "user-1")).resolves.toBe(true);
+
+    // Counts OTHER owners, same as setMemberRole — it can't be fooled by
+    // counting the very row it's about to delete.
+    expect(countMemberships).toHaveBeenCalledWith({
+      where: { teamId: "team-1", role: "OWNER", userId: { not: "user-1" } },
+    });
+    expect(deleteMembership).toHaveBeenCalled();
   });
 });

--- a/src/lib/memberships.ts
+++ b/src/lib/memberships.ts
@@ -142,9 +142,63 @@ export async function listDirectory(teamId: string): Promise<DirectoryEntry[]> {
 
 export class LastOwnerError extends Error {
   constructor() {
-    super("Cannot change the role of the team's only owner");
+    super("Cannot remove or demote the team's only owner");
     this.name = "LastOwnerError";
   }
+}
+
+/**
+ * Remove one member from one team.
+ *
+ * Deletes exactly the (userId, teamId) Membership row — nothing else. The
+ * person's User row, their GuardianPlayer links, and their kids' roster spots
+ * all survive: guardianship is global by design (Decision 15), so severing it
+ * here would blind the same parent on every other team, and re-inviting them
+ * restores access with the family intact. One honest consequence: a removed
+ * guardian whose kid is still rostered keeps receiving roster-driven email
+ * (announcements, reminders recipients come from the roster, not Membership).
+ * Fully detaching a family means also unlinking the guardian on the roster
+ * entry page.
+ *
+ * The last-owner guard mirrors setMemberRole, and for the same racing reason
+ * runs under Serializable isolation: two admins removing two different owners
+ * at once must not leave the team with zero.
+ *
+ * Returns false when no membership exists — already removed in another tab —
+ * so the caller can decline to claim a deletion that never happened.
+ */
+export async function removeMember(
+  teamId: string,
+  userId: string,
+): Promise<boolean> {
+  return db.$transaction(
+    async (tx) => {
+      const current = await tx.membership.findUnique({
+        where: { userId_teamId: { userId, teamId } },
+        select: { role: true },
+      });
+
+      if (!current) {
+        return false;
+      }
+
+      if (current.role === "OWNER") {
+        const otherOwners = await tx.membership.count({
+          where: { teamId, role: "OWNER", userId: { not: userId } },
+        });
+
+        if (otherOwners === 0) {
+          throw new LastOwnerError();
+        }
+      }
+
+      await tx.membership.delete({
+        where: { userId_teamId: { userId, teamId } },
+      });
+      return true;
+    },
+    { isolationLevel: "Serializable" },
+  );
 }
 
 /**

--- a/src/lib/memberships.ts
+++ b/src/lib/memberships.ts
@@ -160,6 +160,15 @@ export class LastOwnerError extends Error {
  * Fully detaching a family means also unlinking the guardian on the roster
  * entry page.
  *
+ * The team's ICS feed is the same shape of leak and is deliberately left
+ * open: `/api/calendar/[token]` is authorized by the team-wide
+ * `Team.calendarToken`, generated once in `createTeam` and never rotated, so
+ * a removed member who already subscribed keeps receiving the schedule.
+ * Rotating on removal would silently break every *remaining* subscriber's
+ * calendar to close a hole whose payload is a youth team's game times — a
+ * bad trade for a season that runs a couple of months. Revisit only by
+ * deciding about per-member feed tokens, not by rotating the shared one.
+ *
  * The last-owner guard mirrors setMemberRole, and for the same racing reason
  * runs under Serializable isolation: two admins removing two different owners
  * at once must not leave the team with zero.


### PR DESCRIPTION
## Summary

The members page gains member removal — an owner can now take someone off a team, which was previously impossible from inside the app. The member rows also restack so a long email address wraps instead of pushing the Save button off the edge of a phone screen.

Reported from a phone screenshot: the Save button on the `test-svjpa8fcr@srv1.mail-tester.com` row was clipped outside the frame, and there was no way to clear out test members at all.

## Key Decisions

**Removal deletes only the `Membership` row.** The person's `User`, their `GuardianPlayer` links, and their kids' `RosterEntry` spots all survive. Guardianship is global by design (Decision 15), so severing it here would blind the same parent on every other team — and re-inviting someone restores access with the family intact.

**The last-owner guard is duplicated, deliberately.** The UI hides Remove for a sole owner (`ownerCount <= 1`, the same rule that already disables their role select), and `removeMember` re-checks inside its transaction. The transaction runs at `Serializable` isolation for the same reason `setMemberRole` does: two admins removing two different owners at once must not leave the team with zero, and read-then-write under READ COMMITTED would let both proceed.

**The confirm step is server-side, not a `confirm()` dialog.** `?confirm=remove&member=<userId>` opens the step on that one row, following the existing pattern on the roster entry page (`?confirm=unlink&guardian=<id>`) rather than introducing a client component for a destructive one-tap.

**Controls moved to a row beneath the member, not into a hidden menu.** Fewer taps, and it matches how the rest of the app lays out row actions. The clipping's root cause was the old side-by-side flex giving the text no room to shrink; the address lines now use `break-all` rather than `break-words`, since an email is one long unspaced token that `break-words` only splits *after* it has already overflowed.

## What's in Scope

- `removeMember(teamId, userId)` in `src/lib/memberships.ts` — Serializable transaction, last-owner guard, returns `false` when the row is already gone
- `removeMemberAction` — OWNER + write intent, translates `LastOwnerError` into the page's existing `?error=last-owner`, redirects a self-removing owner to `/`
- A per-row Remove button and inline confirm step on the members page
- Member rows restacked (identity above, wrapping control row beneath); `break-all` on the address lines here and in the pending-invitations list
- A `?removed=1` success banner, matching every other write on the page
- 15 new tests across the three suites

### Out of Scope

- **Removing a member does not remove their kids from the roster.** Announcement and reminder recipients come from the roster (`RosterEntry → Player → GuardianPlayer → User`), not from `Membership`, so a removed guardian whose kid is still rostered keeps receiving that mail. Fully detaching a family means also unlinking the guardian on the roster entry page. A combined "remove family" flow would be its own change.
- Rotating `Team.calendarToken` on removal — see Known Gaps.

## Bugs Found and Fixed During Self-Review

- **Self-removal redirect could 404 the person who just left.** The redirect to `/` was gated on `removed && userId === callerId`. With two tabs racing, the second call finds the row already deleted, reports `removed: false`, and falls through to the members page — which that caller can no longer read. Now keyed on `userId === callerId` alone: the membership is gone either way, so where they land shouldn't depend on which request won. Regression test: *"still sends self-removal home when the row was already gone"*.
- **The confirm step spoke in the third person on your own row**, and said nothing about self-removal being one-way. Every other removal an owner can undo by re-inviting; removing yourself takes away the page holding the invite form, so only another owner can put you back. The page now reads its own caller id and switches to second person there. Two tests pin both branches.

## Known Gaps / Follow-ups

- **The team's ICS feed is deliberately left open to a removed member.** `/api/calendar/[token]` is authorized by the team-wide `Team.calendarToken`, generated once in `createTeam` and never rotated, so someone who already subscribed keeps receiving the schedule. Rotating on removal would silently break every *remaining* subscriber's calendar to close a hole whose payload is a youth team's game times — a bad trade for a season that runs a couple of months. The decision is recorded in `removeMember`'s docstring so it isn't later "fixed" by rotating the shared token; the real revisit is per-member feed tokens.
- **No live-database verification.** Every test mocks Prisma, so the `Membership` delete has not been run against real Postgres. `Membership` has no child relations, so the delete cannot fail on a foreign key, but the round trip is unverified until this deploys.

## Test Plan

- [ ] Run `pnpm check` (lint → typecheck → tests). Currently green: 114 files, 1736 tests.
- [ ] Sign in as the team owner and open `/t/<teamId>/members` on a narrow viewport (~390px, or a phone). Confirm every row shows the name/email stacked above the role select, Save, and Remove, and that the long `test-svjpa8fcr@srv1.mail-tester.com` row wraps with all three controls fully on screen.
- [ ] Tap **Remove** on a parent row. Confirm the step opens on that row only, other rows keep their one-tap buttons, and Cancel returns to a clean list. Tap **Yes, remove them** and confirm the "Member removed." banner and that the row is gone.
- [ ] Re-invite the removed address from the same page and accept the invitation — confirm access comes back with the family links intact.
- [ ] Confirm your own row (sole owner) shows **no** Remove button and a disabled role select.
- [ ] Promote a second person to Owner, then confirm both owner rows gain a Remove button and that removing yourself reads "Remove yourself from this team? … only another owner can add you back" and lands on `/`.
- [ ] Sign in as a coach or parent: confirm no Members tab, and that typing `/t/<teamId>/members` directly 404s.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwoZogkEpgtZqxRig6Qvrf)_