### PR TITLE
Replace the sign-in magic link with a typed emailed code (#60)

### DIFF
--- a/.agents/app-brainstorm/youth-baseball-team-manager/stack-decisions.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/stack-decisions.md
@@ -22,7 +22,7 @@ Written before any technology is named.
 |---|---|
 | **Client** | Installable to a phone home screen. Mobile-first. Touch drag-and-drop with an activation delay so page scrolling never triggers a drag. Must render a labeled baseball diamond with arbitrary drop targets, plus a reorderable vertical list. Realtime sync **not** required — a refresh is acceptable. Offline read of the current chart is desirable, not required, for MVP. |
 | **Data** | Strongly relational with referential integrity that matters: guardians ↔ players is many-to-many, and RSVPs for a single upcoming event are read against the team's standing chart to flag gaps. **Two tiers** — people (`User`, `Player`) persist across seasons and hold no team-specific attributes; participation (`Membership`, `RosterEntry`) is team-scoped, as is everything a team produces (`Event`, `Message`, `Invitation`, `Rsvp`). A player may be on two active teams at once, so jersey number, batting slot, and position are per-team by necessity, not merely by preference. The batting order and positions chart are **standing per team, not per game**, and live as columns on `RosterEntry` — see Decisions 15 and 16. Entities: `Team`, `Membership`, `Player`, `RosterEntry`, `GuardianPlayer`, `User`, `Invitation`, `Event`, `Rsvp`, `Message`, `PushSubscription`. Total data volume is measured in kilobytes — a season is ~40 events and ~600 RSVP rows, and a decade of archived seasons is still kilobytes. No full-text search. No analytics workload. |
-| **Auth** | Passwordless. Invitation-gated: no self-serve signup exists. Onboarding is one-time, expiring email links. Three roles — owner, coach, parent — assigned **per team** and checked server-side on every mutation, against the team that owns the record being touched. Long-lived sessions so parents are not re-authenticating on a phone at a ballfield. |
+| **Auth** | Passwordless. Invitation-gated: no self-serve signup exists. Onboarding is one-time, expiring email links; recurring sign-in is a short-lived emailed code the person types (revised from a tapped link — see Decision 5). Three roles — owner, coach, parent — assigned **per team** and checked server-side on every mutation, against the team that owns the record being touched. Long-lived sessions so parents are not re-authenticating on a phone at a ballfield. |
 | **Backgrounding** | Send transactional email — invitations, **added-to-team notices** (sent to existing accounts when a returning player pulls their guardians onto a new team; a heads-up and a link, *not* a magic link), coach broadcasts, and parent→coaches. Fan out web push to stored subscriptions. Optionally, a scheduled pre-game RSVP reminder. Fan-out size is ~25 recipients — no queue, no worker infrastructure justified. |
 | **Scale** | ~15 players, ~25 guardians, ~40 accounts *per team*, growing by one team a season. Peak concurrency is one coach and a handful of parents on a Saturday morning, all on the active team. Archived teams are cold data that must remain readable. Explicitly do not design for growth. |
 | **Integrations** | A transactional email provider and browser Web Push. No payments, no AI, no third-party sports data. |
@@ -118,9 +118,21 @@ today it does not have one.
 - **Clerk** — hosted auth, excellent components, free below 10k monthly active users.
 - **Hand-rolled token table** — an `Invitation` row, a signed cookie, ~200 lines.
 
-**Decision:** **Auth.js v5, Email (magic link) provider, Prisma adapter.** Invitations are
+**Decision:** **Auth.js v5, Email provider, Prisma adapter.** Invitations are
 a first-class `Invitation` table that gates account creation, so there is no self-serve
 signup path.
+
+> **Revised (#60, 2026-08):** the emailed credential is now a **typed 8-character code**
+> (`generateVerificationToken` + a 10-minute `maxAge` on the same Email provider), not a
+> tappable magic link. The link flow had a structural dead end on phones: the link is
+> redeemed by whichever browser the OS hands it to, and an installed PWA can hold a
+> separate cookie container from that browser — confirmed in the field on Android
+> (sign-in from the installed app looped back to the email form forever), and the
+> designed-for case on iOS Home Screen apps. A typed code is the one credential that
+> crosses a container boundary, because the human carries it instead of the OS routing
+> it. Everything below the credential — the Invitation gate, the Prisma adapter, database
+> sessions — is unchanged; the code redeems through the same Auth.js callback the link
+> did.
 
 **Rationale:** Auth.js's Email provider *is* the mechanism the proposal describes — a
 one-time, expiring link — so it's a direct fit rather than something bent into shape. It
@@ -496,7 +508,7 @@ populated going forward. Noted in Revisit Triggers.
 | API | Server Actions + Route Handlers | Medium | — | No separate backend deploy |
 | Database | Neon Postgres (via Vercel) | Medium | $0–19 | Free tier is genuinely sufficient at this scale |
 | ORM | Prisma | Medium–High | $0 | Prisma Studio for roster seeding and debugging |
-| Auth | Auth.js v5, magic link + Prisma adapter | Medium | $0 | Invitation-gated; no self-serve signup |
+| Auth | Auth.js v5, emailed sign-in code + Prisma adapter | Medium | $0 | Invitation-gated; no self-serve signup |
 | Hosting | Vercel | High | $20 (already paid) | Preview deploys; cron available for later reminders |
 | Email | Resend + React Email | Medium | $0 | 3,000/mo free; **requires domain verification** |
 | Push *(later)* | `web-push` + VAPID | **Low** | $0 | iOS requires Home Screen install — see Decision 8 |
@@ -530,7 +542,7 @@ Plus roughly $12/year for a domain.
 | Global `Player` identity | Never — this is the load-bearing one. Adding returning kids to a new team depends on it (Decision 15), and reversing it means reconstructing family links per season. |
 | Neon free tier | Cold-start latency on the autosuspended database becomes noticeable at the field, or storage passes the free limit. Upgrade to the paid tier; it's a plan change, not a migration. |
 | Prisma | Serverless cold starts become a felt problem, or the bundle size starts to matter. Drizzle is the migration target. |
-| Auth.js v5 | Wiring the magic-link flow eats more than ~4 days. Fall back to Clerk and accept the two-system user sync. |
+| Auth.js v5 | Wiring the email sign-in flow eats more than ~4 days. Fall back to Clerk and accept the two-system user sync. |
 | Hand-written service worker | Offline lineup viewing gets promoted from *Later* to required. Adopt Serwist then. |
 | `web-push` | iOS Home-Screen-install adoption among parents proves too low to be useful. The answer is probably to lean harder on email, not to switch push vendors — no vendor can fix this. |
 | Resend | Deliverability problems after domain verification, or volume passes 3,000/month. Postmark is the upgrade. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,7 +388,11 @@ production — the dev command can prompt, generate new migrations, and reset th
   unique on `(identifier, token)`, not on `identifier`, so every request would otherwise
   add another live code and divide the guessing work. `withSingleLiveCode`
   (`auth-adapter.ts`) wraps the Prisma adapter to delete the address's other codes before
-  minting one; length, expiry and that wrapper stand or fall together. Second, the pending
+  minting one; length, expiry and that wrapper stand or fall together. Prune-then-create
+  is two statements, so *concurrent* requests for one address can still both survive —
+  knowingly left open in #81, where the atomic fix (a unique index on `identifier` plus an
+  upsert) needs a migration, and where the reason the obvious patch is worse is written
+  down. Second, the pending
   cookie is read through `readPendingSignIn`, which takes the first name that **parses**
   and tries `__Secure-` first: taking the first that merely *existed* let junk planted in
   the bare `pending-signin` name shadow the real cookie and lock someone out of signing in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,30 @@ production — the dev command can prompt, generate new migrations, and reset th
   invitation-accept link (`/invite/[token]`) is the one emailed link that signs someone
   in, and it stays: it is a POST from a page, not a bare GET, and it establishes the
   session in whichever container the parent opened it in.
+
+  **Three things hold that code up, and none of them is optional.** The 40 bits assume
+  *one* live code per address, which `VerificationToken` does not give for free — it is
+  unique on `(identifier, token)`, not on `identifier`, so every request would otherwise
+  add another live code and divide the guessing work. `withSingleLiveCode`
+  (`auth-adapter.ts`) wraps the Prisma adapter to delete the address's other codes before
+  minting one; length, expiry and that wrapper stand or fall together. Second, the pending
+  cookie is read through `readPendingSignIn`, which takes the first name that **parses**
+  and tries `__Secure-` first: taking the first that merely *existed* let junk planted in
+  the bare `pending-signin` name shadow the real cookie and lock someone out of signing in
+  entirely. Third, `resend-provider.ts` imports the mail stack *inside* the send path —
+  `src/auth.ts` is in every page's graph, so a static `@/lib/email` import puts the Resend
+  SDK and React Email there too.
+
+  **A wrong code goes back to the code form, not to the email form.** `pages.error` is
+  global, so Auth.js can only fail a redeem to `/signin`; that loader bounces
+  `?error=Verification` on to `/signin/check-email?error=wrong-code` when the pending
+  cookie is still alive, because the cookie and the mailed code expire together — a live
+  cookie means there is still a code worth retyping, and sending the parent back for a
+  second email throws away a working one. `AccessDenied` is deliberately not bounced: the
+  gate refused the address, and retyping cannot change that. The entry form itself is
+  `useActionState` (`CodeEntryForm` + `check-email-state.ts`), so a mistype keeps the
+  characters — the convention every typed-into form here follows, and the reason
+  `?error=invalid-code` no longer exists.
 - **`public/sw.js` caches nothing, and must not start.** It is `skipWaiting`,
   `clients.claim`, and the `push` / `notificationclick` pair — no `fetch` handler, which is
   Decision 9 and the reason there is no Workbox build step. Adding a `fetch` handler is not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@ fixes, what the team has on file for them.
 - **Framework**: Next.js 16.2 (App Router), React 19.2
 - **Database**: Neon Postgres (via Vercel Marketplace) — *not* Prisma Postgres
 - **ORM**: Prisma 7.9 with the `@prisma/adapter-pg` driver adapter
-- **Auth**: Auth.js v5 beta (`next-auth@5.0.0-beta.32`) + Prisma adapter, magic-link only
+- **Auth**: Auth.js v5 beta (`next-auth@5.0.0-beta.32`) + Prisma adapter, emailed
+  sign-in codes only (a typed code, not a tapped link — see the PWA gotcha below)
 - **Styling**: Tailwind CSS 4
 - **Drag & drop**: `@dnd-kit` (core, sortable, utilities)
 - **Animation**: `motion` v12 — import via `LazyMotion` + `m`, not the top-level `motion`
@@ -109,7 +110,7 @@ URL.
 ## Architecture
 
 Server Actions for mutations; Route Handlers only for things needing a real HTTP endpoint
-(magic-link callback, the ICS feed, push subscription registration, the reminder cron
+(the Auth.js email callback, the ICS feed, push subscription registration, the reminder cron
 target). No separate API layer.
 
 ### Team scoping
@@ -363,17 +364,24 @@ production — the dev command can prompt, generate new migrations, and reset th
   the build passes and every page renders — and only an actual iPhone shows it, by putting
   a screenshot of the page on the home screen instead of the crest. `layout.test.tsx` pins
   the declaration and `manifest.test.ts` pins the file it points at.
-- **An installed iOS Home Screen app may not share Safari's cookies — and this app is
-  magic-link only.** iOS gives a standalone web app its own storage container. If that
-  holds here, the sequence is a dead end: a parent installs from Safari, opens the app,
-  finds it signed out, requests a magic link, and the link opens in *Safari* — iOS has no
-  way to route it back to a Home Screen web app — so the session lands in the container
-  the app cannot read, every time, forever. **This is unverified**, it is the first thing
-  the real-device test in #14 must check, and it is why the app has to stay fully usable
-  without installing. If it is confirmed, the remedy is an emailed sign-in *code* the
-  person types into whichever container they are standing in, not a link; that is an auth
-  change well beyond the PWA work, designed and costed in #60. Until it is checked, treat
-  the iOS half of `InstallPrompt` as provisional.
+- **Sign-in is a typed code because an installed PWA and the email's browser can hold
+  separate cookie containers.** A tapped magic link is redeemed by whichever browser the
+  OS hands it to, and that is routinely not the container the person requested it from —
+  **confirmed in the field on Android** (sign-in from the installed app looped back to
+  the email form forever, the report behind #60's implementation) and the designed-for
+  case on iOS Home Screen apps, which iOS cannot route a link back into. So `/signin`
+  mails an 8-character code (Crockford base32, 10-minute expiry — `signin-code.ts`) that
+  the person types into `/signin/check-email`, whose action rebuilds the same
+  `/api/auth/callback/resend?token=&email=` URL the link used to carry; the gate,
+  `acceptInvitations`, and the session cookie are untouched. The pending address rides in
+  a short-lived httpOnly cookie (`pending-signin-cookie.ts`), never a query parameter.
+  Do not reintroduce a tappable link in the sign-in email, even alongside the code: both
+  would be the same token, so a mail scanner following the link would burn the typed code
+  too. The code's 40 bits and short expiry carry the security — there is no attempt
+  counter (that would need a migration), so neither may be weakened alone. The
+  invitation-accept link (`/invite/[token]`) is the one emailed link that signs someone
+  in, and it stays: it is a POST from a page, not a bare GET, and it establishes the
+  session in whichever container the parent opened it in.
 - **`public/sw.js` caches nothing, and must not start.** It is `skipWaiting`,
   `clients.claim`, and the `push` / `notificationclick` pair — no `fetch` handler, which is
   Decision 9 and the reason there is no Workbox build step. Adding a `fetch` handler is not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ docs/design/       # The design plan and its SVG mockups — kept in step with t
 .claude/           # Agent config: workflow skills, agent defs, permissions (do not edit)
 ```
 
-`src/app/` now has real routes: `/` (auth-gated landing), `/signin`, `/invite/[token]`
+`src/app/` now has real routes: `/` (auth-gated landing), `/signin` and
+`/signin/check-email` (ask for an emailed code, then type it — the second is a real form,
+not a confirmation screen), `/invite/[token]`
 (unauthenticated invitation accept page — deliberately outside proxy.ts's matcher),
 `/profile` (the signed-in person's own name and phone — global, not team-scoped, since
 those are `User` columns — and the app's only sign-out, a server action wrapping Auth.js

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ parking lot fifteen minutes before first pitch.
 ## Status
 
 **Phase 10 complete — the batting order editor.** Phase 1 laid the data model, tooling, and
-domain guards. Phase 2 added sign-in. Phase 3 added team scoping (`/t/[teamId]`,
+domain guards. Phase 2 added sign-in — a typed, emailed code rather than a tapped magic link, since a
+link is redeemed by whichever browser the OS picks and that is not always the installed
+app the person is standing in (#60). Phase 3 added team scoping (`/t/[teamId]`,
 `requireTeamAccess`). Phase 4 added the roster itself: players, jersey numbers, guardian
 links, working invitations, and owner-only member/role management. Phase 5 added the
 returning-player picker — the owner-only global `Player` read that pulls a kid and their
@@ -40,9 +42,10 @@ What exists today:
   contract plus its team-scoped, guardian-guarded data wrapper, the view page's pure
   chart render model (`chart-view.ts`), and the batting order editor's pure draft/drop/
   validation logic (`chart.ts`) — all unit-tested
-- `src/auth.ts` — Auth.js v5 config: Prisma adapter, Resend provider, database sessions
+- `src/auth.ts` — Auth.js v5 config: Prisma adapter (wrapped so one sign-in code is
+  live per address), Resend provider issuing typed codes, database sessions
 - `src/proxy.ts` — redirects signed-out visitors away from `/t/:path*`
-- `src/app/signin/` — the sign-in form and its confirmation page
+- `src/app/signin/` — the email form and the code-entry page it hands off to
 - `src/app/invite/[token]/` — the (unauthenticated) invitation accept page
 - `src/app/t/[teamId]/` — team home, settings, roster (list + player detail with guardian
   linking and phone), owner-only member management, an owner-only returning-player picker

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Run `pnpm check` before pushing — it chains lint, typecheck, and tests.
 ## Stack
 
 Next.js 16 (App Router) · React 19 · TypeScript · Tailwind CSS 4 · Prisma 7 on Neon
-Postgres · Auth.js v5 magic links · `@dnd-kit` · Motion · Resend · `web-push` · Vitest ·
+Postgres · Auth.js v5 emailed sign-in codes · `@dnd-kit` · Motion · Resend · `web-push` · Vitest ·
 deployed on Vercel.
 
 Every one of those was chosen deliberately, with alternatives considered and rejected in

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -217,8 +217,18 @@ All inside the existing viewBox — `DIAMOND_GEOMETRY.width = 400`,
 ## 7. Screen-by-screen pass
 
 **Sign-in** — first impression, currently a form. Cream page, pinstripe band, slab
-wordmark, one banana button ("Email me a magic link"), and a tiny flat field illustration
+wordmark, one banana button ("Email me a sign-in code"), and a tiny flat field illustration
 (a cropped reuse of `FieldArt`). Empty-state copy: "The gate's open."
+
+**Enter your code (post-ship addition)** — the second half of sign-in since #60 replaced
+the tapped link with a typed code. Same cream card as the screen before it, and it spends
+its own banana on the one button ("Sign in"), which is the §2 budget rather than a second
+helping: it is a separate screen, reached by a full navigation. The code box is monospaced
+and letter-spaced because a code is *read off one screen and typed into another* — the
+shape of the characters is the whole job, so this is the one input in the app that does
+not use the shared field styling. A rejection keeps what was typed and puts the sentence
+in a `StatusBanner` under the box, never a redirect: eight characters retyped on a phone,
+mid-code, is where a parent gives up.
 
 **Team chrome (post-ship addition)** — every `/t/[teamId]` view now carries a persistent
 `TeamNav` in the team layout: pill tabs on the header band, the active section filled

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,8 @@
 import { handlers } from "@/auth";
 
-/// The magic-link callback needs a real HTTP endpoint, which is why this is a
-/// Route Handler rather than a Server Action.
+/// Auth.js's email callback needs a real HTTP endpoint, which is why this is a
+/// Route Handler rather than a Server Action. Since #60 the browser arrives
+/// here from `submitSignInCode` rebuilding the URL with a typed code, rather
+/// than from a link in an email — the endpoint itself is indifferent to which.
 
 export const { GET, POST } = handlers;

--- a/src/app/invite/[token]/actions.ts
+++ b/src/app/invite/[token]/actions.ts
@@ -30,8 +30,8 @@ import { createUserSession } from "@/lib/sessions";
  * function Auth.js's `events.signIn` calls, so there is still one grant path.
  * What changes is only where the session comes from.
  *
- * The magic link is not gone — it is what `/signin` still sends, and a parent
- * whose session lapses next season signs in that way, admitted by the
+ * Ordinary sign-in is not gone — `/signin` mails a typed code (#60), and a
+ * parent whose session lapses next season signs in that way, admitted by the
  * Membership this action created.
  *
  * This is a POST for a reason. Accepting consumes the invitation, and

--- a/src/app/signin/actions.test.ts
+++ b/src/app/signin/actions.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const signIn = vi.fn();
+const cookieSet = vi.fn();
+const cookieGet = vi.fn();
+const headerGet = vi.fn();
+
+vi.mock("@/auth", () => ({
+  signIn: (...args: unknown[]) => signIn(...args),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    set: (...args: unknown[]) => cookieSet(...args),
+    get: (...args: unknown[]) => cookieGet(...args),
+  }),
+  headers: async () => ({ get: (...args: unknown[]) => headerGet(...args) }),
+}));
+
+// redirect() throws in Next; reproduce that so control flow matches production
+// and a "redirected" assertion can't pass by accident.
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+  unstable_rethrow: (error: unknown) => {
+    if (error instanceof Error && error.message.startsWith("NEXT_REDIRECT:")) {
+      throw error;
+    }
+  },
+}));
+
+import { requestSignInCode, submitSignInCode } from "./actions";
+
+function form(entries: Record<string, string>) {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    data.set(key, value);
+  }
+  return data;
+}
+
+async function redirectOf(action: Promise<unknown>): Promise<string> {
+  try {
+    await action;
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("NEXT_REDIRECT:")) {
+      return error.message.slice("NEXT_REDIRECT:".length);
+    }
+    throw error;
+  }
+  throw new Error("expected a redirect");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  headerGet.mockReturnValue("https");
+  cookieGet.mockReturnValue(undefined);
+});
+
+describe("requestSignInCode", () => {
+  it("bounces a malformed address without calling Auth.js", async () => {
+    const destination = await redirectOf(
+      requestSignInCode(form({ email: "not-an-email" })),
+    );
+
+    expect(destination).toBe("/signin?error=invalid-email");
+    expect(signIn).not.toHaveBeenCalled();
+    expect(cookieSet).not.toHaveBeenCalled();
+  });
+
+  it("requests the code, sets the pending cookie, and lands on check-email", async () => {
+    const destination = await redirectOf(
+      requestSignInCode(
+        form({ email: "Parent@Example.com", callbackUrl: "/t/team-a" }),
+      ),
+    );
+
+    expect(destination).toBe("/signin/check-email");
+
+    // Normalized exactly as Auth.js normalizes the identifier, so the typed
+    // code later looks up the row that was actually written.
+    expect(signIn).toHaveBeenCalledWith("resend", {
+      email: "parent@example.com",
+      redirectTo: "/t/team-a",
+      redirect: false,
+    });
+
+    expect(cookieSet).toHaveBeenCalledTimes(1);
+    const [name, value, options] = cookieSet.mock.calls[0] as [
+      string,
+      string,
+      { httpOnly: boolean; path: string },
+    ];
+    expect(name).toBe("__Secure-pending-signin");
+    expect(JSON.parse(value)).toEqual({
+      email: "parent@example.com",
+      callbackUrl: "/t/team-a",
+    });
+    expect(options.httpOnly).toBe(true);
+    expect(options.path).toBe("/signin");
+  });
+
+  it("uses the unprefixed cookie name over plain HTTP", async () => {
+    headerGet.mockReturnValue("http");
+
+    await redirectOf(requestSignInCode(form({ email: "a@b.com" })));
+
+    expect(cookieSet.mock.calls[0][0]).toBe("pending-signin");
+  });
+
+  // The failure posture: a denied gate, a Resend outage and a success all end
+  // on the same page with the same cookie, so nothing about the response says
+  // whether the address is on a team.
+  it("still sets the cookie and lands on check-email when the send fails", async () => {
+    signIn.mockRejectedValue(new Error("AccessDenied"));
+
+    const destination = await redirectOf(
+      requestSignInCode(form({ email: "a@b.com" })),
+    );
+
+    expect(destination).toBe("/signin/check-email");
+    expect(cookieSet).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("submitSignInCode", () => {
+  function pendingCookie() {
+    cookieGet.mockImplementation((name: string) =>
+      name === "__Secure-pending-signin"
+        ? {
+            value: JSON.stringify({
+              email: "parent@example.com",
+              callbackUrl: "/t/team-a",
+            }),
+          }
+        : undefined,
+    );
+  }
+
+  it("starts over when the pending cookie is gone", async () => {
+    const destination = await redirectOf(
+      submitSignInCode(form({ code: "K3M7QP2X" })),
+    );
+
+    expect(destination).toBe("/signin?error=code-expired");
+  });
+
+  it("returns to the entry form for something that cannot be a code", async () => {
+    pendingCookie();
+
+    const destination = await redirectOf(
+      submitSignInCode(form({ code: "nope" })),
+    );
+
+    expect(destination).toBe("/signin/check-email?error=invalid-code");
+  });
+
+  // The whole trick of #60: rebuild the URL the magic link used to carry.
+  // Auth.js's callback verifies ?token=&email= without caring how they
+  // arrived, so the gate, the signIn event and the session cookie all run
+  // exactly as they did for a clicked link.
+  it("redeems a typed code against the Auth.js email callback", async () => {
+    pendingCookie();
+
+    const destination = await redirectOf(
+      submitSignInCode(form({ code: "k3m7 qp2x" })),
+    );
+
+    const url = new URL(destination, "https://app.example");
+    expect(url.pathname).toBe("/api/auth/callback/resend");
+    expect(url.searchParams.get("token")).toBe("K3M7QP2X");
+    expect(url.searchParams.get("email")).toBe("parent@example.com");
+    expect(url.searchParams.get("callbackUrl")).toBe("/t/team-a");
+  });
+});

--- a/src/app/signin/actions.test.ts
+++ b/src/app/signin/actions.test.ts
@@ -31,6 +31,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { requestSignInCode, submitSignInCode } from "./actions";
+import { CHECK_EMAIL_INITIAL_STATE } from "./check-email-state";
 
 function form(entries: Record<string, string>) {
   const data = new FormData();
@@ -138,22 +139,26 @@ describe("submitSignInCode", () => {
     );
   }
 
+  function submit(code: string) {
+    return submitSignInCode(CHECK_EMAIL_INITIAL_STATE, form({ code }));
+  }
+
   it("starts over when the pending cookie is gone", async () => {
-    const destination = await redirectOf(
-      submitSignInCode(form({ code: "K3M7QP2X" })),
-    );
+    const destination = await redirectOf(submit("K3M7QP2X"));
 
     expect(destination).toBe("/signin?error=code-expired");
   });
 
-  it("returns to the entry form for something that cannot be a code", async () => {
+  // The value comes back with the state instead of being thrown away by a
+  // redirect: eight characters retyped on a phone is where people give up.
+  it("returns a mistyped code as state, keeping what was typed", async () => {
     pendingCookie();
 
-    const destination = await redirectOf(
-      submitSignInCode(form({ code: "nope" })),
-    );
-
-    expect(destination).toBe("/signin/check-email?error=invalid-code");
+    await expect(submit("nope")).resolves.toEqual({
+      status: "invalid",
+      code: "invalid-code",
+      value: "nope",
+    });
   });
 
   // The whole trick of #60: rebuild the URL the magic link used to carry.
@@ -163,14 +168,34 @@ describe("submitSignInCode", () => {
   it("redeems a typed code against the Auth.js email callback", async () => {
     pendingCookie();
 
-    const destination = await redirectOf(
-      submitSignInCode(form({ code: "k3m7 qp2x" })),
-    );
+    const destination = await redirectOf(submit("k3m7 qp2x"));
 
     const url = new URL(destination, "https://app.example");
     expect(url.pathname).toBe("/api/auth/callback/resend");
     expect(url.searchParams.get("token")).toBe("K3M7QP2X");
     expect(url.searchParams.get("email")).toBe("parent@example.com");
     expect(url.searchParams.get("callbackUrl")).toBe("/t/team-a");
+  });
+
+  // Junk in the unprefixed name used to shadow the real cookie and lock the
+  // person out of signing in with nothing on screen to explain it.
+  it("ignores a planted unprefixed cookie", async () => {
+    cookieGet.mockImplementation((name: string) =>
+      name === "pending-signin"
+        ? { value: "not json" }
+        : {
+            value: JSON.stringify({
+              email: "parent@example.com",
+              callbackUrl: "/",
+            }),
+          },
+    );
+
+    const destination = await redirectOf(submit("K3M7QP2X"));
+
+    expect(destination).toContain("/api/auth/callback/resend");
+    expect(new URL(destination, "https://app.example").searchParams.get("email")).toBe(
+      "parent@example.com",
+    );
   });
 });

--- a/src/app/signin/actions.ts
+++ b/src/app/signin/actions.ts
@@ -7,15 +7,16 @@ import { z } from "zod";
 import { signIn } from "@/auth";
 import { safeCallbackUrl } from "@/lib/callback-url";
 import {
-  PENDING_SIGNIN_COOKIE_NAMES,
   normalizeSignInEmail,
-  parsePendingSignIn,
   pendingSignInCookieName,
   pendingSignInCookieOptions,
+  readPendingSignIn,
   serializePendingSignIn,
 } from "@/lib/pending-signin-cookie";
 import { usesSecureCookies } from "@/lib/session-cookie";
 import { normalizeSignInCode } from "@/lib/signin-code";
+
+import type { CheckEmailState } from "./check-email-state";
 
 const emailSchema = z.email();
 
@@ -87,28 +88,34 @@ export async function requestSignInCode(formData: FormData) {
  * (a bespoke code table, a direct session write) would duplicate the gate and
  * the invitation wiring into a second sign-in path — see #60.
  *
- * A wrong-but-well-formed code fails inside Auth.js and lands on
- * /signin?error=Verification; a mistyped one is caught here and returns to
- * the entry form. Neither reveals whether the address is invited, and neither
- * burns the real code — `useVerificationToken` deletes the row only on a
- * successful match.
+ * `useActionState`-shaped, so a mistype comes back as typed state with the
+ * characters still in the box. A redirect would have wiped them, and eight
+ * characters retyped on a phone is where people stop.
+ *
+ * A wrong-but-well-formed code cannot be judged here — only Auth.js can say
+ * whether it matches — so it goes to the callback and comes back through
+ * `/signin`, which bounces it to the entry form while the code is still live.
+ * Neither path reveals whether the address is invited, and neither burns the
+ * real code: `useVerificationToken` deletes the row only on a match.
  */
-export async function submitSignInCode(formData: FormData) {
+export async function submitSignInCode(
+  _state: CheckEmailState,
+  formData: FormData,
+): Promise<CheckEmailState> {
   const cookieStore = await cookies();
-  const raw = PENDING_SIGNIN_COOKIE_NAMES.map(
-    (name) => cookieStore.get(name)?.value,
-  ).find((value) => value !== undefined);
+  const pending = readPendingSignIn((name) => cookieStore.get(name)?.value);
 
-  const pending = parsePendingSignIn(raw);
   if (!pending) {
     // The cookie and the code expire together, so no address here means no
     // live code to redeem — start over rather than invite a doomed submit.
     redirect("/signin?error=code-expired");
   }
 
-  const code = normalizeSignInCode(formData.get("code"));
+  const typed = String(formData.get("code") ?? "");
+  const code = normalizeSignInCode(typed);
+
   if (!code) {
-    redirect("/signin/check-email?error=invalid-code");
+    return { status: "invalid", code: "invalid-code", value: typed };
   }
 
   redirect(

--- a/src/app/signin/actions.ts
+++ b/src/app/signin/actions.ts
@@ -1,23 +1,38 @@
 "use server";
 
+import { cookies, headers } from "next/headers";
 import { redirect, unstable_rethrow } from "next/navigation";
 import { z } from "zod";
 
 import { signIn } from "@/auth";
 import { safeCallbackUrl } from "@/lib/callback-url";
+import {
+  PENDING_SIGNIN_COOKIE_NAMES,
+  normalizeSignInEmail,
+  parsePendingSignIn,
+  pendingSignInCookieName,
+  pendingSignInCookieOptions,
+  serializePendingSignIn,
+} from "@/lib/pending-signin-cookie";
+import { usesSecureCookies } from "@/lib/session-cookie";
+import { normalizeSignInCode } from "@/lib/signin-code";
 
 const emailSchema = z.email();
 
 /**
- * Request a magic link.
+ * Request a sign-in code (#60 — a typed code, not a tapped link, because the
+ * link is redeemed by whichever browser the OS picks and that is not always
+ * the container the person is standing in).
  *
  * Every path that gets as far as a well-formed address ends on the same page,
- * whether or not a link was actually sent. This form is the app's only
+ * whether or not a code was actually sent. This form is the app's only
  * unauthenticated POST surface, and an explicit "that address isn't invited"
  * would turn it into a way to test which families are on a team. The gate in
  * src/auth.ts declines silently, and no mail leaves for an uninvited address.
+ * The pending cookie is set on every path for the same reason — its absence
+ * must not say anything either.
  */
-export async function requestSignInLink(formData: FormData) {
+export async function requestSignInCode(formData: FormData) {
   const parsed = emailSchema.safeParse(formData.get("email"));
 
   // A malformed address is a typo, not a probe: saying so reveals nothing and
@@ -28,9 +43,13 @@ export async function requestSignInLink(formData: FormData) {
 
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl"));
 
+  // The spelling Auth.js stores the verification token under — the cookie
+  // must hold the same one, or the typed code looks up the wrong row.
+  const email = normalizeSignInEmail(parsed.data);
+
   try {
     await signIn("resend", {
-      email: parsed.data,
+      email,
       redirectTo: callbackUrl,
       redirect: false,
     });
@@ -40,8 +59,63 @@ export async function requestSignInLink(formData: FormData) {
 
     // Everything else — a denied gate (AccessDenied), a Resend outage, a
     // missing env var — is logged server-side and hidden from the visitor.
-    console.warn("Sign-in link not sent:", error);
+    console.warn("Sign-in code not sent:", error);
   }
 
+  const secure = usesSecureCookies({
+    authUrl: process.env.AUTH_URL,
+    forwardedProto: (await headers()).get("x-forwarded-proto"),
+  });
+
+  (await cookies()).set(
+    pendingSignInCookieName(secure),
+    serializePendingSignIn({ email, callbackUrl }),
+    pendingSignInCookieOptions(secure),
+  );
+
   redirect("/signin/check-email");
+}
+
+/**
+ * Redeem a typed code.
+ *
+ * This action's whole job is to rebuild the URL a magic link used to carry
+ * and send the browser there: Auth.js's email callback verifies
+ * `?token=&email=` without caring whether they arrived from a clicked link or
+ * a form — the hash, the gate in src/auth.ts, the `signIn` event and the
+ * session cookie all run exactly as before. Owning more of the flow than this
+ * (a bespoke code table, a direct session write) would duplicate the gate and
+ * the invitation wiring into a second sign-in path — see #60.
+ *
+ * A wrong-but-well-formed code fails inside Auth.js and lands on
+ * /signin?error=Verification; a mistyped one is caught here and returns to
+ * the entry form. Neither reveals whether the address is invited, and neither
+ * burns the real code — `useVerificationToken` deletes the row only on a
+ * successful match.
+ */
+export async function submitSignInCode(formData: FormData) {
+  const cookieStore = await cookies();
+  const raw = PENDING_SIGNIN_COOKIE_NAMES.map(
+    (name) => cookieStore.get(name)?.value,
+  ).find((value) => value !== undefined);
+
+  const pending = parsePendingSignIn(raw);
+  if (!pending) {
+    // The cookie and the code expire together, so no address here means no
+    // live code to redeem — start over rather than invite a doomed submit.
+    redirect("/signin?error=code-expired");
+  }
+
+  const code = normalizeSignInCode(formData.get("code"));
+  if (!code) {
+    redirect("/signin/check-email?error=invalid-code");
+  }
+
+  redirect(
+    `/api/auth/callback/resend?${new URLSearchParams({
+      token: code,
+      email: pending.email,
+      callbackUrl: pending.callbackUrl,
+    })}`,
+  );
 }

--- a/src/app/signin/check-email-state.ts
+++ b/src/app/signin/check-email-state.ts
@@ -1,0 +1,23 @@
+/// The shape `submitSignInCode` hands back to `CodeEntryForm`.
+///
+/// Its own module because `actions.ts` is `"use server"`, where the directive
+/// marks *every* export as a server function — so a runtime constant like
+/// `CHECK_EMAIL_INITIAL_STATE` cannot live there. That fails at `next build`
+/// rather than at `pnpm check`, which is worth a file to avoid.
+
+export type CheckEmailState =
+  | { status: "idle" }
+  | {
+      status: "invalid";
+      /// A key into `CODE_ENTRY_MESSAGES`, not a sentence: the wording lives
+      /// in one table the page and the form both read, so a redirect-borne
+      /// failure and an in-form one cannot drift apart.
+      code: string;
+      /// Exactly what was typed, echoed back. Eight characters is short, but
+      /// retyping all of them because one was wrong is the failure this
+      /// state exists to prevent — and on a phone, mid-code, it is the point
+      /// where people give up.
+      value: string;
+    };
+
+export const CHECK_EMAIL_INITIAL_STATE: CheckEmailState = { status: "idle" };

--- a/src/app/signin/check-email/CodeEntryForm.test.tsx
+++ b/src/app/signin/check-email/CodeEntryForm.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { CheckEmailState } from "../check-email-state";
+
+// The real action reaches Auth.js and the Prisma client. `useActionState`
+// only needs something action-shaped, so the mock returns the state a real
+// rejection would.
+const submitSignInCode = vi.fn();
+
+vi.mock("../actions", () => ({
+  submitSignInCode: (state: CheckEmailState, formData: FormData) =>
+    submitSignInCode(state, formData),
+}));
+
+import { CodeEntryForm } from "./CodeEntryForm";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  submitSignInCode.mockImplementation(
+    async (_state: CheckEmailState, formData: FormData): Promise<CheckEmailState> => ({
+      status: "invalid",
+      code: "invalid-code",
+      value: String(formData.get("code") ?? ""),
+    }),
+  );
+});
+
+describe("CodeEntryForm", () => {
+  it("offers the one-time-code keyboard hint", async () => {
+    render(<CodeEntryForm />);
+
+    // On a phone the code arrives as a notification; this is what lets the
+    // keyboard offer it without a trip to the mail app.
+    expect(screen.getByLabelText("Sign-in code")).toHaveAttribute(
+      "autocomplete",
+      "one-time-code",
+    );
+  });
+
+  it("shows no error until something fails", () => {
+    render(<CodeEntryForm />);
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  // The regression this exists for: a redirect emptied the box, so one wrong
+  // character cost all eight — mid-code, on a phone, which is where people
+  // give up and ask for another email instead.
+  it("keeps the typed code on screen after a rejection", async () => {
+    const user = userEvent.setup();
+    render(<CodeEntryForm />);
+
+    const input = screen.getByLabelText("Sign-in code");
+    await user.type(input, "K3M7QP2");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /doesn't look like a code/i,
+    );
+    expect(input).toHaveValue("K3M7QP2");
+  });
+
+  it("marks the box as invalid and points the description at the message", async () => {
+    const user = userEvent.setup();
+    render(<CodeEntryForm />);
+
+    await user.type(screen.getByLabelText("Sign-in code"), "nope");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await screen.findByRole("alert");
+    const input = screen.getByLabelText("Sign-in code");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "code-error");
+  });
+
+  // The other route into this screen: Auth.js rejected the redeem and the
+  // page passed the sentence down, rather than this leaf reading the query.
+  it("renders a message handed down from the page", () => {
+    render(<CodeEntryForm serverMessage="That code didn't match." />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/didn't match/i);
+  });
+
+  it("lets the person type over a server-side rejection", async () => {
+    const user = userEvent.setup();
+    render(<CodeEntryForm serverMessage="That code didn't match." />);
+
+    await user.type(screen.getByLabelText("Sign-in code"), "K3M7QP2X");
+
+    expect(screen.getByLabelText("Sign-in code")).toHaveValue("K3M7QP2X");
+  });
+});

--- a/src/app/signin/check-email/CodeEntryForm.tsx
+++ b/src/app/signin/check-email/CodeEntryForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import * as React from "react";
+import { useActionState } from "react";
+
+import { StatusBanner } from "@/components/StatusBanner";
+import { SubmitButton } from "@/components/SubmitButton";
+import { messageFor } from "@/lib/error-messages";
+
+import { submitSignInCode } from "../actions";
+import { CHECK_EMAIL_INITIAL_STATE } from "../check-email-state";
+import { CODE_ENTRY_MESSAGES } from "../signin-messages";
+
+/**
+ * The code-entry box, as a form that keeps what was typed.
+ *
+ * A redirect on a mistyped code emptied the field, which on eight characters
+ * read from a notification while standing somewhere is the moment a parent
+ * gives up and asks for another email. `useActionState` returns the failure
+ * with the characters intact instead — the convention every form people type
+ * into follows here (AGENTS.md; `AddPlayerForm` is the annotated reference).
+ *
+ * The value is controlled so it survives the rejection without depending on
+ * when React resets an uncontrolled form, and its initial value still comes
+ * from the returned state, which is what refills the box when JavaScript
+ * never ran at all.
+ *
+ * `serverMessage` is the other way this screen can fail: Auth.js rejects a
+ * wrong-but-well-formed code at the callback, and the page bounces it back
+ * here as `?error=wrong-code`. It arrives as a prop rather than being read
+ * here so this component stays a leaf, and both sentences come out of one
+ * table so the two routes cannot drift.
+ */
+export function CodeEntryForm({
+  serverMessage,
+}: {
+  serverMessage?: string | null;
+}) {
+  const [state, formAction] = useActionState(
+    submitSignInCode,
+    CHECK_EMAIL_INITIAL_STATE,
+  );
+
+  const rejected = state.status === "invalid" ? state : null;
+  const [code, setCode] = React.useState(() => rejected?.value ?? "");
+
+  const message = rejected
+    ? messageFor(CODE_ENTRY_MESSAGES, rejected.code)
+    : (serverMessage ?? null);
+  const errorId = "code-error";
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <div className="space-y-2">
+        <label
+          htmlFor="code"
+          className="block text-sm font-medium text-foreground"
+        >
+          Sign-in code
+        </label>
+        <input
+          id="code"
+          name="code"
+          type="text"
+          // The one autofill hint that matters: on a phone the code arrives
+          // as a notification, and this lets the keyboard offer it without a
+          // trip to the mail app.
+          autoComplete="one-time-code"
+          autoCapitalize="characters"
+          autoCorrect="off"
+          spellCheck={false}
+          required
+          maxLength={12}
+          placeholder="K3M7-QP2X"
+          value={code}
+          onChange={(event) => setCode(event.target.value)}
+          aria-invalid={message ? true : undefined}
+          aria-describedby={message ? errorId : undefined}
+          className={`w-full rounded-md bg-background px-3 py-2 font-mono text-lg tracking-widest text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring ${
+            message
+              ? "border-2 border-destructive"
+              : "border border-border"
+          }`}
+        />
+      </div>
+
+      {message ? (
+        <StatusBanner tone="error" id={errorId}>
+          {message}
+        </StatusBanner>
+      ) : null}
+
+      {/* This screen's one banana (design-plan.md §2), matching the request
+          form it follows. */}
+      <SubmitButton
+        className="w-full bg-banana text-banana-foreground hover:bg-banana/90"
+        pendingLabel="Signing you in…"
+      >
+        Sign in
+      </SubmitButton>
+    </form>
+  );
+}

--- a/src/app/signin/check-email/page.test.tsx
+++ b/src/app/signin/check-email/page.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// The real action pulls in Auth.js and the Prisma client; the page only needs
+// something form-shaped to point at.
+vi.mock("../actions", () => ({
+  submitSignInCode: vi.fn(),
+}));
+
+const cookieGet = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: (...args: unknown[]) => cookieGet(...args) }),
+}));
+
+import CheckEmailPage from "./page";
+
+function pendingCookie(email = "parent@example.com") {
+  cookieGet.mockImplementation((name: string) =>
+    name === "pending-signin"
+      ? { value: JSON.stringify({ email, callbackUrl: "/" }) }
+      : undefined,
+  );
+}
+
+async function renderPage(searchParams: { error?: string } = {}) {
+  render(await CheckEmailPage({ searchParams: Promise.resolve(searchParams) }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cookieGet.mockReturnValue(undefined);
+});
+
+describe("CheckEmailPage", () => {
+  describe("with a pending sign-in", () => {
+    beforeEach(() => pendingCookie());
+
+    it("renders the code entry form", async () => {
+      await renderPage();
+
+      const input = screen.getByLabelText("Sign-in code");
+      // On a phone the code arrives as a notification; this is what lets the
+      // keyboard offer it without a trip to the mail app.
+      expect(input).toHaveAttribute("autocomplete", "one-time-code");
+      expect(
+        screen.getByRole("button", { name: /sign in/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("names the address the code went to", async () => {
+      await renderPage();
+
+      expect(
+        screen.getByText(/parent@example\.com/),
+      ).toBeInTheDocument();
+    });
+
+    // The wording must not promise a send: for an uninvited address none
+    // happened, and saying otherwise tests who is on a team.
+    it("stops short of promising an email was sent", async () => {
+      await renderPage();
+
+      expect(screen.getByText(/^If /)).toHaveTextContent(/is on a team/i);
+    });
+
+    it("shows no error by default", async () => {
+      await renderPage();
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("explains a mistyped code", async () => {
+      await renderPage({ error: "invalid-code" });
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /doesn't look like a code/i,
+      );
+    });
+
+    // Same hardening as every other ?error= page: inherited keys must hit
+    // messageFor's string check, not render a function.
+    it("renders nothing for an inherited key", async () => {
+      await renderPage({ error: "constructor" });
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /something went wrong/i,
+      );
+    });
+
+    it("offers a way back to a different address", async () => {
+      await renderPage();
+
+      expect(
+        screen.getByRole("link", { name: /use a different address/i }),
+      ).toHaveAttribute("href", "/signin");
+    });
+  });
+
+  describe("without a pending sign-in", () => {
+    it("offers to start over instead of a doomed form", async () => {
+      // The cookie and the code expire together — a direct visit or a stale
+      // tab has nothing left to redeem.
+      await renderPage();
+
+      expect(screen.queryByLabelText("Sign-in code")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /enter your email/i }),
+      ).toHaveAttribute("href", "/signin");
+    });
+  });
+
+  it("reads the __Secure- spelling too", async () => {
+    cookieGet.mockImplementation((name: string) =>
+      name === "__Secure-pending-signin"
+        ? { value: JSON.stringify({ email: "a@b.com", callbackUrl: "/" }) }
+        : undefined,
+    );
+
+    await renderPage();
+
+    expect(screen.getByLabelText("Sign-in code")).toBeInTheDocument();
+  });
+});

--- a/src/app/signin/check-email/page.test.tsx
+++ b/src/app/signin/check-email/page.test.tsx
@@ -70,12 +70,21 @@ describe("CheckEmailPage", () => {
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
 
-    it("explains a mistyped code", async () => {
-      await renderPage({ error: "invalid-code" });
+    // Auth.js rejected a redeem and /signin bounced it back here rather than
+    // making the parent ask for a second email, so the message has to say the
+    // mailed code is still good.
+    it("explains a wrong code without sending the parent back for another", async () => {
+      await renderPage({ error: "wrong-code" });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(
-        /doesn't look like a code/i,
-      );
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveTextContent(/didn't match/i);
+      expect(alert).toHaveTextContent(/still works/i);
+    });
+
+    it("keeps the entry form on screen alongside that message", async () => {
+      await renderPage({ error: "wrong-code" });
+
+      expect(screen.getByLabelText("Sign-in code")).toBeInTheDocument();
     });
 
     // Same hardening as every other ?error= page: inherited keys must hit
@@ -94,6 +103,15 @@ describe("CheckEmailPage", () => {
       expect(
         screen.getByRole("link", { name: /use a different address/i }),
       ).toHaveAttribute("href", "/signin");
+    });
+
+    // withSingleLiveCode makes this true rather than merely tidy: a second
+    // request deletes the first code, and someone holding both emails needs
+    // to know which one still works.
+    it("says a new code replaces the one already sent", async () => {
+      await renderPage();
+
+      expect(screen.getByText(/replaces the one we already sent/i)).toBeInTheDocument();
     });
   });
 

--- a/src/app/signin/check-email/page.tsx
+++ b/src/app/signin/check-email/page.tsx
@@ -2,7 +2,6 @@ import { cookies } from "next/headers";
 import Link from "next/link";
 
 import { PageContainer } from "@/components/layout/PageContainer";
-import { SubmitButton } from "@/components/SubmitButton";
 import {
   Card,
   CardContent,
@@ -10,22 +9,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { messageFor, messageTable } from "@/lib/error-messages";
-import {
-  PENDING_SIGNIN_COOKIE_NAMES,
-  parsePendingSignIn,
-} from "@/lib/pending-signin-cookie";
+import { messageFor } from "@/lib/error-messages";
+import { readPendingSignIn } from "@/lib/pending-signin-cookie";
 
-import { submitSignInCode } from "../actions";
+import { CODE_ENTRY_MESSAGES } from "../signin-messages";
+import { CodeEntryForm } from "./CodeEntryForm";
 
 export const metadata = {
   title: "Enter your code — Youth Baseball Team Manager",
 };
-
-const ERROR_MESSAGES = messageTable({
-  "invalid-code":
-    "That doesn't look like a code — it's 8 letters and numbers, like K3M7-QP2X.",
-});
 
 /// Where every sign-in attempt lands, invited or not — now as the code-entry
 /// form (#60). The wording deliberately stops short of promising that an
@@ -36,20 +28,21 @@ const ERROR_MESSAGES = messageTable({
 ///
 /// The pending cookie expires with the code, so a stale tab or a direct visit
 /// gets the start-over card instead of a form whose submission can only fail.
+///
+/// `?error=` here is only ever `wrong-code`, put there by `/signin` when
+/// Auth.js rejects a redeem while this cookie is still live. A mistyped code
+/// never reaches the query string at all — the form owns that failure and
+/// keeps the characters (see `CodeEntryForm`).
 export default async function CheckEmailPage({
   searchParams,
 }: {
   searchParams: Promise<{ error?: string }>;
 }) {
   const { error } = await searchParams;
-  const errorMessage = messageFor(ERROR_MESSAGES, error);
+  const errorMessage = messageFor(CODE_ENTRY_MESSAGES, error);
 
   const cookieStore = await cookies();
-  const pending = parsePendingSignIn(
-    PENDING_SIGNIN_COOKIE_NAMES.map(
-      (name) => cookieStore.get(name)?.value,
-    ).find((value) => value !== undefined),
-  );
+  const pending = readPendingSignIn((name) => cookieStore.get(name)?.value);
 
   if (!pending) {
     return (
@@ -93,51 +86,7 @@ export default async function CheckEmailPage({
           </CardHeader>
 
           <CardContent>
-            <form action={submitSignInCode} className="space-y-4">
-              <div className="space-y-2">
-                <label
-                  htmlFor="code"
-                  className="block text-sm font-medium text-foreground"
-                >
-                  Sign-in code
-                </label>
-                <input
-                  id="code"
-                  name="code"
-                  type="text"
-                  // The one autofill hint that matters: on a phone the code
-                  // arrives as a notification, and this lets the keyboard
-                  // offer it without a trip to the mail app.
-                  autoComplete="one-time-code"
-                  autoCapitalize="characters"
-                  autoCorrect="off"
-                  spellCheck={false}
-                  required
-                  maxLength={12}
-                  placeholder="K3M7-QP2X"
-                  aria-describedby={errorMessage ? "code-error" : undefined}
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-lg tracking-widest text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                />
-                {errorMessage ? (
-                  <p
-                    id="code-error"
-                    role="alert"
-                    className="text-sm text-destructive"
-                  >
-                    {errorMessage}
-                  </p>
-                ) : null}
-              </div>
-
-              {/* This screen's one banana (design-plan.md §2), matching the
-                  request form it follows. */}
-              <SubmitButton
-                className="w-full bg-banana text-banana-foreground hover:bg-banana/90"
-                pendingLabel="Signing you in…"
-              >
-                Sign in
-              </SubmitButton>
-            </form>
+            <CodeEntryForm serverMessage={errorMessage} />
           </CardContent>
         </Card>
 
@@ -150,7 +99,8 @@ export default async function CheckEmailPage({
           <p>
             <Link href="/signin" className="font-medium text-primary underline">
               Use a different address
-            </Link>
+            </Link>{" "}
+            — asking for a new code replaces the one we already sent.
           </p>
         </div>
       </div>

--- a/src/app/signin/check-email/page.tsx
+++ b/src/app/signin/check-email/page.tsx
@@ -1,6 +1,8 @@
+import { cookies } from "next/headers";
 import Link from "next/link";
 
 import { PageContainer } from "@/components/layout/PageContainer";
+import { SubmitButton } from "@/components/SubmitButton";
 import {
   Card,
   CardContent,
@@ -8,16 +10,76 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { messageFor, messageTable } from "@/lib/error-messages";
+import {
+  PENDING_SIGNIN_COOKIE_NAMES,
+  parsePendingSignIn,
+} from "@/lib/pending-signin-cookie";
+
+import { submitSignInCode } from "../actions";
 
 export const metadata = {
-  title: "Check your email — Youth Baseball Team Manager",
+  title: "Enter your code — Youth Baseball Team Manager",
 };
 
-/// Where every sign-in attempt lands, invited or not. The wording deliberately
-/// stops short of promising that an email was sent: for an address with no
-/// invitation, none was. Saying otherwise here would give away who is on a team
-/// to anyone willing to type addresses into the form.
-export default function CheckEmailPage() {
+const ERROR_MESSAGES = messageTable({
+  "invalid-code":
+    "That doesn't look like a code — it's 8 letters and numbers, like K3M7-QP2X.",
+});
+
+/// Where every sign-in attempt lands, invited or not — now as the code-entry
+/// form (#60). The wording deliberately stops short of promising that an
+/// email was sent: for an address with no invitation, none was. Saying
+/// otherwise here would give away who is on a team to anyone willing to type
+/// addresses into the form. The address shown back is the one the person just
+/// typed, so echoing it reveals nothing either.
+///
+/// The pending cookie expires with the code, so a stale tab or a direct visit
+/// gets the start-over card instead of a form whose submission can only fail.
+export default async function CheckEmailPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+  const errorMessage = messageFor(ERROR_MESSAGES, error);
+
+  const cookieStore = await cookies();
+  const pending = parsePendingSignIn(
+    PENDING_SIGNIN_COOKIE_NAMES.map(
+      (name) => cookieStore.get(name)?.value,
+    ).find((value) => value !== undefined),
+  );
+
+  if (!pending) {
+    return (
+      <PageContainer>
+        <div className="mx-auto w-full max-w-md">
+          <Card>
+            <CardHeader>
+              <CardTitle>Ask for a new code</CardTitle>
+              <CardDescription>
+                Sign-in codes only last ten minutes, and this one&apos;s window
+                has closed.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              <p>
+                <Link
+                  href="/signin"
+                  className="font-medium text-primary underline"
+                >
+                  Enter your email
+                </Link>{" "}
+                and we&apos;ll send a fresh one.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </PageContainer>
+    );
+  }
+
   return (
     <PageContainer>
       <div className="mx-auto w-full max-w-md">
@@ -25,27 +87,72 @@ export default function CheckEmailPage() {
           <CardHeader>
             <CardTitle>Check your email</CardTitle>
             <CardDescription>
-              If that address is on a team, a sign-in link is on its way. It
-              works once and expires after a day.
+              If {pending.email} is on a team, a sign-in code is on its way.
+              Type it below — it works once and expires in ten minutes.
             </CardDescription>
           </CardHeader>
 
-          <CardContent className="space-y-4 text-sm text-muted-foreground">
-            <p>
-              Nothing after a few minutes? Check your spam folder, then make
-              sure you used the same address your coach has for you.
-            </p>
-            <p>
-              Still nothing — ask your coach to check the address on your team
-              and send the invite again.
-            </p>
-            <p>
-              <Link href="/signin" className="font-medium text-primary underline">
-                Try a different address
-              </Link>
-            </p>
+          <CardContent>
+            <form action={submitSignInCode} className="space-y-4">
+              <div className="space-y-2">
+                <label
+                  htmlFor="code"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  Sign-in code
+                </label>
+                <input
+                  id="code"
+                  name="code"
+                  type="text"
+                  // The one autofill hint that matters: on a phone the code
+                  // arrives as a notification, and this lets the keyboard
+                  // offer it without a trip to the mail app.
+                  autoComplete="one-time-code"
+                  autoCapitalize="characters"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  required
+                  maxLength={12}
+                  placeholder="K3M7-QP2X"
+                  aria-describedby={errorMessage ? "code-error" : undefined}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-lg tracking-widest text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+                {errorMessage ? (
+                  <p
+                    id="code-error"
+                    role="alert"
+                    className="text-sm text-destructive"
+                  >
+                    {errorMessage}
+                  </p>
+                ) : null}
+              </div>
+
+              {/* This screen's one banana (design-plan.md §2), matching the
+                  request form it follows. */}
+              <SubmitButton
+                className="w-full bg-banana text-banana-foreground hover:bg-banana/90"
+                pendingLabel="Signing you in…"
+              >
+                Sign in
+              </SubmitButton>
+            </form>
           </CardContent>
         </Card>
+
+        <div className="mt-6 space-y-2 text-center text-sm text-muted-foreground">
+          <p>
+            Capitals don&apos;t matter, and neither does the dash. Nothing
+            after a few minutes? Check your spam folder, then make sure you
+            used the same address your coach has for you.
+          </p>
+          <p>
+            <Link href="/signin" className="font-medium text-primary underline">
+              Use a different address
+            </Link>
+          </p>
+        </div>
       </div>
     </PageContainer>
   );

--- a/src/app/signin/page.test.tsx
+++ b/src/app/signin/page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 // The real action pulls in Auth.js and the Prisma client; the page only needs
@@ -7,7 +7,34 @@ vi.mock("./actions", () => ({
   requestSignInCode: vi.fn(),
 }));
 
+const cookieGet = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: (...args: unknown[]) => cookieGet(...args) }),
+}));
+
+// redirect() throws in Next; reproduce that so a "bounced" assertion cannot
+// pass by accident.
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  },
+}));
+
 import SignInPage from "./page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cookieGet.mockReturnValue(undefined);
+});
+
+function pendingCookie() {
+  cookieGet.mockImplementation((name: string) =>
+    name === "__Secure-pending-signin"
+      ? { value: JSON.stringify({ email: "a@b.com", callbackUrl: "/" }) }
+      : undefined,
+  );
+}
 
 async function renderPage(
   searchParams: { error?: string; callbackUrl?: string } = {},
@@ -116,6 +143,37 @@ describe("SignInPage", () => {
         "aria-describedby",
         "email-error",
       );
+    });
+  });
+
+  // A wrong-but-well-formed code fails inside Auth.js, which has only this
+  // page to fail to. While the pending cookie is alive the mailed code is
+  // too, so the parent is sent back to retype it rather than being told to
+  // ask for a second email.
+  describe("a failed redeem with a live pending sign-in", () => {
+    it("bounces back to the code form", async () => {
+      pendingCookie();
+
+      await expect(renderPage({ error: "Verification" })).rejects.toThrow(
+        "NEXT_REDIRECT:/signin/check-email?error=wrong-code",
+      );
+    });
+
+    it("stays here when there is no pending sign-in left", async () => {
+      await renderPage({ error: "Verification" });
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /didn't match or has expired/i,
+      );
+    });
+
+    // The gate refused the address; retyping the code cannot change that.
+    it("does not bounce a denied address", async () => {
+      pendingCookie();
+
+      await renderPage({ error: "AccessDenied" });
+
+      expect(screen.getByRole("alert")).toHaveTextContent(/no longer valid/i);
     });
   });
 

--- a/src/app/signin/page.test.tsx
+++ b/src/app/signin/page.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 // The real action pulls in Auth.js and the Prisma client; the page only needs
 // something form-shaped to point at.
 vi.mock("./actions", () => ({
-  requestSignInLink: vi.fn(),
+  requestSignInCode: vi.fn(),
 }));
 
 import SignInPage from "./page";
@@ -21,7 +21,7 @@ describe("SignInPage", () => {
 
     expect(screen.getByLabelText("Email")).toHaveAttribute("type", "email");
     expect(
-      screen.getByRole("button", { name: /email me a sign-in link/i }),
+      screen.getByRole("button", { name: /email me a sign-in code/i }),
     ).toBeInTheDocument();
   });
 
@@ -66,15 +66,23 @@ describe("SignInPage", () => {
   // pages.error points here, so Auth.js's own error screen never renders and
   // its copy has to be reproduced. A silent form is the bug these cover.
   describe("Auth.js error codes", () => {
-    it("explains an expired or already-used link", async () => {
+    it("explains a wrong or expired code", async () => {
       await renderPage({ error: "Verification" });
 
       expect(screen.getByRole("alert")).toHaveTextContent(
-        /expired or was already used/i,
+        /didn't match or has expired/i,
       );
     });
 
-    it("explains a denied link without naming the reason", async () => {
+    it("explains a vanished pending cookie as an expired code", async () => {
+      // submitSignInCode's own key: the pending cookie and the code expire
+      // together, so no cookie means nothing left to redeem.
+      await renderPage({ error: "code-expired" });
+
+      expect(screen.getByRole("alert")).toHaveTextContent(/code has expired/i);
+    });
+
+    it("explains a denied code without naming the reason", async () => {
       await renderPage({ error: "AccessDenied" });
 
       const alert = screen.getByRole("alert");
@@ -111,7 +119,7 @@ describe("SignInPage", () => {
     });
   });
 
-  it("carries callbackUrl through the form so the link lands where the visitor was headed", async () => {
+  it("carries callbackUrl through the form so sign-in lands where the visitor was headed", async () => {
     const { container } = render(
       await SignInPage({
         searchParams: Promise.resolve({ callbackUrl: "/t/team-a/roster" }),

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,3 +1,6 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
 import { PageContainer } from "@/components/layout/PageContainer";
 import { SubmitButton } from "@/components/SubmitButton";
 import {
@@ -10,6 +13,7 @@ import {
 
 import { requestSignInCode } from "./actions";
 import { messageFor, messageTable } from "@/lib/error-messages";
+import { readPendingSignIn } from "@/lib/pending-signin-cookie";
 
 export const metadata = {
   title: "Sign in — Youth Baseball Team Manager",
@@ -24,6 +28,10 @@ export const metadata = {
 /// /signin/check-email — but naming the reason would still leak whether an
 /// invitation exists, so both get the neutral wording. `code-expired` is this
 /// app's own key, set by `submitSignInCode` when the pending cookie is gone.
+///
+/// `Verification` keeps its wording for the case where the code really is
+/// spent, but most arrivals never see it: with a live pending cookie the
+/// loader below sends them back to the entry form instead.
 const ERROR_MESSAGES = messageTable({
   "invalid-email":
     "That doesn't look like an email address — check it and try again.",
@@ -46,6 +54,24 @@ export default async function SignInPage({
   searchParams: Promise<{ error?: string; callbackUrl?: string }>;
 }) {
   const { error, callbackUrl } = await searchParams;
+
+  // A wrong-but-well-formed code lands here, because `pages.error` is global
+  // and Auth.js has nowhere else to send a failed redeem. Bouncing it back to
+  // the entry form is the difference between "type that again" and "we have
+  // thrown away the code you were holding, ask for another email" — the
+  // mailed code and this cookie expire together, so a live cookie means there
+  // is still something worth retyping.
+  //
+  // Only `Verification`. `AccessDenied` means the gate refused the address,
+  // and no amount of retyping changes that.
+  if (error === "Verification") {
+    const cookieStore = await cookies();
+    const pending = readPendingSignIn((name) => cookieStore.get(name)?.value);
+
+    if (pending) {
+      redirect("/signin/check-email?error=wrong-code");
+    }
+  }
 
   const errorMessage = messageFor(ERROR_MESSAGES, error, FALLBACK_ERROR_MESSAGE);
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -8,7 +8,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-import { requestSignInLink } from "./actions";
+import { requestSignInCode } from "./actions";
 import { messageFor, messageTable } from "@/lib/error-messages";
 
 export const metadata = {
@@ -17,19 +17,22 @@ export const metadata = {
 
 /// `pages.error` points at this page, so Auth.js's own error screen never
 /// renders and its copy has to live here instead. Without this map a parent
-/// whose link expired lands on a bare form with no idea what went wrong.
+/// whose code expired lands on a bare form with no idea what went wrong.
 ///
-/// The two link failures say the same thing on purpose. AccessDenied only
-/// reaches this page from a click — the send path always ends on
+/// The two code failures say the same thing on purpose. AccessDenied only
+/// reaches this page from a redeem — the send path always ends on
 /// /signin/check-email — but naming the reason would still leak whether an
-/// invitation exists, so both get the neutral wording.
+/// invitation exists, so both get the neutral wording. `code-expired` is this
+/// app's own key, set by `submitSignInCode` when the pending cookie is gone.
 const ERROR_MESSAGES = messageTable({
   "invalid-email":
     "That doesn't look like an email address — check it and try again.",
+  "code-expired":
+    "That sign-in code has expired. Enter your email and we'll send a fresh one.",
   Verification:
-    "That sign-in link has expired or was already used. Enter your email and we'll send a fresh one.",
+    "That sign-in code didn't match or has expired. Enter your email and we'll send a fresh one.",
   AccessDenied:
-    "That sign-in link is no longer valid. Enter your email to try again, or ask your coach to send a new invite.",
+    "That sign-in code is no longer valid. Enter your email to try again, or ask your coach to send a new invite.",
   Configuration:
     "Something is wrong on our end, and it has been logged. Please try again in a few minutes.",
 });
@@ -53,13 +56,13 @@ export default async function SignInPage({
           <CardHeader>
             <CardTitle>Sign in</CardTitle>
             <CardDescription>
-              Enter your email and we&apos;ll send you a link that signs you in.
+              Enter your email and we&apos;ll send you a code that signs you in.
               No password to remember at the field.
             </CardDescription>
           </CardHeader>
 
           <CardContent>
-            <form action={requestSignInLink} className="space-y-4">
+            <form action={requestSignInCode} className="space-y-4">
               <input type="hidden" name="callbackUrl" value={callbackUrl ?? "/"} />
 
               <div className="space-y-2">
@@ -91,16 +94,16 @@ export default async function SignInPage({
               {/* This screen's one banana (design-plan.md §2). */}
               <SubmitButton
                 className="w-full bg-banana text-banana-foreground hover:bg-banana/90"
-                pendingLabel="Sending the link…"
+                pendingLabel="Sending the code…"
               >
-                Email me a sign-in link
+                Email me a sign-in code
               </SubmitButton>
             </form>
           </CardContent>
         </Card>
 
         <p className="mt-6 text-center text-sm text-muted-foreground">
-          This app is invite-only. Your coach adds you to a team, and the link
+          This app is invite-only. Your coach adds you to a team, and the code
           arrives at the address they used.
         </p>
       </div>

--- a/src/app/signin/signin-messages.ts
+++ b/src/app/signin/signin-messages.ts
@@ -1,0 +1,18 @@
+import { messageTable } from "@/lib/error-messages";
+
+/// What the code-entry screen says when a code does not go through.
+///
+/// Shared by the form (which gets a typed state back from the action) and by
+/// the page (which gets `?error=wrong-code` after Auth.js rejects a redeem),
+/// so the same failure reads the same way whichever route it arrives by.
+/// Same reasoning as `roster-messages.ts`.
+export const CODE_ENTRY_MESSAGES = messageTable({
+  "invalid-code":
+    "That doesn't look like a code — it's 8 letters and numbers, like K3M7-QP2X.",
+  // Deliberately says the mailed code still works: Auth.js's `Verification`
+  // covers "wrong" and "expired" alike, and this message is only ever shown
+  // while the pending cookie — which expires with the code — is still alive.
+  // Sending someone back to request a second email is the waste this avoids.
+  "wrong-code":
+    "That code didn't match. Check it and type it again — the code we emailed you still works.",
+});

--- a/src/app/t/[teamId]/members/page.tsx
+++ b/src/app/t/[teamId]/members/page.tsx
@@ -323,7 +323,7 @@ export default async function MembersPage({
         <CardHeader>
           <CardTitle className="text-lg">Invite someone</CardTitle>
           <CardDescription>
-            Coaches and parents both receive the same one-time sign-in link.
+            Coaches and parents both receive the same one-time invitation link.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth from "next-auth";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 
+import { withSingleLiveCode } from "@/lib/auth-adapter";
 import { db } from "@/lib/db";
 import { acceptInvitations, loadSignInContext } from "@/lib/invitations";
 import { resendProvider } from "@/lib/resend-provider";
@@ -33,7 +34,10 @@ import {
 /// actually fires, which is only the "request a sign-in code" step of sign-in.
 
 export const { handlers, auth, signIn, signOut } = NextAuth(() => ({
-  adapter: PrismaAdapter(db),
+  // Wrapped so requesting a code invalidates the address's previous one. The
+  // 40-bit code assumes exactly one live code per address; the table's unique
+  // indexes do not provide that on their own. See lib/auth-adapter.ts.
+  adapter: withSingleLiveCode(PrismaAdapter(db)),
 
   providers: [resendProvider()],
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,7 +10,13 @@ import {
   SESSION_UPDATE_AGE_SECONDS,
 } from "@/lib/sessions";
 
-/// Auth.js v5 — magic link only, gated by the Invitation table.
+/// Auth.js v5 — emailed sign-in codes only, gated by the Invitation table.
+///
+/// The email provider's token is a typed code rather than a tappable link
+/// (#60): see resendProvider(), which supplies `generateVerificationToken`
+/// and replaces the send. Everything here — the gate, the events, sessions —
+/// is unchanged by that, because a typed code redeems through the same
+/// /api/auth/callback/resend?token=&email= the link carried.
 ///
 /// This file is deliberately thin. Every decision worth asserting lives in a pure
 /// module (owner.ts, signin-gate.ts) that tests without a database; what remains
@@ -24,7 +30,7 @@ import {
 /// not just a sign-in attempt — including a signed-out visitor on the marketing
 /// page, who triggers no email at all. resendProvider() (src/lib/resend-provider.ts)
 /// pushes that check one level further in, to the moment sendVerificationRequest
-/// actually fires, which is only the "request a magic link" step of sign-in.
+/// actually fires, which is only the "request a sign-in code" step of sign-in.
 
 export const { handlers, auth, signIn, signOut } = NextAuth(() => ({
   adapter: PrismaAdapter(db),
@@ -44,16 +50,18 @@ export const { handlers, auth, signIn, signOut } = NextAuth(() => ({
   },
 
   // No `cookies` block on purpose. The Auth.js defaults are httpOnly and
-  // sameSite "lax", and lax is load-bearing twice over: a magic link clicked in
-  // an email client is a cross-site top-level navigation that "strict" would
-  // silently drop, and same-origin service worker fetches need the cookie too.
+  // sameSite "lax", and lax is load-bearing twice over: an invitation link
+  // clicked in an email client is a cross-site top-level navigation that
+  // "strict" would silently drop, and same-origin service worker fetches need
+  // the cookie too.
 
   callbacks: {
     /**
-     * The gate. This runs twice per sign-in: once when the link is requested
-     * (`email.verificationRequest`) and again when it is clicked. Rejecting on
-     * the first pass means an uninvited address never receives mail at all;
-     * rejecting on the second covers an invitation that expired in between.
+     * The gate. This runs twice per sign-in: once when the code is requested
+     * (`email.verificationRequest`) and again when it is redeemed. Rejecting
+     * on the first pass means an uninvited address never receives mail at
+     * all; rejecting on the second covers an invitation that expired in
+     * between.
      */
     async signIn({ user, email }) {
       const address = user.email;
@@ -61,7 +69,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth(() => ({
         return false;
       }
 
-      const stage = email?.verificationRequest ? "link request" : "link click";
+      const stage = email?.verificationRequest ? "code request" : "code redeem";
 
       try {
         const context = await loadSignInContext(address);
@@ -94,10 +102,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth(() => ({
 
   events: {
     /**
-     * Turn accepted invitations into team access. This fires only after a link
-     * is actually clicked and the session exists — doing it in the signIn
-     * callback instead would grant memberships to anyone who typed an address
-     * into the form, since that callback also runs on the send path.
+     * Turn accepted invitations into team access. This fires only after a
+     * code is actually redeemed and the session exists — doing it in the
+     * signIn callback instead would grant memberships to anyone who typed an
+     * address into the form, since that callback also runs on the send path.
      */
     async signIn({ user }) {
       if (!user.id || !user.email) {

--- a/src/emails/SignInCodeEmail.tsx
+++ b/src/emails/SignInCodeEmail.tsx
@@ -1,0 +1,55 @@
+import {
+  Body,
+  Container,
+  Head,
+  Html,
+  Preview,
+  Text,
+} from "@react-email/components";
+
+/// The sign-in code email — what `/signin` sends instead of a magic link
+/// (#60). Deliberately nothing to tap: a link would be redeemed by whichever
+/// browser the OS hands it to, which on a phone is routinely not the
+/// container the person requested it from. The code is read here and typed
+/// there, so it is large, monospaced, and the first thing in the body.
+
+export type SignInCodeEmailProps = {
+  /// Display form, e.g. "K3M7-QP2X" — the entry form strips the dash.
+  formattedCode: string;
+  expiresMinutes: number;
+};
+
+export function SignInCodeEmail({
+  formattedCode,
+  expiresMinutes,
+}: SignInCodeEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your sign-in code is {formattedCode}</Preview>
+      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
+        <Container>
+          <Text>Type this code into the sign-in screen:</Text>
+          <Text
+            style={{
+              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+              fontSize: "32px",
+              fontWeight: 700,
+              letterSpacing: "4px",
+            }}
+          >
+            {formattedCode}
+          </Text>
+          <Text>
+            It works once and expires in {expiresMinutes} minutes. Capitals
+            don&apos;t matter, and neither does the dash.
+          </Text>
+          <Text>
+            If you didn&apos;t ask for this code, you can ignore this email —
+            nothing happens without it.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/src/emails/signin-code-email.test.ts
+++ b/src/emails/signin-code-email.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSignInCodeEmail } from "./signin-code-email";
+
+describe("buildSignInCodeEmail", () => {
+  it("leads the subject with the display form of the code", () => {
+    // The code is in the subject so it shows in the notification shade — a
+    // parent reads it there and types it without leaving the app.
+    const { subject } = buildSignInCodeEmail({ code: "K3M7QP2X" });
+
+    expect(subject).toBe("K3M7-QP2X is your sign-in code");
+  });
+
+  it("formats the code split in half with a dash", () => {
+    expect(buildSignInCodeEmail({ code: "K3M7QP2X" }).formattedCode).toBe(
+      "K3M7-QP2X",
+    );
+  });
+
+  it("states the expiry in minutes, matching the token maxAge", () => {
+    expect(buildSignInCodeEmail({ code: "K3M7QP2X" }).expiresMinutes).toBe(10);
+  });
+});

--- a/src/emails/signin-code-email.ts
+++ b/src/emails/signin-code-email.ts
@@ -1,0 +1,36 @@
+import {
+  SIGNIN_CODE_MAX_AGE_SECONDS,
+  formatSignInCode,
+} from "@/lib/signin-code";
+
+/// Pure — builds the subject and display form of a sign-in code email without
+/// touching Resend or React Email, matching every other builder in this
+/// directory.
+///
+/// The code goes in the subject on purpose: it shows in the notification
+/// shade, so a parent can read it there and type it into the app without ever
+/// leaving it — the exact screen-to-screen trip this email exists for. The
+/// exposure is a ten-minute, single-purpose credential on a surface that
+/// already implies possession of the inbox.
+
+export type BuildSignInCodeEmailInput = {
+  /// Canonical form, exactly as generated — formatting is this builder's job.
+  code: string;
+};
+
+export type SignInCodeEmailContent = {
+  subject: string;
+  formattedCode: string;
+  expiresMinutes: number;
+};
+
+export function buildSignInCodeEmail({
+  code,
+}: BuildSignInCodeEmailInput): SignInCodeEmailContent {
+  const formattedCode = formatSignInCode(code);
+  return {
+    subject: `${formattedCode} is your sign-in code`,
+    formattedCode,
+    expiresMinutes: Math.round(SIGNIN_CODE_MAX_AGE_SECONDS / 60),
+  };
+}

--- a/src/lib/auth-adapter.test.ts
+++ b/src/lib/auth-adapter.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Adapter } from "next-auth/adapters";
+
+import { withSingleLiveCode } from "./auth-adapter";
+
+function fakeAdapter(overrides: Partial<Adapter> = {}): Adapter {
+  return {
+    createVerificationToken: vi.fn(async (token) => token),
+    ...overrides,
+  } as Adapter;
+}
+
+const TOKEN = {
+  identifier: "parent@example.com",
+  token: "hashed",
+  expires: new Date("2026-08-28T12:10:00Z"),
+};
+
+describe("withSingleLiveCode", () => {
+  it("prunes the address's other codes before minting one", async () => {
+    const order: string[] = [];
+    const prune = vi.fn(async () => {
+      order.push("prune");
+    });
+    const base = fakeAdapter({
+      createVerificationToken: vi.fn(async (token) => {
+        order.push("create");
+        return token;
+      }),
+    });
+
+    await withSingleLiveCode(base, prune).createVerificationToken?.(TOKEN);
+
+    expect(prune).toHaveBeenCalledWith("parent@example.com");
+    // Order is the whole point: pruning after the create would delete the
+    // code that was just handed to the person.
+    expect(order).toEqual(["prune", "create"]);
+  });
+
+  it("returns whatever the wrapped adapter returns", async () => {
+    const wrapped = withSingleLiveCode(fakeAdapter(), async () => {});
+
+    await expect(wrapped.createVerificationToken?.(TOKEN)).resolves.toEqual(
+      TOKEN,
+    );
+  });
+
+  // A prune failure means the database is unreachable, and the create is about
+  // to hit it too. Failing loudly beats quietly leaving the extra live codes
+  // this wrapper exists to remove.
+  it("does not mint a code when the prune fails", async () => {
+    const base = fakeAdapter();
+    const wrapped = withSingleLiveCode(base, async () => {
+      throw new Error("connection lost");
+    });
+
+    await expect(wrapped.createVerificationToken?.(TOKEN)).rejects.toThrow(
+      "connection lost",
+    );
+    expect(base.createVerificationToken).not.toHaveBeenCalled();
+  });
+
+  it("leaves the rest of the adapter alone", async () => {
+    const getUserByEmail = vi.fn();
+    const base = fakeAdapter({ getUserByEmail });
+
+    expect(withSingleLiveCode(base, async () => {}).getUserByEmail).toBe(
+      getUserByEmail,
+    );
+  });
+
+  it("passes an adapter that cannot mint tokens straight through", () => {
+    const base = { getUserByEmail: vi.fn() } as unknown as Adapter;
+
+    expect(withSingleLiveCode(base, async () => {})).toBe(base);
+  });
+});

--- a/src/lib/auth-adapter.test.ts
+++ b/src/lib/auth-adapter.test.ts
@@ -34,6 +34,11 @@ describe("withSingleLiveCode", () => {
     expect(prune).toHaveBeenCalledWith("parent@example.com");
     // Order is the whole point: pruning after the create would delete the
     // code that was just handed to the person.
+    //
+    // This is the *sequential* guarantee, which is all two statements can
+    // give. Two requests that interleave between the prune and the create
+    // both survive — see #81 and the note in auth-adapter.ts for why the
+    // fixes that fit in this wrapper are worse than the gap.
     expect(order).toEqual(["prune", "create"]);
   });
 

--- a/src/lib/auth-adapter.ts
+++ b/src/lib/auth-adapter.ts
@@ -1,0 +1,70 @@
+import type { Adapter, VerificationToken } from "next-auth/adapters";
+
+import { db } from "./db";
+
+/// One live sign-in code per address, enforced at the adapter.
+///
+/// `VerificationToken` is unique on `(identifier, token)` and on `token`, but
+/// **not** on `identifier` alone, so every `/signin` POST used to mint another
+/// live row for the same address — and `@auth/core`'s `sendToken` starts that
+/// write beside the send, so even a send that fails leaves the code behind.
+/// Codes therefore accumulated, and the security argument for an 8-character
+/// code does not survive that: 40 bits is out of reach for online guessing
+/// against *one* live code in a ten-minute window, and there is no attempt
+/// counter to lean on (adding one needs a migration — see `signin-code.ts`).
+/// N live codes divide the work by N, and N was unbounded by anything but how
+/// many times someone could press the button.
+///
+/// So the wrapper prunes before it creates. A person who asks for a second
+/// code invalidates their first, which is also what the wording on
+/// `/signin/check-email` implies.
+///
+/// The other side of that: anyone who can make the app send to an address can
+/// invalidate the code outstanding for it. That grants nothing new — the same
+/// request already mailed that address, and the gate still refuses anyone who
+/// is not invited — and the newest email is always the live code, which is the
+/// behaviour people already expect from a resend.
+///
+/// It wraps rather than replaces the Prisma adapter because everything else
+/// about that adapter is right; this is the one method whose default
+/// behaviour the code flow cannot use as-is.
+///
+/// The `next-auth/adapters` import is `import type`, so it is erased before
+/// anything runs — which is what keeps it clear of the rule in
+/// `resend-provider.ts` against pulling next-auth's main entry into a module
+/// Vitest has to load.
+
+export type PruneCodes = (identifier: string) => Promise<unknown>;
+
+async function pruneCodesInDatabase(identifier: string) {
+  return db.verificationToken.deleteMany({ where: { identifier } });
+}
+
+/**
+ * Wrap an adapter so creating a verification token first deletes every other
+ * token held for that identifier.
+ *
+ * A prune failure is deliberately not swallowed: it is a database failure, and
+ * `createVerificationToken` is about to hit the same database anyway. Letting
+ * it throw fails the sign-in loudly rather than quietly widening the guessing
+ * surface it exists to close.
+ */
+export function withSingleLiveCode(
+  adapter: Adapter,
+  prune: PruneCodes = pruneCodesInDatabase,
+): Adapter {
+  const create = adapter.createVerificationToken;
+
+  // Nothing to guard if the adapter cannot mint tokens at all.
+  if (!create) {
+    return adapter;
+  }
+
+  return {
+    ...adapter,
+    async createVerificationToken(token: VerificationToken) {
+      await prune(token.identifier);
+      return create.call(adapter, token);
+    },
+  };
+}

--- a/src/lib/auth-adapter.ts
+++ b/src/lib/auth-adapter.ts
@@ -2,7 +2,7 @@ import type { Adapter, VerificationToken } from "next-auth/adapters";
 
 import { db } from "./db";
 
-/// One live sign-in code per address, enforced at the adapter.
+/// One live sign-in code per address — as far as two statements can manage.
 ///
 /// `VerificationToken` is unique on `(identifier, token)` and on `token`, but
 /// **not** on `identifier` alone, so every `/signin` POST used to mint another
@@ -18,6 +18,22 @@ import { db } from "./db";
 /// So the wrapper prunes before it creates. A person who asks for a second
 /// code invalidates their first, which is also what the wording on
 /// `/signin/check-email` implies.
+///
+/// **Sequential requests, not concurrent ones.** Prune-then-create is two
+/// statements, so `A.prune → B.prune → A.create → B.create` leaves both codes
+/// live. That is knowingly left open (#81), and the reason it is not patched
+/// here is that every available patch is worse. Pruning again *after* the
+/// create, excluding one's own token, has an interleaving that deletes both
+/// rows and leaves **zero** working codes — and `sendToken` runs
+/// `Promise.all([sendRequest, createToken])`, so both people have already been
+/// mailed a code by then. A transaction does not help either: at Postgres
+/// READ COMMITTED neither sees the other's uncommitted insert. The honest fix
+/// is a unique index on `identifier` and an upsert, which needs a migration.
+///
+/// What is left is bounded by *overlap* rather than by request count — the
+/// milliseconds between the two statements — where the unguarded version grew
+/// N with every request across the whole ten-minute window, no concurrency
+/// needed. See `signin-code.ts` for what N costs the entropy argument.
 ///
 /// The other side of that: anyone who can make the app send to an address can
 /// invalidate the code outstanding for it. That grants nothing new — the same
@@ -42,7 +58,8 @@ async function pruneCodesInDatabase(identifier: string) {
 
 /**
  * Wrap an adapter so creating a verification token first deletes every other
- * token held for that identifier.
+ * token held for that identifier. Read the note above on what that does and
+ * does not guarantee before relying on it.
  *
  * A prune failure is deliberately not swallowed: it is a database failure, and
  * `createVerificationToken` is about to hit the same database anyway. Letting

--- a/src/lib/pending-signin-cookie.test.ts
+++ b/src/lib/pending-signin-cookie.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PENDING_SIGNIN_COOKIE_NAMES,
+  normalizeSignInEmail,
+  parsePendingSignIn,
+  pendingSignInCookieName,
+  pendingSignInCookieOptions,
+  serializePendingSignIn,
+} from "./pending-signin-cookie";
+import { SIGNIN_CODE_MAX_AGE_SECONDS } from "./signin-code";
+
+describe("pendingSignInCookieName", () => {
+  it("applies the __Secure- prefix exactly when secure", () => {
+    expect(pendingSignInCookieName(true)).toBe("__Secure-pending-signin");
+    expect(pendingSignInCookieName(false)).toBe("pending-signin");
+  });
+
+  it("both spellings are listed for reading", () => {
+    expect(PENDING_SIGNIN_COOKIE_NAMES).toContain(pendingSignInCookieName(true));
+    expect(PENDING_SIGNIN_COOKIE_NAMES).toContain(
+      pendingSignInCookieName(false),
+    );
+  });
+});
+
+describe("pendingSignInCookieOptions", () => {
+  it("is httpOnly, lax, scoped to /signin, and dies with the code", () => {
+    expect(pendingSignInCookieOptions(true)).toEqual({
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/signin",
+      secure: true,
+      maxAge: SIGNIN_CODE_MAX_AGE_SECONDS,
+    });
+  });
+
+  it("carries the secure flag through", () => {
+    expect(pendingSignInCookieOptions(false).secure).toBe(false);
+  });
+});
+
+describe("normalizeSignInEmail", () => {
+  // Mirrors @auth/core's defaultNormalizer: the cookie must hold the same
+  // spelling Auth.js stores the verification token under.
+  it("lowercases, trims, and NFKC-normalizes", () => {
+    expect(normalizeSignInEmail("  Parent@Example.COM ")).toBe(
+      "parent@example.com",
+    );
+    // U+FF20 FULLWIDTH COMMERCIAL AT normalizes to a real @.
+    expect(normalizeSignInEmail("a＠example.com")).toBe("a@example.com");
+  });
+});
+
+describe("serialize / parse round trip", () => {
+  it("carries email and callbackUrl through", () => {
+    const value = serializePendingSignIn({
+      email: "parent@example.com",
+      callbackUrl: "/t/team-a/roster",
+    });
+
+    expect(parsePendingSignIn(value)).toEqual({
+      email: "parent@example.com",
+      callbackUrl: "/t/team-a/roster",
+    });
+  });
+});
+
+describe("parsePendingSignIn", () => {
+  it("returns null for a missing cookie", () => {
+    expect(parsePendingSignIn(undefined)).toBeNull();
+    expect(parsePendingSignIn("")).toBeNull();
+  });
+
+  it("returns null for junk the client invented", () => {
+    expect(parsePendingSignIn("not json")).toBeNull();
+    expect(parsePendingSignIn("42")).toBeNull();
+    expect(parsePendingSignIn("null")).toBeNull();
+    expect(parsePendingSignIn('{"callbackUrl":"/"}')).toBeNull();
+    expect(parsePendingSignIn('{"email":42}')).toBeNull();
+    expect(parsePendingSignIn('{"email":"no-at-sign"}')).toBeNull();
+  });
+
+  it("re-normalizes an email that was tampered into mixed case", () => {
+    expect(
+      parsePendingSignIn('{"email":"Parent@Example.com","callbackUrl":"/"}'),
+    ).toEqual({ email: "parent@example.com", callbackUrl: "/" });
+  });
+
+  it("re-sanitizes the callbackUrl rather than trusting the write", () => {
+    for (const hostile of [
+      "https://evil.example",
+      "//evil.example",
+      "/\\evil.example",
+    ]) {
+      const parsed = parsePendingSignIn(
+        JSON.stringify({ email: "a@b.com", callbackUrl: hostile }),
+      );
+      expect(parsed?.callbackUrl).toBe("/");
+    }
+  });
+
+  it("defaults a missing callbackUrl to the landing page", () => {
+    expect(parsePendingSignIn('{"email":"a@b.com"}')?.callbackUrl).toBe("/");
+  });
+});

--- a/src/lib/pending-signin-cookie.test.ts
+++ b/src/lib/pending-signin-cookie.test.ts
@@ -6,6 +6,7 @@ import {
   parsePendingSignIn,
   pendingSignInCookieName,
   pendingSignInCookieOptions,
+  readPendingSignIn,
   serializePendingSignIn,
 } from "./pending-signin-cookie";
 import { SIGNIN_CODE_MAX_AGE_SECONDS } from "./signin-code";
@@ -102,5 +103,65 @@ describe("parsePendingSignIn", () => {
 
   it("defaults a missing callbackUrl to the landing page", () => {
     expect(parsePendingSignIn('{"email":"a@b.com"}')?.callbackUrl).toBe("/");
+  });
+});
+
+describe("readPendingSignIn", () => {
+  const live = JSON.stringify({
+    email: "parent@example.com",
+    callbackUrl: "/t/team-a",
+  });
+
+  function reader(jar: Record<string, string>) {
+    return (name: string) => jar[name];
+  }
+
+  it("reads either spelling", () => {
+    expect(readPendingSignIn(reader({ "pending-signin": live }))?.email).toBe(
+      "parent@example.com",
+    );
+    expect(
+      readPendingSignIn(reader({ "__Secure-pending-signin": live }))?.email,
+    ).toBe("parent@example.com");
+  });
+
+  it("returns null when the jar holds none", () => {
+    expect(readPendingSignIn(reader({}))).toBeNull();
+  });
+
+  // The lockout this closes: the bare name can be planted by a sibling
+  // subdomain or a plain-HTTP response, and taking the first cookie that
+  // *existed* meant that junk shadowed the real one — leaving the victim
+  // unable to sign in at all, with nothing on screen to explain it.
+  it("ignores junk in the unprefixed name and uses the real cookie", () => {
+    const pending = readPendingSignIn(
+      reader({ "pending-signin": "not json", "__Secure-pending-signin": live }),
+    );
+
+    expect(pending?.email).toBe("parent@example.com");
+  });
+
+  it("ignores an empty planted cookie", () => {
+    const pending = readPendingSignIn(
+      reader({ "pending-signin": "", "__Secure-pending-signin": live }),
+    );
+
+    expect(pending?.email).toBe("parent@example.com");
+  });
+
+  // Both parse, so ordering alone decides — and the __Secure- one is the only
+  // one an attacker on a sibling host could not have written.
+  it("prefers the __Secure- cookie when both parse", () => {
+    const pending = readPendingSignIn(
+      reader({
+        "pending-signin": JSON.stringify({
+          email: "attacker@example.com",
+          callbackUrl: "/",
+        }),
+        "__Secure-pending-signin": live,
+      }),
+    );
+
+    expect(pending?.email).toBe("parent@example.com");
   });
 });

--- a/src/lib/pending-signin-cookie.ts
+++ b/src/lib/pending-signin-cookie.ts
@@ -7,8 +7,10 @@ import { SIGNIN_CODE_MAX_AGE_SECONDS } from "./signin-code";
 /// referrers and server logs (#60).
 ///
 /// Same shape as `session-cookie.ts` and for the same reason: the attributes
-/// live in one pure module so the writer (`requestSignInLink`) and the readers
-/// (the check-email page and `submitSignInCode`) cannot drift. The `__Secure-`
+/// live in one pure module so the writer (`requestSignInCode`) and the readers
+/// (the check-email page and `submitSignInCode`) cannot drift — which is also
+/// why reading goes through `readPendingSignIn` rather than each caller
+/// picking a cookie name for itself. The `__Secure-`
 /// prefix follows `usesSecureCookies` exactly as the session cookie does.
 ///
 /// The value is client-held and therefore client-tamperable, and that is fine:
@@ -22,7 +24,16 @@ const SECURE_NAME = `__Secure-${BASE_NAME}`;
 
 /// Both spellings, for reading — which one exists depends on whether the
 /// request came in over HTTPS, same as the session cookie.
-export const PENDING_SIGNIN_COOKIE_NAMES = [BASE_NAME, SECURE_NAME] as const;
+///
+/// `__Secure-` first, and that order is load-bearing: only HTTPS can set a
+/// `__Secure-` cookie, while the bare name can be planted by any sibling
+/// subdomain or by a plain-HTTP response. Reading the bare one first let junk
+/// there shadow the real cookie — and since a cookie that fails to parse was
+/// treated as "no pending sign-in at all", that shadow locked the victim out
+/// of signing in entirely, with no diagnostic. `readPendingSignIn` closes the
+/// other half by taking the first cookie that *parses* rather than the first
+/// that exists.
+export const PENDING_SIGNIN_COOKIE_NAMES = [SECURE_NAME, BASE_NAME] as const;
 
 export function pendingSignInCookieName(secure: boolean): string {
   return secure ? SECURE_NAME : BASE_NAME;
@@ -102,4 +113,27 @@ export function parsePendingSignIn(
   } catch {
     return null;
   }
+}
+
+/**
+ * The pending sign-in, read from whichever cookie actually carries one.
+ *
+ * Callers pass their own getter (`(await cookies()).get(name)?.value` in a
+ * page, the same in an action) so this module keeps its no-dependency rule
+ * and stays testable without a request.
+ *
+ * Note "first that parses", not "first that exists" — see the ordering note
+ * on `PENDING_SIGNIN_COOKIE_NAMES` for the lockout that distinction prevents.
+ */
+export function readPendingSignIn(
+  read: (name: string) => string | undefined,
+): PendingSignIn | null {
+  for (const name of PENDING_SIGNIN_COOKIE_NAMES) {
+    const pending = parsePendingSignIn(read(name));
+    if (pending) {
+      return pending;
+    }
+  }
+
+  return null;
 }

--- a/src/lib/pending-signin-cookie.ts
+++ b/src/lib/pending-signin-cookie.ts
@@ -1,0 +1,105 @@
+import { safeCallbackUrl } from "./callback-url";
+import { SIGNIN_CODE_MAX_AGE_SECONDS } from "./signin-code";
+
+/// The address a sign-in code was just mailed to, carried from the request
+/// form to the code-entry form in a short-lived httpOnly cookie — never a
+/// query parameter, which would put someone's email address in history,
+/// referrers and server logs (#60).
+///
+/// Same shape as `session-cookie.ts` and for the same reason: the attributes
+/// live in one pure module so the writer (`requestSignInLink`) and the readers
+/// (the check-email page and `submitSignInCode`) cannot drift. The `__Secure-`
+/// prefix follows `usesSecureCookies` exactly as the session cookie does.
+///
+/// The value is client-held and therefore client-tamperable, and that is fine:
+/// a forged email only changes which identifier the typed code is verified
+/// against, and the code was hashed against that identifier's row — a
+/// mismatch fails exactly like a wrong code. The callbackUrl is re-sanitized
+/// on every parse rather than trusted from the write.
+
+const BASE_NAME = "pending-signin";
+const SECURE_NAME = `__Secure-${BASE_NAME}`;
+
+/// Both spellings, for reading — which one exists depends on whether the
+/// request came in over HTTPS, same as the session cookie.
+export const PENDING_SIGNIN_COOKIE_NAMES = [BASE_NAME, SECURE_NAME] as const;
+
+export function pendingSignInCookieName(secure: boolean): string {
+  return secure ? SECURE_NAME : BASE_NAME;
+}
+
+export type PendingSignInCookieOptions = {
+  httpOnly: true;
+  sameSite: "lax";
+  /// Scoped to the sign-in pages — nothing else reads it, so nothing else
+  /// receives it. Path-matching covers /signin/check-email.
+  path: "/signin";
+  secure: boolean;
+  maxAge: number;
+};
+
+export function pendingSignInCookieOptions(
+  secure: boolean,
+): PendingSignInCookieOptions {
+  return {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/signin",
+    secure,
+    // The cookie and the code it belongs to expire together. A stale cookie
+    // outliving the code would offer a form whose submission can only fail.
+    maxAge: SIGNIN_CODE_MAX_AGE_SECONDS,
+  };
+}
+
+export type PendingSignIn = {
+  email: string;
+  callbackUrl: string;
+};
+
+/**
+ * The identifier Auth.js will store the verification token under. Mirrors
+ * `defaultNormalizer` in `@auth/core`'s send-token step (NFKC, lowercase,
+ * trim): the callback looks the token up by identifier, so the cookie has to
+ * hold the same spelling Auth.js derived from the form value — a mixed-case
+ * address stored verbatim would make every code "wrong".
+ */
+export function normalizeSignInEmail(email: string): string {
+  return email.normalize("NFKC").toLowerCase().trim();
+}
+
+export function serializePendingSignIn(pending: PendingSignIn): string {
+  return JSON.stringify(pending);
+}
+
+export function parsePendingSignIn(
+  value: string | undefined,
+): PendingSignIn | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as { email?: unknown }).email !== "string" ||
+      !(parsed as { email: string }).email.includes("@")
+    ) {
+      return null;
+    }
+
+    const { email, callbackUrl } = parsed as {
+      email: string;
+      callbackUrl?: unknown;
+    };
+
+    return {
+      email: normalizeSignInEmail(email),
+      callbackUrl: safeCallbackUrl(callbackUrl),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/resend-provider.test.ts
+++ b/src/lib/resend-provider.test.ts
@@ -1,29 +1,38 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Only resendProvider()'s wrapping behavior is under test here — not the real
-// Resend network call. Mocking the provider factory lets us observe whether
-// sendVerificationRequest was reached without hitting the network, and keeps
-// this test from depending on next-auth's internal EmailConfig shape.
-const sendVerificationRequest = vi.fn();
+// Resend network call. Mocking the provider factory keeps this test from
+// depending on next-auth's internal EmailConfig shape, and mocking sendEmail
+// keeps the code email off the network.
+const providerSendVerificationRequest = vi.fn();
 
 vi.mock("next-auth/providers/resend", () => ({
   default: (config: { apiKey: string; from: string }) => ({
     id: "resend",
     type: "email",
     name: "Resend",
-    sendVerificationRequest,
+    sendVerificationRequest: providerSendVerificationRequest,
     options: config,
   }),
 }));
 
-import { resendProvider } from "./resend-provider";
+const sendEmail = vi.fn();
 
-const PARAMS = {} as Parameters<
-  ReturnType<typeof resendProvider>["sendVerificationRequest"]
->[0];
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: unknown[]) => sendEmail(...args),
+}));
+
+import { resendProvider } from "./resend-provider";
+import { SIGNIN_CODE_MAX_AGE_SECONDS, normalizeSignInCode } from "./signin-code";
+
+const PARAMS = {
+  identifier: "parent@example.com",
+  token: "K3M7QP2X",
+} as Parameters<ReturnType<typeof resendProvider>["sendVerificationRequest"]>[0];
 
 beforeEach(() => {
   vi.clearAllMocks();
+  sendEmail.mockResolvedValue({ ok: true });
   vi.stubEnv("RESEND_API_KEY", "re_test_key");
   vi.stubEnv("EMAIL_FROM", "coach@example.com");
 });
@@ -50,7 +59,7 @@ describe("resendProvider", () => {
     await expect(resendProvider().sendVerificationRequest(PARAMS)).rejects.toThrow(
       "RESEND_API_KEY is not set",
     );
-    expect(sendVerificationRequest).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
   });
 
   it("throws when EMAIL_FROM is unset at send time, without sending", async () => {
@@ -59,12 +68,45 @@ describe("resendProvider", () => {
     await expect(resendProvider().sendVerificationRequest(PARAMS)).rejects.toThrow(
       "EMAIL_FROM is not set",
     );
-    expect(sendVerificationRequest).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
   });
 
-  it("delegates to the real provider once both env vars are present", async () => {
+  // #60: the email is the code, and only the code. The provider's default
+  // send mails a tappable link, which is exactly the thing being removed —
+  // a link is redeemed in whichever browser the OS picks, not necessarily
+  // the container the person requested it from.
+  it("mails the typed code instead of delegating to the link email", async () => {
     await resendProvider().sendVerificationRequest(PARAMS);
 
-    expect(sendVerificationRequest).toHaveBeenCalledWith(PARAMS);
+    expect(providerSendVerificationRequest).not.toHaveBeenCalled();
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+
+    const input = sendEmail.mock.calls[0][0] as {
+      to: string;
+      subject: string;
+    };
+    expect(input.to).toBe("parent@example.com");
+    expect(input.subject).toContain("K3M7-QP2X");
+  });
+
+  it("throws when the code email fails to send", async () => {
+    sendEmail.mockResolvedValue({ ok: false, reason: "rate limited" });
+
+    await expect(resendProvider().sendVerificationRequest(PARAMS)).rejects.toThrow(
+      /failed to send/i,
+    );
+  });
+
+  it("generates verification tokens the entry form's normalizer accepts", () => {
+    const provider = resendProvider();
+    const token = provider.generateVerificationToken();
+
+    // The raw token is canonical: normalizing it is the identity, which is
+    // what lets `submitSignInCode` rebuild it from whatever the person types.
+    expect(normalizeSignInCode(token)).toBe(token);
+  });
+
+  it("expires codes on the shared ten-minute maxAge", () => {
+    expect(resendProvider().maxAge).toBe(SIGNIN_CODE_MAX_AGE_SECONDS);
   });
 });

--- a/src/lib/resend-provider.ts
+++ b/src/lib/resend-provider.ts
@@ -1,8 +1,5 @@
 import Resend from "next-auth/providers/resend";
 
-import { SignInCodeEmail } from "@/emails/SignInCodeEmail";
-import { buildSignInCodeEmail } from "@/emails/signin-code-email";
-import { sendEmail } from "@/lib/email";
 import {
   SIGNIN_CODE_MAX_AGE_SECONDS,
   generateSignInCode,
@@ -26,6 +23,15 @@ import {
 /// mails a link built from the callback URL, and there must be nothing in
 /// the email to follow — code *and* link would be the same token, so a mail
 /// scanner following the link would burn the code too.
+///
+/// The mail stack is imported **inside** the send path, not at the top of
+/// this file, and that is the same argument one level down: `src/auth.ts`
+/// imports this module, and every page calls `auth()`. Static imports of
+/// `@/lib/email` and the React Email template would therefore pull the Resend
+/// SDK and `@react-email/components` into the graph of every page render —
+/// paid on each cold start, by a signed-out visitor who triggers no email at
+/// all. `@/lib/signin-code` stays static: it is pure, tiny, and
+/// `generateVerificationToken` has to be able to return synchronously.
 ///
 /// Lives outside src/auth.ts, which is otherwise deliberately thin: this
 /// file avoids the top-level `next-auth` package import (only the
@@ -65,6 +71,13 @@ export function resendProvider() {
     ) {
       requireEnv("RESEND_API_KEY");
       requireEnv("EMAIL_FROM");
+
+      const [{ sendEmail }, { SignInCodeEmail }, { buildSignInCodeEmail }] =
+        await Promise.all([
+          import("@/lib/email"),
+          import("@/emails/SignInCodeEmail"),
+          import("@/emails/signin-code-email"),
+        ]);
 
       const content = buildSignInCodeEmail({ code: params.token });
       const result = await sendEmail({

--- a/src/lib/resend-provider.ts
+++ b/src/lib/resend-provider.ts
@@ -1,12 +1,31 @@
 import Resend from "next-auth/providers/resend";
 
+import { SignInCodeEmail } from "@/emails/SignInCodeEmail";
+import { buildSignInCodeEmail } from "@/emails/signin-code-email";
+import { sendEmail } from "@/lib/email";
+import {
+  SIGNIN_CODE_MAX_AGE_SECONDS,
+  generateSignInCode,
+} from "@/lib/signin-code";
+
 /// Wraps Auth.js's Resend provider so RESEND_API_KEY/EMAIL_FROM are demanded
-/// only when a magic-link email is actually about to be sent, not on every
+/// only when a sign-in email is actually about to be sent, not on every
 /// page view. Building the provider object is inert — Resend() just
 /// assembles config, it makes no network call — so passing possibly-empty
 /// strings is safe; sendVerificationRequest is the one place those values
 /// are read to make a request, which is why the checks live in this
 /// wrapper's send path.
+///
+/// Since #60 the email carries a **typed code, not a link**. A link is
+/// redeemed by whichever browser the OS hands it to, and an installed PWA
+/// and that browser can hold separate cookie jars (hit for real on Android;
+/// the designed-for case on iOS) — the session then lands where the app
+/// cannot read it, every time. So `generateVerificationToken` supplies the
+/// code as the verification token, `maxAge` shortens its life to match, and
+/// `sendVerificationRequest` is replaced outright: the provider's default
+/// mails a link built from the callback URL, and there must be nothing in
+/// the email to follow — code *and* link would be the same token, so a mail
+/// scanner following the link would burn the code too.
 ///
 /// Lives outside src/auth.ts, which is otherwise deliberately thin: this
 /// file avoids the top-level `next-auth` package import (only the
@@ -29,19 +48,41 @@ export function resendProvider() {
     apiKey: process.env.RESEND_API_KEY ?? "",
     // Must be explicit. The provider's default `from` is an authjs.dev address
     // that this project does not control, and mail from an unverified domain
-    // is the difference between parents seeing invitations and never finding
+    // is the difference between parents seeing sign-in codes and never finding
     // them.
     from: process.env.EMAIL_FROM ?? "",
   });
 
   return {
     ...provider,
+    // The raw token Auth.js hashes, stores, and later matches against
+    // `?token=` — which `submitSignInCode` builds from what the person typed.
+    // Canonical form (no dash); the email formats it for reading.
+    generateVerificationToken: generateSignInCode,
+    maxAge: SIGNIN_CODE_MAX_AGE_SECONDS,
     async sendVerificationRequest(
       params: Parameters<typeof provider.sendVerificationRequest>[0],
     ) {
       requireEnv("RESEND_API_KEY");
       requireEnv("EMAIL_FROM");
-      return provider.sendVerificationRequest(params);
+
+      const content = buildSignInCodeEmail({ code: params.token });
+      const result = await sendEmail({
+        to: params.identifier,
+        subject: content.subject,
+        react: SignInCodeEmail({
+          formattedCode: content.formattedCode,
+          expiresMinutes: content.expiresMinutes,
+        }),
+      });
+
+      // Throw rather than return: Auth.js treats a resolved
+      // sendVerificationRequest as "sent", and the person is about to stare
+      // at a code-entry form. The signin action catches this, logs it, and
+      // still lands on the same page — the failure posture is unchanged.
+      if (!result.ok) {
+        throw new Error(`Sign-in code email failed to send: ${result.reason}`);
+      }
     },
   };
 }

--- a/src/lib/session-cookie.ts
+++ b/src/lib/session-cookie.ts
@@ -75,10 +75,10 @@ export type SessionCookieOptions = {
 /**
  * The attributes Auth.js writes the session cookie with.
  *
- * `sameSite: "lax"` is load-bearing, for the reason `src/auth.ts` gives: a
- * magic link clicked in an email client is a cross-site top-level navigation
- * that "strict" would silently drop. `expires` matches the `Session` row's
- * own expiry, so the cookie and the row die together.
+ * `sameSite: "lax"` is load-bearing, for the reason `src/auth.ts` gives: an
+ * invitation link clicked in an email client is a cross-site top-level
+ * navigation that "strict" would silently drop. `expires` matches the
+ * `Session` row's own expiry, so the cookie and the row die together.
  */
 export function sessionCookieOptions(
   secure: boolean,

--- a/src/lib/signin-code.test.ts
+++ b/src/lib/signin-code.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SIGNIN_CODE_ALPHABET,
+  SIGNIN_CODE_LENGTH,
+  SIGNIN_CODE_MAX_AGE_SECONDS,
+  formatSignInCode,
+  generateSignInCode,
+  normalizeSignInCode,
+} from "./signin-code";
+
+describe("SIGNIN_CODE_ALPHABET", () => {
+  it("is Crockford base32: 32 characters, no I, L, O or U", () => {
+    expect(SIGNIN_CODE_ALPHABET).toHaveLength(32);
+    for (const ambiguous of ["I", "L", "O", "U"]) {
+      expect(SIGNIN_CODE_ALPHABET).not.toContain(ambiguous);
+    }
+    // 32 must divide 256 for `byte & 31` to be uniform.
+    expect(256 % SIGNIN_CODE_ALPHABET.length).toBe(0);
+  });
+});
+
+describe("generateSignInCode", () => {
+  it("returns 8 characters drawn from the alphabet", () => {
+    for (let i = 0; i < 50; i++) {
+      const code = generateSignInCode();
+      expect(code).toHaveLength(SIGNIN_CODE_LENGTH);
+      for (const character of code) {
+        expect(SIGNIN_CODE_ALPHABET).toContain(character);
+      }
+    }
+  });
+
+  it("survives its own normalizer untouched", () => {
+    for (let i = 0; i < 50; i++) {
+      const code = generateSignInCode();
+      expect(normalizeSignInCode(code)).toBe(code);
+    }
+  });
+
+  it("does not repeat across a handful of draws", () => {
+    // 40 bits of entropy: a collision in 20 draws is a broken generator, not
+    // bad luck.
+    const codes = new Set(Array.from({ length: 20 }, generateSignInCode));
+    expect(codes.size).toBe(20);
+  });
+});
+
+describe("formatSignInCode", () => {
+  it("splits the code in half with a dash", () => {
+    expect(formatSignInCode("K3M7QP2X")).toBe("K3M7-QP2X");
+  });
+
+  it("round-trips through the normalizer", () => {
+    const code = generateSignInCode();
+    expect(normalizeSignInCode(formatSignInCode(code))).toBe(code);
+  });
+});
+
+describe("normalizeSignInCode", () => {
+  it("uppercases and strips spaces and dashes", () => {
+    // The exact example the issue promises: a parent typing `k3m7 qp2x`
+    // succeeds.
+    expect(normalizeSignInCode("k3m7 qp2x")).toBe("K3M7QP2X");
+    expect(normalizeSignInCode("K3M7-QP2X")).toBe("K3M7QP2X");
+    expect(normalizeSignInCode("  k3 m7-qp 2x ")).toBe("K3M7QP2X");
+  });
+
+  it("maps the misread characters the alphabet excludes", () => {
+    // O→0, I→1, L→1 — the generator never emits them, so this only rescues.
+    expect(normalizeSignInCode("KOM7-QPIX")).toBe("K0M7QP1X");
+    expect(normalizeSignInCode("klm7-qp2x")).toBe("K1M7QP2X");
+  });
+
+  it("rejects the wrong length", () => {
+    expect(normalizeSignInCode("K3M7QP2")).toBeNull();
+    expect(normalizeSignInCode("K3M7QP2XX")).toBeNull();
+    expect(normalizeSignInCode("")).toBeNull();
+  });
+
+  it("rejects characters outside the alphabet", () => {
+    expect(normalizeSignInCode("K3M7QP2U")).toBeNull();
+    expect(normalizeSignInCode("K3M7QP2!")).toBeNull();
+    expect(normalizeSignInCode("K3M7QP2é")).toBeNull();
+  });
+
+  it("rejects non-strings", () => {
+    expect(normalizeSignInCode(null)).toBeNull();
+    expect(normalizeSignInCode(undefined)).toBeNull();
+    expect(normalizeSignInCode(42)).toBeNull();
+  });
+});
+
+describe("SIGNIN_CODE_MAX_AGE_SECONDS", () => {
+  it("is ten minutes", () => {
+    // Short expiry is half of the no-attempt-counter trade; the code's 40
+    // bits are the other half. Lengthen this only alongside that reasoning.
+    expect(SIGNIN_CODE_MAX_AGE_SECONDS).toBe(600);
+  });
+});

--- a/src/lib/signin-code.ts
+++ b/src/lib/signin-code.ts
@@ -18,6 +18,13 @@
 /// a migration), so guesses are unlimited inside the expiry window. 2^40
 /// against a 10-minute window is comfortably out of online-guessing reach; a
 /// 6-digit code's 20 bits would not be.
+///
+/// That argument assumes **one** live code per address, which the token table
+/// does not give for free: it is unique on `(identifier, token)`, not on
+/// `identifier`, so repeated requests would otherwise pile up live codes and
+/// divide the guessing work by however many. `withSingleLiveCode`
+/// (`auth-adapter.ts`) is what actually holds N at 1, and the three — length,
+/// expiry, one-live-code — stand or fall together.
 export const SIGNIN_CODE_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 export const SIGNIN_CODE_LENGTH = 8;

--- a/src/lib/signin-code.ts
+++ b/src/lib/signin-code.ts
@@ -1,0 +1,89 @@
+/// The typed sign-in code — replacing the tapped magic link (#60).
+///
+/// A link is redeemed by whichever browser the OS hands it to, and on a phone
+/// that is routinely not the container the person is standing in: an installed
+/// PWA and the browser the email link opens in can hold separate cookie jars
+/// (confirmed on Android — the report behind this change — and the designed-for
+/// case on iOS). The session then lands where the app cannot read it, every
+/// time. A typed code is the one credential that crosses a storage-container
+/// boundary, because the human carries it instead of the OS routing it.
+///
+/// Pure and dependency-free: the generator feeds Auth.js's
+/// `generateVerificationToken`, the normalizer runs in the code-entry action,
+/// and both are enumerable in tests without either of those hosts.
+
+/// Crockford base32: no I, L, O or U, so nothing in a code is one squint away
+/// from another character. 8 characters × 5 bits = 40 bits, which has to carry
+/// the security by itself — there is no attempt counter (adding one would need
+/// a migration), so guesses are unlimited inside the expiry window. 2^40
+/// against a 10-minute window is comfortably out of online-guessing reach; a
+/// 6-digit code's 20 bits would not be.
+export const SIGNIN_CODE_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+export const SIGNIN_CODE_LENGTH = 8;
+
+/// Ten minutes. The code is read off one screen and typed into another, so it
+/// lives minutes, not the day a magic link did — short expiry is the other
+/// half of the no-attempt-counter trade above.
+export const SIGNIN_CODE_MAX_AGE_SECONDS = 60 * 10;
+
+/**
+ * A fresh code in canonical form: 8 uppercase alphabet characters, no
+ * separator. This exact string is what Auth.js hashes and stores, and what
+ * `normalizeSignInCode` must reproduce from whatever the person types.
+ *
+ * `byte & 31` is uniform because 32 divides 256 exactly — no rejection
+ * sampling needed, and nothing here to bias.
+ */
+export function generateSignInCode(): string {
+  const bytes = new Uint8Array(SIGNIN_CODE_LENGTH);
+  crypto.getRandomValues(bytes);
+
+  let code = "";
+  for (const byte of bytes) {
+    code += SIGNIN_CODE_ALPHABET[byte & 31];
+  }
+  return code;
+}
+
+/// How the code renders in the email: split in half so it chunks the way a
+/// person reads it. The dash is display only — the normalizer strips it.
+export function formatSignInCode(code: string): string {
+  return `${code.slice(0, 4)}-${code.slice(4)}`;
+}
+
+/// Crockford's decode conventions for the characters the alphabet excludes on
+/// purpose: a person reading O, I or l off a small screen meant 0 or 1. The
+/// generator never emits these, so mapping them can only rescue a misread,
+/// never corrupt a valid code. U stays unmapped — it is excluded to keep
+/// profanity out of codes, not because it resembles anything.
+const MISREAD_MAP: Record<string, string> = { O: "0", I: "1", L: "1" };
+
+/**
+ * Reduce whatever the person typed to canonical form, or null when it cannot
+ * be a code at all. `k3m7 qp2x`, `K3M7-QP2X` and `k3m7qp2x` all succeed; the
+ * null case is the form's cue to say "that doesn't look like a code" without
+ * a round trip through Auth.js.
+ */
+export function normalizeSignInCode(raw: unknown): string | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  const cleaned = raw
+    .replace(/[\s-]/g, "")
+    .toUpperCase()
+    .replace(/[OIL]/g, (c) => MISREAD_MAP[c] ?? c);
+
+  if (cleaned.length !== SIGNIN_CODE_LENGTH) {
+    return null;
+  }
+
+  for (const character of cleaned) {
+    if (!SIGNIN_CODE_ALPHABET.includes(character)) {
+      return null;
+    }
+  }
+
+  return cleaned;
+}

--- a/src/lib/signin-code.ts
+++ b/src/lib/signin-code.ts
@@ -23,8 +23,10 @@
 /// does not give for free: it is unique on `(identifier, token)`, not on
 /// `identifier`, so repeated requests would otherwise pile up live codes and
 /// divide the guessing work by however many. `withSingleLiveCode`
-/// (`auth-adapter.ts`) is what actually holds N at 1, and the three — length,
-/// expiry, one-live-code — stand or fall together.
+/// (`auth-adapter.ts`) is what holds N down — at 1 for sequential requests,
+/// and at the number that *overlap* its prune-then-create window otherwise
+/// (#81). The three — length, expiry, one-live-code — stand or fall together,
+/// so weakening any one of them means redoing this arithmetic.
 export const SIGNIN_CODE_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 export const SIGNIN_CODE_LENGTH = 8;

--- a/src/lib/signin-gate.ts
+++ b/src/lib/signin-gate.ts
@@ -1,7 +1,7 @@
 import { isOwnerEmail } from "@/lib/owner";
 import { isLiveInvitation } from "@/lib/invitation-token";
 
-/// Who is allowed to obtain a magic link, and therefore an account.
+/// Who is allowed to obtain a sign-in code, and therefore an account.
 ///
 /// There is no self-serve signup path in this app: an address gets in only if it
 /// holds a live Invitation, already holds a Membership somewhere, or is the
@@ -45,7 +45,7 @@ export type SignInDecision = {
 };
 
 /**
- * Decide whether an address may receive a magic link.
+ * Decide whether an address may receive a sign-in code.
  *
  * Note what is deliberately absent: any notion of archived teams or of role.
  * Signing in is not a write, and a role is meaningless until a team is in the


### PR DESCRIPTION
## Summary

Sign-in from the installed Android PWA looped back to the enter-your-email page forever: the magic link is redeemed by whichever browser the OS hands it to, and that browser and the installed app can hold separate cookie containers, so the session lands where the app can never read it. This is exactly the dead end #60 designed for (on iOS, with the Android/Gmail variant named in its context), now confirmed on a real device — so this PR implements #60: the sign-in email carries a typed 8-character code instead of a tappable link.

## Key Decisions

- **Ride the existing Auth.js email flow rather than owning a code table.** `generateVerificationToken` supplies the code, `maxAge` shortens its life to 10 minutes, and `submitSignInCode` rebuilds the same `/api/auth/callback/resend?token=&email=` URL the link used to carry — verified against the installed `@auth/core@0.41.3` source, whose callback doesn't care how the parameters arrived. The invitation gate, `acceptInvitations`, and session creation run unchanged, and there is no Prisma migration (the code lives in the existing `VerificationToken` row).
- **Code-only, never code-and-link.** Both would be the same token, so a mail scanner following the link would burn the typed code too.
- **Three things carry the security, and they stand or fall together.** 8 characters of Crockford base32 is 40 bits; the code expires in 10 minutes; and `withSingleLiveCode` collapses repeat requests for an address down to one live code. There is no attempt counter (that would need a migration), so none of the three may be weakened alone. That third property is sequential only — concurrent requests can still overlap its prune-then-create window, which is #81 and is written up in `auth-adapter.ts` including why the obvious patch is worse than the gap.
- **The pending address rides in a short-lived httpOnly cookie scoped to `/signin`** (`pending-signin-cookie.ts`), never a query parameter — keeping it out of history, referrers, and logs. It is set on every request path, success or silent decline, so its absence reveals nothing about who is invited; it stores the address normalized exactly the way `@auth/core` normalizes the identifier; and it is read through `readPendingSignIn`, which prefers the `__Secure-` spelling and takes the first cookie that *parses*.
- **The normalizer is forgiving the way Crockford intended**: strips spaces/dashes, uppercases, and maps O→0, I/L→1 — safe because the generator never emits those characters, so mapping can only rescue a misread.
- **The invitation-accept link stays a link.** It is a POST from a page and establishes its session in whichever container it was opened in, so it does not have this bug.

## What's in Scope

- `src/lib/signin-code.ts` — pure generator, formatter (`K3M7-QP2X`), and normalizer, with tests
- `src/lib/auth-adapter.ts` — `withSingleLiveCode`, wrapping the Prisma adapter so requesting a code deletes the address's previous ones
- `src/lib/pending-signin-cookie.ts` — cookie name/attributes (with the `__Secure-` prefix rule mirrored from `session-cookie.ts`), JSON serialize/parse that re-sanitizes `callbackUrl` on every read, and the shared `readPendingSignIn`
- `src/lib/resend-provider.ts` — `generateVerificationToken`, 10-minute `maxAge`, and a `sendVerificationRequest` that mails the code email (nothing tappable), with the mail stack imported inside the send path
- `src/emails/SignInCodeEmail.tsx` + `signin-code-email.ts` — template and pure props builder; the code leads the subject so it is readable from the notification shade
- `/signin/check-email` rebuilt as the code-entry form — `CodeEntryForm` on `useActionState` (`autoComplete="one-time-code"`), with a start-over card when the pending cookie has expired
- `submitSignInCode` and the renamed `requestSignInCode` actions, plus the `/signin` loader that returns a failed redeem to the entry form
- Docs: the Decision 5 revision note in `stack-decisions.md`, the AGENTS.md gotcha and route list, the design-plan §7 entry for the code screen, and the README status narrative and layout bullets

### Out of Scope

- An attempt counter on code redemption — needs a migration; 40 bits + 10 minutes + one live code is the chosen mitigation, documented in AGENTS.md
- Any change to invitation acceptance, sessions, or the proxy
- The `.agents/` planning docs under `issue-planner/` and `archive/` still say "magic link" and are deliberately untouched — they record what was planned at the time, and the decision record itself carries the revision note

## Bugs Found and Fixed During Self-Review

A review of the first commit turned up six findings, all closed here. Two were security:

- **Live codes accumulated per address.** `VerificationToken` is unique on `(identifier, token)`, not on `identifier`, and `@auth/core` starts the token write beside the send — so every `/signin` POST left another live code behind, even one whose email failed. The 40-bit argument assumes one live code; N of them divide the guessing work by N. `withSingleLiveCode` now prunes before minting. A follow-up review correctly noted that two statements cannot close the concurrent case; that residual window is #81, and the comments were corrected to stop claiming otherwise.
- **A planted cookie could lock someone out of signing in.** The pending cookie was read by taking the first name that was *present*, unprefixed first — and any sibling host or plain-HTTP response can set `pending-signin`, unlike `__Secure-`. Since an unparseable cookie reads as "no pending sign-in", junk there shadowed the real cookie permanently, with nothing on screen to explain it. `readPendingSignIn` takes the first that *parses*, `__Secure-` first.

Two cost a parent their sign-in attempt:

- **A mistyped code emptied the box.** The action redirected, so one wrong character cost all eight — mid-code, on a phone, which is where people give up. The form is `useActionState` now, per the convention AGENTS.md already sets for forms people type into.
- **A wrong code dead-ended on the email form** while the code the parent was holding was still live, forcing a second email. `/signin` now bounces `?error=Verification` back to the entry form whenever the pending cookie is alive (the cookie and the code expire together). `AccessDenied` is deliberately not bounced — the gate refused the address.

Plus a performance regression and doc drift: the new top-level `@/lib/email` and template imports had pulled the Resend SDK and React Email into `src/auth.ts`'s graph, so every page render loaded the mail stack (the tests missed it by mocking `@/lib/email`); they move inside the send path.

## Known Gaps / Follow-ups

- **Real-device verification is the one thing this environment cannot do**, and it is the point of the change: once deployed, request a code from inside the installed Android PWA, type it, and confirm the session sticks — ideally the same on an iPhone Home Screen install. Existing sessions are untouched; only new sign-ins use codes.
- **#81** — making "one live code per address" atomic (unique index on `identifier` + upsert) needs a migration, so it is deferred. The residual window is the milliseconds between prune and create, so N is bounded by request *overlap* rather than request count, and each extra code costs the attacker an email into the victim's inbox.
- Redeeming goes through `redirect()` from a Server Action into the Auth.js Route Handler. That works — the router follows the 302 chain and applies the session cookie — but it is load-bearing on that navigation behaviour, worth knowing if Next changes it.

## Test Plan

- [ ] Run this repo's full check gate (see `AGENTS.md` → `## Commands`) — lint, typecheck, tests, and build must all pass. (`pnpm check`: 128 files / 1977 tests green; `pnpm exec next build` compiles with `/signin` and `/signin/check-email` present. CI green on the head commit.)
- [ ] With Resend env vars set, run `pnpm dev`, request a code at `/signin`, and confirm the email contains a code and no link; type the code (try `k3m7 qp2x`-style lowercase/spaced input) at `/signin/check-email` and confirm it signs in and lands on the `callbackUrl`.
- [ ] Mistype the code: confirm the characters stay in the box with a message under it, and that correcting them signs you in without a new email.
- [ ] Submit a wrong-but-well-formed code (8 valid characters, not the mailed one): confirm you land back on the code form, not the email form, and that the originally mailed code still works.
- [ ] Request a second code for the same address, then try the first one: confirm it is dead and only the newest works.
- [ ] Let the 10-minute window lapse or clear cookies: confirm the start-over card and the `code-expired` message, and that nothing anywhere reveals whether an address is invited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NuY1RCuhrQJVVSFeBQsuG