### PR TITLE
Let an allPlay coach place up to three kids at each outfield spot

### DIFF
--- a/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
+++ b/.agents/app-brainstorm/youth-baseball-team-manager/product-brief.md
@@ -110,10 +110,13 @@ Scoped to fit **6 weeks of evenings and weekends**.
 - **Positions** — drag players onto a labeled diamond, likewise **standing** and likewise
   permanent (no inning rotation, no per-game chart). The nine standard defensive
   positions: **P, C, 1B, 2B, 3B, SS, LF, CF, RF** — `C` is Catcher, `CF` is Center Field.
-  `allPlay = true` → one kid per infield position **except catcher** (P, 1B, 2B, 3B, SS),
-  outfield holds all remaining players; at this level the coach pitches and nobody plays
-  behind the plate, so C is not a spot that can be filled. `allPlay = false` → one kid per
-  position, remainder sit in a Bench/Dugout zone. Cancel / Save.
+  `allPlay = true` → one kid per infield position **except catcher** (P, 1B, 2B, 3B, SS);
+  at this level the coach pitches and nobody plays behind the plate, so C is not a spot
+  that can be filled. **LF, CF and RF are placeable spots holding up to three kids each**
+  (revised 2026-08-27; previously the outfield was a single anonymous zone with no named
+  spots), and anyone the coach leaves unpinned still plays the general outfield zone —
+  placement is optional, nobody sits. `allPlay = false` → one kid per position, remainder
+  sit in a Bench/Dugout zone. Cancel / Save.
 - **Next-game readiness** — the one place attendance meets the chart. For the team's
   **next game only** — not practices, not later games — the app shows who's out and which
   positions that leaves uncovered. It never rearranges the chart on the coach's behalf;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,14 +479,27 @@ production — the dev command can prompt, generate new migrations, and reset th
   therefore posts the chart *as it loaded it* in a `baseline` field, and the action compares
   that against its own fresh read before writing, refusing on a mismatch (`chart-changed`).
   The baseline comes from `storedBattingOrder` / `storedPositions` in `chart.ts`, never from
-  the draft: both draft builders normalize (pooling stale outfield rows, packing sparse
+  the draft: both draft builders normalize (pooling stale catcher rows, packing sparse
   orders), so a draft-derived baseline would look stale on every save. If you add a third
   chart column, it needs the same guard. The read-then-write gap is knowingly left open —
   see the comment in the positions action.
+- **An allPlay outfield spot seats up to three kids, and the slot column is plumbing, not
+  state.** LF/CF/RF are placeable spots on an allPlay board (`ALL_PLAY_POSITIONS`), each
+  stacking to `OUTFIELD_SPOT_CAPACITY` (3); the catcher stays unfieldable there — the coach
+  pitches. The unique index is `[teamId, position, positionSlot]`: infield writes always use
+  slot 0 (so one-kid-per-infield-spot stays database-enforced), `savePositions` numbers a
+  stack 0..n-1 on every save, and **nothing reads the slot back** — order within a spot is
+  jersey-then-name, derived on read, and `samePositions` deliberately ignores it, so don't
+  give it meaning. Unpinned players remain the general outfield as `position = null`; the
+  up-to-three cap lives in `validatePositions` (`position-full`), because a CHECK constraint
+  isn't expressible in the schema. On `/view`, pinned kids fan around their spot
+  (`outfieldSpotCoords`) and the moment any spot is occupied the zone drops to its deep row
+  (`outfieldZoneCoords(..., {deep})`) — the shallow zone row IS the LF/CF/RF coordinates, so
+  drawing both shallow would stack two markers on one point, silently.
 - **Save and Cancel answer different questions in both chart editors**, and it is not
   redundancy. Cancel is "has the coach changed anything" (draft vs. the loaded draft); Save is
   "would writing change the database" (draft vs. `stored*`). They diverge on first render
-  whenever the draft builder normalized something — a stale `CENTER_FIELD` row under allPlay,
+  whenever the draft builder normalized something — a stale `CATCHER` row under allPlay,
   or nine slots holding what used to be ten batters — and gating Save on the Cancel question
   leaves the coach looking at a change they cannot commit.
 - **`List-Unsubscribe` is set on two sends, and which two is a claim, not an oversight.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,9 +274,13 @@ production — the dev command can prompt, generate new migrations, and reset th
   `fill-none stroke-banana`, so a test telling them apart has to key on the radius.
   `guarded-style.ts`, `FieldArt.test.tsx` and the no-guard case in the view page's suite
   are where that budget is written down. One known hole, judged not worth a third branch:
-  an allPlay board with 13+ players in the zone draws no ring, so a reader whose only
-  guarded kid is there and has no batting slot sees a chalk fence and no banana at all.
-  That needs an 18+ roster, past what this app is built for.
+  a reader whose only guarded kid stands somewhere too crowded for a ring, and who has no
+  batting slot to carry the banana on a row instead, sees a chalk fence and no banana at
+  all. **The bound on that used to read "an 18+ roster" and no longer does** — three kids
+  at one outfield spot stand 40px apart, so a guarded kid *inside* a full spot draws no
+  ring on a twelve-player roster. What was fixed rather than documented is the collateral
+  case: `outfieldHaloRadius` measures around the guarded markers themselves, so a crowd on
+  the far side of the field no longer erases the ring around a kid standing alone at LF.
 
   The third caller is **`MiniDiamondHero`** (team home's player cards), and it passes
   `fence="chalk"` unconditionally — not a judgement call, a consequence of when it renders
@@ -490,12 +494,22 @@ production — the dev command can prompt, generate new migrations, and reset th
   slot 0 (so one-kid-per-infield-spot stays database-enforced), `savePositions` numbers a
   stack 0..n-1 on every save, and **nothing reads the slot back** — order within a spot is
   jersey-then-name, derived on read, and `samePositions` deliberately ignores it, so don't
-  give it meaning. Unpinned players remain the general outfield as `position = null`; the
+  give it meaning. A spot can hold **more rows than it seats** — three kids at CF the
+  moment allPlay is switched off — so "where does this kid play" is `seatedEntryIds`
+  (chart-view.ts), never the `position` column read straight: team home and the readiness
+  list both go through it, or they tell a family a spot the diamond gives to someone else.
+  That seating cut runs over a *sorted* list, because `getChart` has no `orderBy` and
+  picking "the first arrivals" out of Postgres's order seats a different kid per request. Unpinned players remain the general outfield as `position = null`; the
   up-to-three cap lives in `validatePositions` (`position-full`), because a CHECK constraint
   isn't expressible in the schema. On `/view`, pinned kids fan around their spot
   (`outfieldSpotCoords`) and the moment any spot is occupied the zone drops to its deep row
   (`outfieldZoneCoords(..., {deep})`) — the shallow zone row IS the LF/CF/RF coordinates, so
-  drawing both shallow would stack two markers on one point, silently.
+  drawing both shallow would stack two markers on one point, silently. The deep row is the
+  only row left (a third reaches the middle infielders), so it holds eight — past that
+  `deepZoneFits` is false and `Diamond` lays pinned and unpinned kids out **together** in
+  the ordinary two-row zone, each keeping its own label. Reachable without an odd roster:
+  pinning outfielders before placing the infield leaves nine unpinned on a twelve-player
+  team.
 - **Save and Cancel answer different questions in both chart editors**, and it is not
   redundancy. Cancel is "has the coach changed anything" (draft vs. the loaded draft); Save is
   "would writing change the database" (draft vs. `stored*`). They diverge on first render

--- a/prisma/migrations/20260827120000_add_roster_entry_position_slot/migration.sql
+++ b/prisma/migrations/20260827120000_add_roster_entry_position_slot/migration.sql
@@ -1,0 +1,20 @@
+-- Named outfield spots on allPlay teams: up to three kids can now share
+-- LF/CF/RF, so the one-row-per-(team, position) index has to widen. The new
+-- "positionSlot" column joins the key purely as a uniqueness mechanism —
+-- infield writes always use slot 0 (keeping "one kid per infield position"
+-- database-enforced exactly as before), and savePositions numbers outfield
+-- slots 0..2 per position on every save. The up-to-three cap itself lives in
+-- validatePositions (chart.ts).
+--
+-- Additive with a DEFAULT, so no backfill: every existing row holds at most
+-- one entry per position and lands on slot 0, which is exactly what the next
+-- save would write for it.
+
+-- AlterTable
+ALTER TABLE "RosterEntry" ADD COLUMN "positionSlot" INTEGER NOT NULL DEFAULT 0;
+
+-- DropIndex
+DROP INDEX "RosterEntry_teamId_position_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RosterEntry_teamId_position_positionSlot_key" ON "RosterEntry"("teamId", "position", "positionSlot");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,8 +179,17 @@ model RosterEntry {
   /// Standing batting order slot. Null = not in the batting order.
   battingOrder Int?
 
-  /// Standing defensive position. Null = bench / dugout.
+  /// Standing defensive position. Null = bench / dugout — or, on an allPlay
+  /// team, the general outfield: a kid the coach hasn't pinned to LF/CF/RF.
   position Position?
+
+  /// Which of a position's spots this entry holds. Always 0 for an infield
+  /// position; 0–2 for LF/CF/RF on an allPlay team, where each named outfield
+  /// spot holds up to three kids. Meaningless (and reset to 0) while
+  /// `position` is null. Purely a uniqueness mechanism: readers never order by
+  /// it — display order within a shared spot is jersey-then-name, derived on
+  /// read — and `savePositions` numbers it 0..n-1 per position on every save.
+  positionSlot Int @default(0)
 
   createdAt DateTime @default(now())
 
@@ -189,7 +198,13 @@ model RosterEntry {
 
   @@unique([playerId, teamId])
   @@unique([teamId, battingOrder])
-  @@unique([teamId, position])
+  /// Was `[teamId, position]` until the allPlay outfield grew named spots:
+  /// up to three kids can share LF/CF/RF there, so the slot joins the key.
+  /// Infield writes always use slot 0, which keeps "one kid per infield
+  /// position" database-enforced exactly as before; the up-to-three cap is
+  /// validatePositions' job (chart.ts), since a CHECK constraint isn't
+  /// expressible here.
+  @@unique([teamId, position, positionSlot])
   @@unique([teamId, jerseyNumber])
   @@index([teamId])
 }

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.test.tsx
@@ -23,14 +23,14 @@ function entry(
   return { entryId, playerName: `Player-${entryId}`, jerseyNumber, position };
 }
 
-function fieldOf(name: string): Record<string, string> {
+function fieldOf(name: string): Record<string, string[]> {
   const form = screen.getByRole("button", { name: "Save positions" }).closest("form")!;
   return JSON.parse(
     form.querySelector<HTMLInputElement>(`input[name="${name}"]`)!.value,
   );
 }
 
-function payloadOf(): Record<string, string> {
+function payloadOf(): Record<string, string[]> {
   return fieldOf("positions");
 }
 
@@ -39,7 +39,7 @@ beforeEach(() => {
 });
 
 describe("PositionsEditor", () => {
-  it("renders five infield targets and an Outfield zone when allPlay is true", () => {
+  it("renders eight targets — no catcher — and an Outfield zone when allPlay is true", () => {
     render(
       <PositionsEditor
         teamId="team-1"
@@ -49,16 +49,18 @@ describe("PositionsEditor", () => {
     );
 
     const field = screen.getByRole("region", { name: "Diamond" });
-    // P, 1B, 2B, 3B, SS — the outfield is one zone, not three spots, and an
-    // allPlay team has no catcher because the coach pitches.
-    for (const label of ["P", "1B", "2B", "3B", "SS"]) {
+    // P, 1B, 2B, 3B, SS and the three named outfield spots. An allPlay team
+    // has no catcher because the coach pitches; unplaced players wait in the
+    // general Outfield zone.
+    for (const label of ["P", "1B", "2B", "3B", "SS", "LF", "CF", "RF"]) {
       expect(field).toHaveTextContent(label);
     }
-    expect(field).not.toHaveTextContent("LF");
-    expect(field).not.toHaveTextContent("RF");
     expect(
       field.querySelector('[data-position="CATCHER"]'),
     ).not.toBeInTheDocument();
+    expect(
+      field.querySelector('[data-position="CENTER_FIELD"]'),
+    ).toBeInTheDocument();
 
     const zone = screen.getByRole("region", { name: "Outfield" });
     expect(zone).toHaveTextContent("Player-b");
@@ -66,6 +68,30 @@ describe("PositionsEditor", () => {
     expect(
       screen.queryByRole("region", { name: "Substitutes" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("seats an allPlay outfield stack of up to three inside one spot", () => {
+    render(
+      <PositionsEditor
+        teamId="team-1"
+        allPlay={true}
+        entries={[
+          entry("a", "CENTER_FIELD"),
+          entry("b", "CENTER_FIELD"),
+          entry("c", "CENTER_FIELD"),
+          entry("d"),
+        ]}
+      />,
+    );
+
+    const spot = document.querySelector('[data-position="CENTER_FIELD"]')!;
+    for (const name of ["Player-a", "Player-b", "Player-c"]) {
+      expect(spot).toHaveTextContent(name);
+    }
+    expect(screen.getByRole("region", { name: "Outfield" })).toHaveTextContent(
+      "Player-d",
+    );
+    expect(payloadOf()).toEqual({ CENTER_FIELD: ["a", "b", "c"] });
   });
 
   it("marks the catcher's empty spot with a filled circle under allPlay", () => {
@@ -134,12 +160,12 @@ describe("PositionsEditor", () => {
     expect(zone).toHaveTextContent("Player-b");
   });
 
-  it("pools an allPlay team's stale outfield player instead of seating them", () => {
+  it("pools an allPlay team's stale catcher instead of seating them", () => {
     render(
       <PositionsEditor
         teamId="team-1"
         allPlay={true}
-        entries={[entry("a", "CENTER_FIELD")]}
+        entries={[entry("a", "CATCHER")]}
       />,
     );
 
@@ -151,8 +177,8 @@ describe("PositionsEditor", () => {
     expect(payloadOf()).toEqual({});
   });
 
-  it("offers Save for a stale outfield row the coach hasn't touched", () => {
-    // The row still says CENTER_FIELD and the payload above says {}, so saving
+  it("offers Save for a stale catcher row the coach hasn't touched", () => {
+    // The row still says CATCHER and the payload above says {}, so saving
     // WOULD change the database. Gating Save on "has the coach moved anyone"
     // strands the row: the board already looks right, so there is nothing the
     // coach can do to make the editor dirty short of an unrelated change.
@@ -160,7 +186,7 @@ describe("PositionsEditor", () => {
       <PositionsEditor
         teamId="team-1"
         allPlay={true}
-        entries={[entry("a", "CENTER_FIELD")]}
+        entries={[entry("a", "CATCHER")]}
       />,
     );
 
@@ -180,10 +206,10 @@ describe("PositionsEditor", () => {
       />,
     );
 
-    expect(fieldOf("baseline")).toEqual({ PITCHER: "a" });
+    expect(fieldOf("baseline")).toEqual({ PITCHER: ["a"] });
   });
 
-  it("puts a stale outfield row in the baseline even though the board can't show it", () => {
+  it("puts a stale catcher row in the baseline even though the board can't show it", () => {
     // The whole reason the baseline is storedPositions and not the draft: the
     // action compares it against a fresh read, so a baseline that had already
     // dropped this row would look stale on every single save.
@@ -191,12 +217,12 @@ describe("PositionsEditor", () => {
       <PositionsEditor
         teamId="team-1"
         allPlay={true}
-        entries={[entry("a", "CENTER_FIELD")]}
+        entries={[entry("a", "CATCHER")]}
       />,
     );
 
     expect(payloadOf()).toEqual({});
-    expect(fieldOf("baseline")).toEqual({ CENTER_FIELD: "a" });
+    expect(fieldOf("baseline")).toEqual({ CATCHER: ["a"] });
   });
 
   it("leaves Save disabled when the board already matches what is stored", () => {
@@ -221,8 +247,8 @@ describe("PositionsEditor", () => {
       />,
     );
 
-    // Five infield spots, one filled.
-    expect(screen.getAllByText("Open")).toHaveLength(4);
+    // Eight spots on an allPlay board, one filled.
+    expect(screen.getAllByText("Open")).toHaveLength(7);
   });
 
   it("shows only first names on the diamond and full names in the zone", () => {
@@ -267,7 +293,7 @@ describe("PositionsEditor", () => {
     ).toBe("team-1");
     // Only the diamond is posted; the zone is everyone else, and the server
     // nulls them in phase 1 of the write.
-    expect(payloadOf()).toEqual({ PITCHER: "a", SHORTSTOP: "b" });
+    expect(payloadOf()).toEqual({ PITCHER: ["a"], SHORTSTOP: ["b"] });
   });
 
   it("gives every player a keyboard drag handle", () => {
@@ -457,7 +483,7 @@ describe("PositionsEditor decline badges", () => {
       />,
     );
 
-    expect(payloadOf()).toEqual({ PITCHER: "a", SHORTSTOP: "b" });
+    expect(payloadOf()).toEqual({ PITCHER: ["a"], SHORTSTOP: ["b"] });
     expect(screen.getByRole("button", { name: "Save positions" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
   });

--- a/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
+++ b/src/app/t/[teamId]/chart/positions/PositionsEditor.tsx
@@ -239,10 +239,12 @@ export function PositionsEditor({
               teamId,
               "positions",
               Object.entries(draft.assigned).map(
-                ([position, entryId]) =>
-                  `${POSITION_LABELS[position as Position]} — ${
-                    byId.get(entryId as string)?.playerName ?? "—"
-                  }`,
+                ([position, entryIds]) =>
+                  `${POSITION_LABELS[position as Position]} — ${(
+                    (entryIds ?? []) as readonly string[]
+                  )
+                    .map((entryId) => byId.get(entryId)?.playerName ?? "—")
+                    .join(", ")}`,
               ),
             )
           }
@@ -333,11 +335,9 @@ function Field({
           <PositionTarget
             key={position}
             position={position}
-            entry={
-              draft.assigned[position] !== undefined
-                ? byId.get(draft.assigned[position])
-                : undefined
-            }
+            entries={(draft.assigned[position] ?? [])
+              .map((entryId) => byId.get(entryId))
+              .filter((entry) => entry !== undefined)}
             diamondNames={diamondNames}
             declined={declined}
           />
@@ -349,12 +349,17 @@ function Field({
 
 function PositionTarget({
   position,
-  entry,
+  entries,
   diamondNames,
   declined,
 }: {
   position: Position;
-  entry: PositionsEditorEntry | undefined;
+  /// Everyone standing at this spot, in arrival order — at most one entry
+  /// anywhere except an allPlay team's LF/CF/RF, which stack to three
+  /// (`positionCapacity`). The whole stack renders inside the one chalk box:
+  /// the box is the drop target, so a drop lands on the spot however many
+  /// chips it already holds.
+  entries: PositionsEditorEntry[];
   /// Marker labels for the whole roster, keyed by playerId. Passed in rather
   /// than shortened here because "is this first name ambiguous" is a question
   /// about every other player on the board, not about this one.
@@ -383,13 +388,16 @@ function PositionTarget({
       <span className="rounded bg-background/85 px-1 text-[11px] font-bold text-foreground">
         {POSITION_LABELS[position]}
       </span>
-      {entry !== undefined ? (
-        <Chip
-          entry={entry}
-          label={diamondNames.get(entry.entryId) ?? entry.playerName}
-          declined={declined.has(entry.entryId)}
-          stacked
-        />
+      {entries.length > 0 ? (
+        entries.map((entry) => (
+          <Chip
+            key={entry.entryId}
+            entry={entry}
+            label={diamondNames.get(entry.entryId) ?? entry.playerName}
+            declined={declined.has(entry.entryId)}
+            stacked
+          />
+        ))
       ) : (
         <span className="rounded bg-background/85 px-1 text-[11px] italic text-muted-foreground">
           Open

--- a/src/app/t/[teamId]/chart/positions/actions.test.ts
+++ b/src/app/t/[teamId]/chart/positions/actions.test.ts
@@ -90,7 +90,7 @@ describe("savePositionsAction", () => {
   it("requires COACH write access before touching anything", async () => {
     await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a"}' }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["a"]}' }),
       ),
     );
 
@@ -105,14 +105,14 @@ describe("savePositionsAction", () => {
       savePositionsAction(
         form({
           teamId: "team-1",
-          positions: '{"SHORTSTOP":"c","PITCHER":"a"}',
+          positions: '{"SHORTSTOP":["c"],"PITCHER":["a"]}',
         }),
       ),
     );
 
     expect(savePositions).toHaveBeenCalledWith("team-1", [
-      { entryId: "a", position: "PITCHER" },
-      { entryId: "c", position: "SHORTSTOP" },
+      { entryId: "a", position: "PITCHER", positionSlot: 0 },
+      { entryId: "c", position: "SHORTSTOP", positionSlot: 0 },
     ]);
     expect(url).toBe("/t/team-1/chart/positions?saved=1");
     expect(revalidatePath).toHaveBeenCalledWith(
@@ -131,7 +131,15 @@ describe("savePositionsAction", () => {
   });
 
   it("rejects unparseable and malformed payloads without hitting the database", async () => {
-    for (const positions of ["not json", '["a"]', '{"PITCHER":3}']) {
+    for (const positions of [
+      "not json",
+      '["a"]',
+      '{"PITCHER":3}',
+      // The old single-id-per-position shape: a form predating the stacked
+      // outfield posts strings, and the schema should refuse rather than
+      // guess at what the coach meant.
+      '{"PITCHER":"a"}',
+    ]) {
       const url = await redirectUrlOf(
         savePositionsAction(form({ teamId: "team-1", positions })),
       );
@@ -161,7 +169,7 @@ describe("savePositionsAction", () => {
     // Ten pairs can't be a real board however they're spelled, so this dies at
     // the schema rather than arriving at validatePositions looking plausible.
     const tooMany = Object.fromEntries(
-      Array.from({ length: 10 }, (_, i) => [`K${i}`, "entry"]),
+      Array.from({ length: 10 }, (_, i) => [`K${i}`, ["entry"]]),
     );
 
     const url = await redirectUrlOf(
@@ -179,7 +187,7 @@ describe("savePositionsAction", () => {
       savePositionsAction(
         form({
           teamId: "team-1",
-          positions: JSON.stringify({ PITCHER: "x".repeat(65) }),
+          positions: JSON.stringify({ PITCHER: ["x".repeat(65)] }),
         }),
       ),
     );
@@ -192,7 +200,7 @@ describe("savePositionsAction", () => {
     // The cap is the enum's length, not one less than it — an off-by-one here
     // would reject exactly the boards a non-allPlay team saves.
     const full = Object.fromEntries(
-      ALL_POSITIONS.map((position, i) => [position, `re-${i}`]),
+      ALL_POSITIONS.map((position, i) => [position, [`re-${i}`]]),
     );
     getChart.mockResolvedValue(ALL_POSITIONS.map((_, i) => chartEntry(`re-${i}`)));
     getTeamById.mockResolvedValue({ id: "team-1", allPlay: false });
@@ -205,7 +213,11 @@ describe("savePositionsAction", () => {
 
     expect(savePositions).toHaveBeenCalledWith(
       "team-1",
-      ALL_POSITIONS.map((position, i) => ({ entryId: `re-${i}`, position })),
+      ALL_POSITIONS.map((position, i) => ({
+        entryId: `re-${i}`,
+        position,
+        positionSlot: 0,
+      })),
     );
   });
 
@@ -222,7 +234,7 @@ describe("savePositionsAction", () => {
 
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a"}', baseline: "{}" }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["a"]}', baseline: "{}" }),
       ),
     );
 
@@ -243,15 +255,15 @@ describe("savePositionsAction", () => {
       savePositionsAction(
         form({
           teamId: "team-1",
-          positions: '{"PITCHER":"a","SHORTSTOP":"b"}',
-          baseline: '{"SHORTSTOP":"b"}',
+          positions: '{"PITCHER":["a"],"SHORTSTOP":["b"]}',
+          baseline: '{"SHORTSTOP":["b"]}',
         }),
       ),
     );
 
     expect(savePositions).toHaveBeenCalledWith("team-1", [
-      { entryId: "a", position: "PITCHER" },
-      { entryId: "b", position: "SHORTSTOP" },
+      { entryId: "a", position: "PITCHER", positionSlot: 0 },
+      { entryId: "b", position: "SHORTSTOP", positionSlot: 0 },
     ]);
   });
 
@@ -264,8 +276,8 @@ describe("savePositionsAction", () => {
       savePositionsAction(
         form({
           teamId: "team-1",
-          positions: '{"PITCHER":"a"}',
-          baseline: '{"PITCHER":"a"}',
+          positions: '{"PITCHER":["a"]}',
+          baseline: '{"PITCHER":["a"]}',
         }),
       ),
     );
@@ -280,7 +292,7 @@ describe("savePositionsAction", () => {
 
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a"}', baseline: "{}" }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["a"]}', baseline: "{}" }),
       ),
     );
 
@@ -310,7 +322,7 @@ describe("savePositionsAction", () => {
   it("rejects an entry that is not on this team's roster", async () => {
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"intruder"}' }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["intruder"]}' }),
       ),
     );
 
@@ -321,7 +333,7 @@ describe("savePositionsAction", () => {
   it("rejects the same player standing at two positions", async () => {
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a","SHORTSTOP":"a"}' }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["a"],"SHORTSTOP":["a"]}' }),
       ),
     );
 
@@ -329,12 +341,43 @@ describe("savePositionsAction", () => {
     expect(savePositions).not.toHaveBeenCalled();
   });
 
-  it("rejects a named outfield spot for an allPlay team, using the freshly loaded flag", async () => {
+  it("saves a stacked outfield spot for an allPlay team, numbering its slots", async () => {
+    await redirectUrlOf(
+      savePositionsAction(
+        form({ teamId: "team-1", positions: '{"LEFT_FIELD":["a","b","c"]}' }),
+      ),
+    );
+
+    expect(savePositions).toHaveBeenCalledWith("team-1", [
+      { entryId: "a", position: "LEFT_FIELD", positionSlot: 0 },
+      { entryId: "b", position: "LEFT_FIELD", positionSlot: 1 },
+      { entryId: "c", position: "LEFT_FIELD", positionSlot: 2 },
+    ]);
+  });
+
+  it("rejects a stacked outfield spot once allPlay is off, using the freshly loaded flag", async () => {
     // The client can't be trusted for allPlay: this payload is what an editor
     // loaded before the setting was toggled would post.
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      allPlay: false,
+      archivedAt: null,
+    });
+
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"LEFT_FIELD":"a"}' }),
+        form({ teamId: "team-1", positions: '{"LEFT_FIELD":["a","b"]}' }),
+      ),
+    );
+
+    expect(url).toBe("/t/team-1/chart/positions?error=position-full");
+    expect(savePositions).not.toHaveBeenCalled();
+  });
+
+  it("rejects a catcher for an allPlay team", async () => {
+    const url = await redirectUrlOf(
+      savePositionsAction(
+        form({ teamId: "team-1", positions: '{"CATCHER":["a"]}' }),
       ),
     );
 
@@ -342,22 +385,18 @@ describe("savePositionsAction", () => {
     expect(savePositions).not.toHaveBeenCalled();
   });
 
-  it("accepts that same spot once allPlay is off", async () => {
-    getTeamById.mockResolvedValue({
-      id: "team-1",
-      allPlay: false,
-      archivedAt: null,
-    });
-
-    await redirectUrlOf(
+  it("rejects a stack deeper than any spot allows at the schema, before validation", async () => {
+    const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"LEFT_FIELD":"a"}' }),
+        form({
+          teamId: "team-1",
+          positions: '{"LEFT_FIELD":["a","b","c","d"]}',
+        }),
       ),
     );
 
-    expect(savePositions).toHaveBeenCalledWith("team-1", [
-      { entryId: "a", position: "LEFT_FIELD" },
-    ]);
+    expect(url).toBe("/t/team-1/chart/positions?error=invalid-positions");
+    expect(getChart).not.toHaveBeenCalled();
   });
 
   it("redirects to access on TeamAccessError", async () => {
@@ -367,7 +406,7 @@ describe("savePositionsAction", () => {
 
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a"}' }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["a"]}' }),
       ),
     );
 
@@ -382,7 +421,7 @@ describe("savePositionsAction", () => {
 
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a"}' }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["a"]}' }),
       ),
     );
 
@@ -399,7 +438,7 @@ describe("savePositionsAction", () => {
 
     const url = await redirectUrlOf(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a"}' }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["a"]}' }),
       ),
     );
 
@@ -411,7 +450,7 @@ describe("savePositionsAction", () => {
 
     await expect(
       savePositionsAction(
-        form({ teamId: "team-1", positions: '{"PITCHER":"a"}' }),
+        form({ teamId: "team-1", positions: '{"PITCHER":["a"]}' }),
       ),
     ).rejects.toThrow("connection lost");
     expect(revalidatePath).not.toHaveBeenCalled();

--- a/src/app/t/[teamId]/chart/positions/actions.ts
+++ b/src/app/t/[teamId]/chart/positions/actions.ts
@@ -10,7 +10,7 @@ import {
   storedPositions,
   validatePositions,
 } from "@/lib/chart";
-import { ALL_POSITIONS } from "@/lib/positions";
+import { ALL_POSITIONS, OUTFIELD_SPOT_CAPACITY } from "@/lib/positions";
 import { getChart, savePositions } from "@/lib/roster";
 import { requireTeamAccess, TeamAccessError } from "@/lib/team-access";
 import { getTeamById } from "@/lib/teams";
@@ -26,9 +26,13 @@ function extractTeamId(formData: FormData): string {
 }
 
 /**
- * The submitted board: entry id per filled position. Bounded like
- * `orderSchema` next door — nine positions is the whole enum, and entry ids
- * are cuids, so 64 characters is already generous.
+ * The submitted board: entry ids per filled position — an array per spot,
+ * since an allPlay outfield spot stacks to `OUTFIELD_SPOT_CAPACITY` (which is
+ * also the biggest stack any real board can hold, so it bounds every array;
+ * whether a given position may hold more than one is `validatePositions`'
+ * question, not this shape's). Bounded like `orderSchema` next door — nine
+ * positions is the whole enum, and entry ids are cuids, so 64 characters is
+ * already generous.
  *
  * **Neither bound is a DoS guard**, and it would be wrong to add more of them
  * believing otherwise: `JSON.parse` above has already materialized the entire
@@ -40,7 +44,10 @@ function extractTeamId(formData: FormData): string {
  * never be a real board from reaching `validatePositions` shaped like one.
  */
 const positionsSchema = z
-  .record(z.string(), z.string().min(1).max(64))
+  .record(
+    z.string(),
+    z.array(z.string().min(1).max(64)).max(OUTFIELD_SPOT_CAPACITY),
+  )
   .refine((board) => Object.keys(board).length <= ALL_POSITIONS.length);
 
 /**

--- a/src/app/t/[teamId]/chart/positions/page.test.tsx
+++ b/src/app/t/[teamId]/chart/positions/page.test.tsx
@@ -188,7 +188,9 @@ describe("PositionsPage rendering", () => {
   });
 
   it("explains the outfield under allPlay and the bench without it", async () => {
-    expect(await render()).toContain("plays the outfield");
+    const allPlayHtml = await render();
+    expect(allPlayHtml).toContain("plays the general outfield");
+    expect(allPlayHtml).toContain("holds up to three");
 
     getTeamById.mockResolvedValue({ ...team, allPlay: false });
     expect(await render()).toContain("sits on the bench");

--- a/src/app/t/[teamId]/chart/positions/page.tsx
+++ b/src/app/t/[teamId]/chart/positions/page.tsx
@@ -31,10 +31,14 @@ const ERROR_MESSAGES = messageTable({
   "unknown-entry":
     "The roster changed while you were editing. Reload and try again.",
   "duplicate-entry": "A player appeared twice. Reload and try again.",
-  // Only reachable when allPlay was switched on mid-edit: the outfield stops
-  // being three named spots and becomes one zone.
+  // Only reachable when allPlay was toggled mid-edit: the catcher spot
+  // appears or disappears with the setting.
   "invalid-position":
     "The team's settings changed while you were editing. Reload and try again.",
+  // Same trigger, other direction: allPlay switched off strips the outfield
+  // spots' room for more than one player, so a stacked board stops fitting.
+  "position-full":
+    "The team's settings changed while you were editing — a spot now holds more players than it can. Reload and try again.",
   "roster-changed":
     "The roster changed while you were editing — nothing was saved. Reload and try again.",
   "position-conflict":
@@ -167,7 +171,7 @@ export default async function PositionsPage({
         <>
           <p className="text-sm text-muted-foreground">
             {team.allPlay
-              ? "Hold and drag a player onto a spot. Everyone not on the infield plays the outfield."
+              ? "Hold and drag a player onto a spot — each outfield spot holds up to three. Anyone left over plays the general outfield."
               : "Hold and drag a player onto a spot. Dropping onto a player swaps the two; anyone left over sits on the bench."}
           </p>
           <PositionsEditor

--- a/src/app/t/[teamId]/page.test.tsx
+++ b/src/app/t/[teamId]/page.test.tsx
@@ -477,6 +477,74 @@ describe("TeamHomePage your players", () => {
     expect(html).not.toContain("Substitute");
   });
 
+  it("reads a named outfield spot as that spot on an allPlay team", async () => {
+    // LF/CF/RF are placeable there since the named-outfield revision, so a
+    // pinned kid's marquee names the spot rather than the general outfield.
+    getChart.mockResolvedValue([{ ...REESE, position: "CENTER_FIELD" }]);
+
+    const html = await render();
+
+    expect(html).toContain("Bats 3rd · CF");
+  });
+
+  it("does not claim a spot for a kid the diamond cannot seat", async () => {
+    // The regression: three kids left at CF the moment allPlay is switched off
+    // is a board /view seats ONE of — it lists the other two as substitutes.
+    // Team home read the position column straight and told all three families
+    // "CF", so two of them stood in the wrong place on Saturday while the page
+    // two taps away said otherwise. Reese has the highest jersey here, so the
+    // diamond seats a teammate and Reese is the one who must not read "CF".
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sluggers",
+      season: "Fall 2026",
+      allPlay: false,
+      archivedAt: null,
+    });
+    getChart.mockResolvedValue([
+      { ...REESE, position: "CENTER_FIELD" },
+      {
+        ...REESE,
+        entryId: "entry-8",
+        playerId: "player-8",
+        playerName: "Kit",
+        jerseyNumber: 2,
+        position: "CENTER_FIELD" as const,
+      },
+    ]);
+
+    const html = await render();
+
+    expect(html).toContain("Bats 3rd");
+    expect(html).not.toContain("CF");
+  });
+
+  it("still names the spot for the kid the diamond does seat", async () => {
+    // The other half: the fix must not silence a legitimately seated kid.
+    getTeamById.mockResolvedValue({
+      id: "team-1",
+      name: "Sluggers",
+      season: "Fall 2026",
+      allPlay: false,
+      archivedAt: null,
+    });
+    getChart.mockResolvedValue([
+      { ...REESE, jerseyNumber: 2, position: "CENTER_FIELD" },
+      {
+        ...REESE,
+        entryId: "entry-8",
+        playerId: "player-8",
+        playerName: "Kit",
+        jerseyNumber: 12,
+        position: "CENTER_FIELD" as const,
+      },
+    ]);
+
+    const html = await render();
+
+    expect(html).toContain("Bats 3rd · CF");
+  });
+
   // /view renders "No chart set yet" for the same data. Printing OF for every
   // kid on an allPlay team would assert a spot nobody has assigned.
   it("says no chart is set rather than inventing a position", async () => {

--- a/src/app/t/[teamId]/page.tsx
+++ b/src/app/t/[teamId]/page.tsx
@@ -20,13 +20,13 @@ import { chartRole, isBenched } from "@/lib/chart-role";
 import {
   byJerseyThenName,
   hasChartSet,
+  seatedEntryIds,
   type ChartViewEntry,
 } from "@/lib/chart-view";
 import { sortDirectory } from "@/lib/directory-rules";
 import { messageFor, messageTable } from "@/lib/error-messages";
 import { mapsUrl } from "@/lib/maps";
 import { listCoachContacts } from "@/lib/memberships";
-import { fieldedPositions } from "@/lib/positions";
 import { getChart } from "@/lib/roster";
 import { buildRsvpStateMapsByEvent } from "@/lib/rsvp";
 import { guardedRosteredPlayerIds, listRsvpsForEvents } from "@/lib/rsvps";
@@ -197,12 +197,22 @@ export default async function TeamHomePage({
   // team, Substitute on a selective one.
   const hasChart = hasChartSet(chartEntries);
 
-  // The spots this team actually fields — the player-card hero's framing
-  // question, asked once here rather than per kid. Same rule chartRole applies
-  // inside: a stale CENTER_FIELD or CATCHER row on an allPlay team is not a
-  // spot, so that kid frames in the outfield zone, where both big boards
-  // already draw them.
-  const fielded = fieldedPositions(team.allPlay);
+  // Which roster spots the diamond actually seats, asked once here rather than
+  // per kid — and asked of `/view`'s own seating rule rather than re-derived,
+  // because this page and that one must not describe the same kid differently.
+  //
+  // Not simply "is this a position the team fields": a spot has a capacity, and
+  // a board can hold more rows than it — three kids saved at CF the moment
+  // allPlay is switched off. Reading the column straight would tell all three
+  // families "CF" while /view seats one and lists two as substitutes.
+  const seated = seatedEntryIds(chartEntries, team.allPlay);
+
+  /// The same entry as the diamond understands it: the position column when the
+  /// board really seats this kid there, and null — the outfield, or the bench —
+  /// when it doesn't. `chartRole` and `isBenched` both read `position`, so
+  /// handing them the raw row is what let the two pages disagree.
+  const asSeated = (entry: ChartViewEntry): ChartViewEntry =>
+    seated.has(entry.entryId) ? entry : { ...entry, position: null };
 
   // Archived teams reject every write regardless of role, so the buttons are
   // hidden rather than shown and refused — AC 4. The summaries and any answer
@@ -292,10 +302,14 @@ export default async function TeamHomePage({
           </h3>
           <ul className="space-y-3">
             {myKids.map((entry, index) => {
+              const seatedEntry = asSeated(entry);
               const roleLine = hasChart
-                ? chartRole(entry, team.allPlay, { benchLabel: "Substitute" })
+                ? chartRole(seatedEntry, team.allPlay, {
+                    benchLabel: "Substitute",
+                  })
                 : "No chart set yet";
-              const celebrate = hasChart && !isBenched(entry, team.allPlay);
+              const celebrate =
+                hasChart && !isBenched(seatedEntry, team.allPlay);
 
               // Where the hero frames the kid, by the diamonds' own rules: a
               // fielded position at its spot, anyone else on an allPlay team
@@ -306,8 +320,8 @@ export default async function TeamHomePage({
               // gated on `celebrate`: with no chart there is no spot, and a
               // substitute's card stays quiet.
               const heroPosition =
-                entry.position !== null && fielded.has(entry.position)
-                  ? entry.position
+                seatedEntry.position !== null
+                  ? seatedEntry.position
                   : team.allPlay
                     ? null
                     : undefined;

--- a/src/app/t/[teamId]/readiness/page.test.tsx
+++ b/src/app/t/[teamId]/readiness/page.test.tsx
@@ -180,10 +180,30 @@ describe("ReadinessPage with a decline", () => {
     expect(html).toContain("Bats 2nd");
   });
 
-  it("labels a stale allPlay row as the outfield, not the position it stores", async () => {
+  it("labels a stale allPlay catcher row as the outfield, not the position it stores", async () => {
     // The page must not print a spot it simultaneously refuses to check. The
-    // view page and the editor both show this kid in the outfield; saying "CF"
+    // view page and the editor both show this kid in the outfield; saying "C"
     // here would make three screens disagree about one player.
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+    getChart.mockResolvedValue([
+      {
+        entryId: "entry-cal",
+        playerId: "cal",
+        playerName: "Cal",
+        jerseyNumber: 3,
+        battingOrder: 1,
+        position: "CATCHER" as const,
+      },
+    ]);
+    listEventRsvps.mockResolvedValue([{ playerId: "cal", attending: false }]);
+
+    const html = await render();
+
+    expect(html).toContain("Bats 1st · OF");
+    expect(html).not.toContain("Bats 1st · C<");
+  });
+
+  it("labels a named outfield row as its spot — the placeable CF, not OF", async () => {
     getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
     getChart.mockResolvedValue([
       {
@@ -199,8 +219,7 @@ describe("ReadinessPage with a decline", () => {
 
     const html = await render();
 
-    expect(html).toContain("Bats 1st · OF");
-    expect(html).not.toContain("CF");
+    expect(html).toContain("Bats 1st · CF");
   });
 
   it("labels an allPlay team's unplaced player as the outfield too", async () => {
@@ -239,6 +258,28 @@ describe("ReadinessPage with a decline", () => {
         playerName: "Cal",
         jerseyNumber: 3,
         battingOrder: 1,
+        position: "CATCHER" as const,
+      },
+    ]);
+    listEventRsvps.mockResolvedValue([{ playerId: "cal", attending: false }]);
+
+    const html = await render();
+
+    // Out, yes — but C is not a spot this team can fill, so it is not a hole.
+    expect(html).toContain("Cal");
+    expect(html).toContain("Needs attention");
+    expect(html).not.toContain("Positions uncovered");
+  });
+
+  it("reports a pinned outfield spot uncovered when its only kid declined", async () => {
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+    getChart.mockResolvedValue([
+      {
+        entryId: "entry-cal",
+        playerId: "cal",
+        playerName: "Cal",
+        jerseyNumber: 3,
+        battingOrder: 1,
         position: "CENTER_FIELD" as const,
       },
     ]);
@@ -246,10 +287,8 @@ describe("ReadinessPage with a decline", () => {
 
     const html = await render();
 
-    // Out, yes — but CF is not a spot this team can fill, so it is not a hole.
-    expect(html).toContain("Cal");
-    expect(html).toContain("Needs attention");
-    expect(html).not.toContain("Positions uncovered");
+    expect(html).toContain("Positions uncovered");
+    expect(html).toContain("CF");
   });
 });
 

--- a/src/app/t/[teamId]/readiness/page.tsx
+++ b/src/app/t/[teamId]/readiness/page.tsx
@@ -16,7 +16,11 @@ import { chartRole } from "@/lib/chart-role";
 import { POSITION_LABELS } from "@/lib/positions";
 import { computeReadiness, type Readiness } from "@/lib/readiness";
 import { getChart } from "@/lib/roster";
-import { hasChartSet, type ChartViewEntry } from "@/lib/chart-view";
+import {
+  hasChartSet,
+  seatedEntryIds,
+  type ChartViewEntry,
+} from "@/lib/chart-view";
 import { buildRsvpStateMap } from "@/lib/rsvp";
 import { listEventRsvps } from "@/lib/rsvps";
 import { nextGame } from "@/lib/schedule";
@@ -49,10 +53,17 @@ export const metadata = {
 function PlayerList({
   entries,
   allPlay,
+  seated,
   tagClassName,
 }: {
   entries: ChartViewEntry[];
   allPlay: boolean;
+  /// Roster spots the diamond actually seats (`seatedEntryIds`). A stored
+  /// position is no longer enough to print one: a spot has a capacity, and a
+  /// board can hold more rows than it, so a kid this set omits plays the
+  /// outfield whatever their `position` column still says — which is exactly
+  /// what /view draws for them.
+  seated: ReadonlySet<string>;
   tagClassName: string;
 }) {
   return (
@@ -67,7 +78,10 @@ function PlayerList({
             {entry.jerseyNumber !== null ? ` #${entry.jerseyNumber}` : ""}
           </span>
           <span className={`text-xs ${tagClassName}`}>
-            {chartRole(entry, allPlay)}
+            {chartRole(
+              seated.has(entry.entryId) ? entry : { ...entry, position: null },
+              allPlay,
+            )}
           </span>
         </li>
       ))}
@@ -177,6 +191,10 @@ export default async function ReadinessPage({
     allPlay,
   );
 
+  // The spots the diamond actually seats, from /view's own rule — see
+  // `PlayerList`'s `seated` prop for why the position column alone won't do.
+  const seated = seatedEntryIds(chartEntries, allPlay);
+
   const hasChart = hasChartSet(chartEntries);
 
   // Whether a decline actually moved the batting order, which is not the same
@@ -265,6 +283,7 @@ export default async function ReadinessPage({
                 <PlayerList
                   entries={readiness.declined}
                   allPlay={allPlay}
+                  seated={seated}
                   tagClassName={RSVP_STYLE.declined.tagClassName}
                 />
               </CardContent>
@@ -348,6 +367,7 @@ export default async function ReadinessPage({
                 <PlayerList
                   entries={readiness.awaiting}
                   allPlay={allPlay}
+                  seated={seated}
                   tagClassName={RSVP_STYLE["no-response"].tagClassName}
                 />
               </CardContent>

--- a/src/app/t/[teamId]/view/Diamond.test.tsx
+++ b/src/app/t/[teamId]/view/Diamond.test.tsx
@@ -4,6 +4,7 @@ import {
   DIAMOND_GEOMETRY,
   FIELD_ART,
   POSITION_COORDS,
+  outfieldSpotCoords,
   outfieldZoneCoords,
   zoneHaloRadius,
 } from "@/components/diamond-geometry";
@@ -119,18 +120,33 @@ describe("diamond geometry", () => {
     }
   });
 
-  it("puts the zone exactly on LF/CF/RF, so nothing may ever draw both", () => {
-    // The coincidence is deliberate — three outfielders should read as the
-    // standard diamond. It also means a board drawing a named outfield marker
-    // AND a zone would stack two markers on one spot, with both names
-    // unreadable and neither an error. `buildChartView` is what makes that
-    // unreachable: under allPlay it pools anyone stored at a named outfield
-    // spot, so `byPosition` cannot hold one while `outfield` is non-empty.
+  it("puts the zone exactly on LF/CF/RF, so nothing may ever draw both shallow", () => {
+    // The coincidence is deliberate — three unpinned outfielders should read
+    // as the standard diamond. It also means a board drawing a named outfield
+    // marker AND a shallow zone would stack two markers on one spot, with
+    // both names unreadable and neither an error. The Diamond's `deep` switch
+    // is what makes that unreachable: the moment any named spot has players,
+    // the zone moves to its deep row (`outfieldZoneCoords(..., {deep})`).
     expect(outfieldZoneCoords(3)).toEqual(
       OUTFIELD_POSITIONS.map((position) => POSITION_COORDS[position]).sort(
         (a, b) => a.x - b.x,
       ),
     );
+  });
+
+  it("keeps every fanned spot halo on the grass, clear of the warning track", () => {
+    // The named-spot counterpart of the zone checks below: a corner trio's
+    // outermost marker is the deepest thing the outfield can draw.
+    const trackInnerEdge = FIELD_ART.trackRadius - FIELD_ART.trackWidth / 2;
+    const home = { x: FIELD_ART.homeCircle.x, y: FIELD_ART.homeCircle.y };
+
+    for (const position of OUTFIELD_POSITIONS) {
+      for (const count of [1, 2, 3]) {
+        for (const coord of outfieldSpotCoords(position, count)) {
+          expect(apart(coord, home) + haloReach).toBeLessThan(trackInnerEdge);
+        }
+      }
+    }
   });
 });
 

--- a/src/app/t/[teamId]/view/Diamond.tsx
+++ b/src/app/t/[teamId]/view/Diamond.tsx
@@ -1,6 +1,7 @@
 import {
   DIAMOND_GEOMETRY,
   POSITION_COORDS,
+  deepZoneFits,
   outfieldHaloRadius,
   outfieldSpotCoords,
   outfieldZoneCoords,
@@ -31,6 +32,17 @@ import {
 
 const EMPTY_GUARDED: ReadonlySet<string> = new Set();
 
+/// One outfielder as the SVG draws them: who, what abbreviation goes inside
+/// their circle, and where they stand. The three layouts below all produce
+/// this same shape, so the render and the halo measurement never have to know
+/// which one ran.
+type OutfieldMarker = {
+  player: ChartViewPlayer;
+  label: string;
+  x: number;
+  y: number;
+};
+
 const MARKER_RADIUS = DIAMOND_GEOMETRY.markerRadius;
 const NAME_OFFSET = DIAMOND_GEOMETRY.nameOffset;
 const TAG_OFFSET = DIAMOND_GEOMETRY.tagOffset;
@@ -57,10 +69,10 @@ function Marker({
   /// point (#49). Purely a property of who is reading, never of the roster
   /// spot, so nothing here is stored.
   isGuarded?: boolean;
-  /// The ring's radius, or null when the board is too crowded for one to fit.
-  /// Fixed positions always get `DIAMOND_GEOMETRY.haloRadius`; the outfield
-  /// zone's shrinks with the count (`zoneHaloRadius`), because that zone packs
-  /// its markers closer as the roster grows.
+  /// The ring's radius, or null when the guarded markers stand too close
+  /// together for one to fit. Fixed positions always get
+  /// `DIAMOND_GEOMETRY.haloRadius`; the outfield's shrinks as its markers pack
+  /// closer (`outfieldHaloRadius`).
   haloRadius?: number | null;
 }) {
   const style = player ? RSVP_STYLE[player.rsvpState] : null;
@@ -197,24 +209,70 @@ export function Diamond({
         (position) => [position, byPosition.get(position) ?? []] as const,
       )
     : [];
-  const spotMarkers = spots.flatMap(([position, players]) =>
-    outfieldSpotCoords(position, players.length).map((coord, index) => ({
-      position,
-      player: players[index],
-      ...coord,
-    })),
+  const pinned = spots.flatMap(([position, players]) =>
+    players.map((player) => ({ position, player })),
   );
   const zone = allPlay ? outfield : [];
-  // The zone's shallow row sits AT the LF/CF/RF coordinates, so the moment a
-  // named spot has players standing on it, the unpinned kids move to the deep
-  // row instead of stacking on top of them.
-  const zoneCoords = outfieldZoneCoords(zone.length, {
-    deep: spotMarkers.length > 0,
-  });
-  // One radius for the whole outfield — spot fans and zone rows together: it
-  // is a function of how tightly the markers pack, not of which marker is
-  // guarded.
-  const zoneHalo = outfieldHaloRadius([...spotMarkers, ...zoneCoords]);
+
+  // Three ways the outfield can be laid out, and the third one exists because
+  // the second cannot always fit.
+  //
+  //   - Nothing pinned: the zone takes its own two rows, whose shallow row IS
+  //     the LF/CF/RF coordinates. An all-unpinned outfield of three therefore
+  //     reads as the standard diamond, which is the point.
+  //   - Something pinned, and the rest fit below: pinned kids fan around their
+  //     spot and the zone drops to its deep row, because a shallow zone marker
+  //     would land on top of them.
+  //   - Something pinned and the rest DON'T fit (`deepZoneFits`): one deep row
+  //     is all there is, and nine in it overlap. So this board gives up the
+  //     pinned coordinates and lays every outfielder — pinned and unpinned —
+  //     out in the ordinary two-row zone, each keeping its own label. The
+  //     assignment is still readable (the marker says LF, not OF); only the
+  //     exact spot is spent, which is the right thing to spend when the
+  //     alternative is two names drawn on one point.
+  //
+  // Reachable without an outlandish roster: pinning outfielders before placing
+  // the infield leaves nine unpinned on a twelve-player team.
+  const crowded = pinned.length > 0 && !deepZoneFits(zone.length);
+  const outfieldMarkers: OutfieldMarker[] = crowded
+    ? (() => {
+        const everyone = [
+          ...pinned.map(({ position, player }) => ({
+            player,
+            label: POSITION_LABELS[position],
+          })),
+          ...zone.map((player) => ({ player, label: OUTFIELD_ZONE_LABEL })),
+        ];
+        return outfieldZoneCoords(everyone.length).map((coord, index) => ({
+          ...everyone[index],
+          ...coord,
+        }));
+      })()
+    : [
+        ...spots.flatMap(([position, players]) =>
+          outfieldSpotCoords(position, players.length).map((coord, index) => ({
+            player: players[index],
+            label: POSITION_LABELS[position],
+            ...coord,
+          })),
+        ),
+        ...outfieldZoneCoords(zone.length, { deep: pinned.length > 0 }).map(
+          (coord, index) => ({
+            player: zone[index],
+            label: OUTFIELD_ZONE_LABEL,
+            ...coord,
+          }),
+        ),
+      ];
+
+  // One radius for the whole outfield, measured around the guarded markers
+  // themselves: a crowded cluster on the far side of the field must not erase
+  // the ring around a kid standing alone at LF. Fixed positions keep the full
+  // radius — they are budgeted for it in DIAMOND_GEOMETRY.
+  const guardedMarkers = outfieldMarkers.filter((marker) =>
+    guardedPlayerIds.has(marker.player.playerId),
+  );
+  const outfieldHalo = outfieldHaloRadius(outfieldMarkers, guardedMarkers);
 
   return (
     <>
@@ -261,29 +319,16 @@ export function Diamond({
           );
         })}
 
-        {spotMarkers.map(({ position, player, x, y }) => (
+        {outfieldMarkers.map(({ player, label, x, y }) => (
           <Marker
             key={player.playerId}
             x={x}
             y={y}
-            label={POSITION_LABELS[position]}
+            label={label}
             player={player}
             showRsvp={showRsvp}
             isGuarded={guardedPlayerIds.has(player.playerId)}
-            haloRadius={zoneHalo}
-          />
-        ))}
-
-        {zone.map((player, index) => (
-          <Marker
-            key={player.playerId}
-            x={zoneCoords[index].x}
-            y={zoneCoords[index].y}
-            label={OUTFIELD_ZONE_LABEL}
-            player={player}
-            showRsvp={showRsvp}
-            isGuarded={guardedPlayerIds.has(player.playerId)}
-            haloRadius={zoneHalo}
+            haloRadius={outfieldHalo}
           />
         ))}
       </svg>

--- a/src/app/t/[teamId]/view/Diamond.tsx
+++ b/src/app/t/[teamId]/view/Diamond.tsx
@@ -1,8 +1,9 @@
 import {
   DIAMOND_GEOMETRY,
   POSITION_COORDS,
+  outfieldHaloRadius,
+  outfieldSpotCoords,
   outfieldZoneCoords,
-  zoneHaloRadius,
 } from "@/components/diamond-geometry";
 import { FieldArt } from "@/components/FieldArt";
 import {
@@ -19,6 +20,7 @@ import type { ChartViewPlayer } from "@/lib/chart-view";
 import {
   ALL_PLAY_INFIELD_POSITIONS,
   ALL_POSITIONS,
+  OUTFIELD_POSITIONS,
   OUTFIELD_ZONE_LABEL,
   POSITION_LABELS,
 } from "@/lib/positions";
@@ -162,11 +164,11 @@ export function Diamond({
   showRsvp = true,
   guardedPlayerIds = EMPTY_GUARDED,
 }: {
-  /// Seated players, keyed by position. Only ever holds spots this team
-  /// fields — `buildChartView` pools the rest, including an allPlay team's
-  /// stale LF/CF/RF or CATCHER row, so the markers below cannot collide with
-  /// the zone drawn at those same coordinates.
-  byPosition: Map<Position, ChartViewPlayer>;
+  /// Seated players, keyed by position — a list per spot, because an allPlay
+  /// team's LF/CF/RF each stack to three. Only ever holds spots this team
+  /// fields: `buildChartView` pools the rest, including an allPlay team's
+  /// stale CATCHER row, so the markers below cannot collide with the zone.
+  byPosition: Map<Position, ChartViewPlayer[]>;
   allPlay: boolean;
   /// Everyone the diamond doesn't seat. Drawn as the outfield zone on an
   /// allPlay team, and ignored otherwise — a benched player belongs on neither.
@@ -181,17 +183,38 @@ export function Diamond({
   /// the one they saw before #49.
   guardedPlayerIds?: ReadonlySet<string>;
 }) {
-  // An allPlay team fields neither a catcher nor three named outfielders: the
-  // coach pitches, and the outfield is one zone holding everyone the infield
-  // leaves over (#11, Decision 1). Drawing C or LF/CF/RF as "Open" would be
-  // doubly wrong for them — the spots aren't open, they don't exist — so those
-  // players come from `outfield` instead, and C gets the disc.
+  // An allPlay team fields no catcher — the coach pitches — so C is drawn as
+  // the disc, never as "Open" (#11, Decision 1). Its LF/CF/RF are real spots
+  // since the named-outfield revision, but they draw differently from the
+  // fixed positions: a spot seats up to three (fanned around the coordinate
+  // via `outfieldSpotCoords`), and an EMPTY one draws nothing at all — the
+  // spots are optional, the general zone still covers the grass, and an
+  // "Open" marker would both claim a hole nobody is required to fill and
+  // collide with the zone drawn at those same coordinates.
   const drawn = allPlay ? ALL_PLAY_INFIELD_POSITIONS : ALL_POSITIONS;
+  const spots: readonly [Position, ChartViewPlayer[]][] = allPlay
+    ? OUTFIELD_POSITIONS.map(
+        (position) => [position, byPosition.get(position) ?? []] as const,
+      )
+    : [];
+  const spotMarkers = spots.flatMap(([position, players]) =>
+    outfieldSpotCoords(position, players.length).map((coord, index) => ({
+      position,
+      player: players[index],
+      ...coord,
+    })),
+  );
   const zone = allPlay ? outfield : [];
-  const zoneCoords = outfieldZoneCoords(zone.length);
-  // One radius for the whole zone: it is a function of how many markers share
-  // those two rows, not of which marker is guarded.
-  const zoneHalo = zoneHaloRadius(zone.length);
+  // The zone's shallow row sits AT the LF/CF/RF coordinates, so the moment a
+  // named spot has players standing on it, the unpinned kids move to the deep
+  // row instead of stacking on top of them.
+  const zoneCoords = outfieldZoneCoords(zone.length, {
+    deep: spotMarkers.length > 0,
+  });
+  // One radius for the whole outfield — spot fans and zone rows together: it
+  // is a function of how tightly the markers pack, not of which marker is
+  // guarded.
+  const zoneHalo = outfieldHaloRadius([...spotMarkers, ...zoneCoords]);
 
   return (
     <>
@@ -222,7 +245,9 @@ export function Diamond({
 
         {drawn.map((position) => {
           const { x, y } = POSITION_COORDS[position];
-          const player = byPosition.get(position);
+          // A fixed position seats one player; the array is the outfield
+          // spots' shape, which render through spotMarkers below.
+          const player = byPosition.get(position)?.[0];
           return (
             <Marker
               key={position}
@@ -235,6 +260,19 @@ export function Diamond({
             />
           );
         })}
+
+        {spotMarkers.map(({ position, player, x, y }) => (
+          <Marker
+            key={player.playerId}
+            x={x}
+            y={y}
+            label={POSITION_LABELS[position]}
+            player={player}
+            showRsvp={showRsvp}
+            isGuarded={guardedPlayerIds.has(player.playerId)}
+            haloRadius={zoneHalo}
+          />
+        ))}
 
         {zone.map((player, index) => (
           <Marker
@@ -256,7 +294,7 @@ export function Diamond({
       <ul className="sr-only">
         {allPlay ? <li>{NO_CATCHER_TEXT}</li> : null}
         {drawn.map((position) => {
-          const player = byPosition.get(position);
+          const player = byPosition.get(position)?.[0];
           return (
             <li key={position}>
               {POSITION_LABELS[position]}:{" "}
@@ -264,6 +302,16 @@ export function Diamond({
             </li>
           );
         })}
+        {spots
+          .filter(([, players]) => players.length > 0)
+          .map(([position, players]) => (
+            <li key={position}>
+              {POSITION_LABELS[position]}:{" "}
+              {players
+                .map((player) => announce(player, showRsvp, guardedPlayerIds))
+                .join("; ")}
+            </li>
+          ))}
         {zone.length > 0 ? (
           <li>
             Outfield:{" "}

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -431,6 +431,44 @@ describe("ViewPage chart rendering", () => {
     expect(new Set(translates).size).toBe(translates.length);
   });
 
+  it("draws every outfielder once when the deep row cannot hold the rest", async () => {
+    // A coach who pins outfielders BEFORE placing the infield leaves nine
+    // unpinned on a twelve-player team, and the deep row — all the zone gets
+    // once a spot is taken — packs nine to 36px against a 40px marker. The
+    // board gives up the pinned coordinates for that case rather than drawing
+    // two names on one point, so every kid is still drawn exactly once and
+    // still labelled with the spot they play.
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+    getChart.mockResolvedValue([
+      ...["a", "b", "c"].map((id, index) => ({
+        playerId: `pin-${id}`,
+        playerName: `Pin${id.toUpperCase()}`,
+        jerseyNumber: index + 1,
+        battingOrder: index + 1,
+        position: "CENTER_FIELD" as const,
+      })),
+      ...Array.from({ length: 9 }, (_, index) => ({
+        playerId: `zone-${index}`,
+        playerName: `Zone${index}`,
+        jerseyNumber: 20 + index,
+        battingOrder: 4 + index,
+        position: null,
+      })),
+    ]);
+
+    const html = await render();
+
+    // Three CF markers and nine OF markers, each drawn once.
+    expect(html.split(">CF<")).toHaveLength(4);
+    expect(html.split(">OF<")).toHaveLength(10);
+
+    // And no two of them share a coordinate.
+    const translates = [
+      ...html.matchAll(/translate\((-?[\d.]+) (-?[\d.]+)\)/g),
+    ].map((match) => `${match[1]},${match[2]}`);
+    expect(new Set(translates).size).toBe(translates.length);
+  });
+
   it("exposes an allPlay outfield to screen readers", async () => {
     getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
     getChart.mockResolvedValue([

--- a/src/app/t/[teamId]/view/page.test.tsx
+++ b/src/app/t/[teamId]/view/page.test.tsx
@@ -336,12 +336,10 @@ describe("ViewPage chart rendering", () => {
     expect(html).not.toContain(">C<");
   });
 
-  it("shows an allPlay team's stale named-outfield row in the outfield", async () => {
-    // Hand-set during #9, or left over from before allPlay was switched on.
-    // The coach's next save collapses it; until then the kid is in the
-    // outfield, which is both where the editor shows them and where that save
-    // will put them. Drawing them at CF instead would land the marker on the
-    // zone's own first coordinate, with two names on one spot.
+  it("seats an allPlay team's named-outfield row at its spot", async () => {
+    // LF/CF/RF are placeable allPlay spots since the named-outfield revision:
+    // a pinned kid draws at the spot with its abbreviation, exactly as the
+    // editor showed the coach.
     getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
     getChart.mockResolvedValue([
       {
@@ -356,12 +354,35 @@ describe("ViewPage chart rendering", () => {
     const html = await render();
 
     expect(html).toContain("Cal");
-    expect(html).toContain(">OF<");
-    expect(html).not.toContain(">CF<");
+    expect(html).toContain(">CF<");
+    expect(html).not.toContain(">OF<");
   });
 
-  it("draws one marker per player when a stale row sits beside a real outfielder", async () => {
-    // The collision case: the zone's first coordinate IS center field.
+  it("shows an allPlay team's stale catcher row in the outfield", async () => {
+    // Left over from before allPlay was switched on. The coach's next save
+    // collapses it; until then the kid is in the outfield, which is both
+    // where the editor shows them and where that save will put them.
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+    getChart.mockResolvedValue([
+      {
+        playerId: "cal",
+        playerName: "Cal",
+        jerseyNumber: 3,
+        battingOrder: 1,
+        position: "CATCHER" as const,
+      },
+    ]);
+
+    const html = await render();
+
+    expect(html).toContain("Cal");
+    expect(html).toContain(">OF<");
+  });
+
+  it("draws one marker per player when a pinned kid sits beside a zone outfielder", async () => {
+    // The collision case: the zone's shallow first coordinate IS center
+    // field, so a pinned centre fielder pushes the unpinned kid to the deep
+    // row — one CF marker, one OF marker, nobody stacked.
     getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
     getChart.mockResolvedValue([
       {
@@ -382,8 +403,32 @@ describe("ViewPage chart rendering", () => {
 
     const html = await render();
 
-    expect(html.split(">OF<")).toHaveLength(3);
-    expect(html).not.toContain(">CF<");
+    // One CF marker (plus its sr-only line) and one OF marker.
+    expect(html.split(">CF<")).toHaveLength(2);
+    expect(html.split(">OF<")).toHaveLength(2);
+  });
+
+  it("stacks up to three named outfielders on one spot, fanned apart", async () => {
+    getTeamById.mockResolvedValue({ id: "team-1", allPlay: true, archivedAt: null });
+    getChart.mockResolvedValue([
+      ["cal", 3],
+      ["dee", 4],
+      ["eli", 5],
+    ].map(([playerId, jerseyNumber], index) => ({
+      playerId: String(playerId),
+      playerName: String(playerId),
+      jerseyNumber: Number(jerseyNumber),
+      battingOrder: index + 1,
+      position: "CENTER_FIELD" as const,
+    })));
+
+    const html = await render();
+
+    // Three markers all labelled CF, at three distinct coordinates.
+    expect(html.split(">CF<")).toHaveLength(4);
+    const translates = [...html.matchAll(/translate\((\d+(?:\.\d+)?) (\d+(?:\.\d+)?)\)/g)]
+      .map((m) => `${m[1]},${m[2]}`);
+    expect(new Set(translates).size).toBe(translates.length);
   });
 
   it("exposes an allPlay outfield to screen readers", async () => {

--- a/src/components/diamond-geometry.test.ts
+++ b/src/components/diamond-geometry.test.ts
@@ -7,6 +7,7 @@ import {
   DIAMOND_GEOMETRY,
   FIELD_ART,
   POSITION_COORDS,
+  deepZoneFits,
   outfieldHaloRadius,
   outfieldSpotCoords,
   outfieldZoneCoords,
@@ -158,7 +159,7 @@ describe("outfieldZoneCoords", () => {
     // The shallow row sits AT the LF/CF/RF coordinates; when a named spot has
     // players on it, a shallow zone marker would land on top of them.
     const shallowRow = Math.max(...outfieldZoneCoords(3).map((c) => c.y));
-    for (let count = 1; count <= 8; count += 1) {
+    for (let count = 1; count <= 16; count += 1) {
       const coords = outfieldZoneCoords(count, { deep: true });
       expect(coords).toHaveLength(count);
       for (const { y } of coords) {
@@ -166,6 +167,54 @@ describe("outfieldZoneCoords", () => {
         expect(y + DIAMOND_GEOMETRY.markerRadius).toBeLessThanOrEqual(
           INFIELD_BACK,
         );
+      }
+    }
+  });
+
+  it("keeps deep-row markers apart only up to deepZoneFits, and says so", () => {
+    // The deep row is one row — a third would reach the middle infielders — so
+    // it runs out, and `deepZoneFits` is the honest boundary rather than a
+    // count the caller has to know. Asserting BOTH directions is the point:
+    // testing only up to the last passing count is the anti-pattern
+    // CROWDED_ZONE_SIZES already warns about, and it is exactly how a 36px
+    // deep row shipped.
+    const minGap = (coords: { x: number; y: number }[]) => {
+      let gap = Infinity;
+      for (let i = 0; i < coords.length; i += 1) {
+        for (let j = i + 1; j < coords.length; j += 1) {
+          gap = Math.min(
+            gap,
+            Math.hypot(coords[i].x - coords[j].x, coords[i].y - coords[j].y),
+          );
+        }
+      }
+      return gap;
+    };
+
+    for (let count = 1; count <= 16; count += 1) {
+      const gap = minGap(outfieldZoneCoords(count, { deep: true }));
+      if (deepZoneFits(count)) {
+        expect(gap).toBeGreaterThanOrEqual(2 * DIAMOND_GEOMETRY.markerRadius);
+      } else {
+        // Not a bug to fix here — it is why `Diamond` stops using this layout
+        // and falls back to the ordinary two-row zone for the whole outfield.
+        expect(gap).toBeLessThan(2 * DIAMOND_GEOMETRY.markerRadius);
+      }
+    }
+  });
+
+  it("holds the whole outfield without overlap in the layout deep mode falls back to", () => {
+    // The crowded board's escape hatch: pinned and unpinned kids together in
+    // the ordinary two-row zone. It must scale past any real roster, since
+    // that is the case that reached it.
+    for (let count = 1; count <= 16; count += 1) {
+      const coords = outfieldZoneCoords(count);
+      for (let i = 0; i < coords.length; i += 1) {
+        for (let j = i + 1; j < coords.length; j += 1) {
+          expect(
+            Math.hypot(coords[i].x - coords[j].x, coords[i].y - coords[j].y),
+          ).toBeGreaterThanOrEqual(2 * DIAMOND_GEOMETRY.markerRadius);
+        }
       }
     }
   });
@@ -223,6 +272,28 @@ describe("outfieldSpotCoords", () => {
     }
   });
 
+  it("keeps every fanned marker inside the band that keeps its NAME on the box", () => {
+    // The regression: a symmetric corner trio put its outer marker at x=35.
+    // The 40px circle still fitted, so nothing looked broken — but names are
+    // centred under their marker, and maxSpread exists precisely to stop one
+    // running off the 400-wide box. The fan slides inward instead.
+    // The band is `maxSpread` either side of the centre line, read off the
+    // widest row the zone itself draws rather than restated as a number here.
+    const widest = outfieldZoneCoords(9).map((coord) => coord.x);
+    const left = Math.min(...widest);
+    const right = Math.max(...widest);
+    expect(left).toBeLessThan(POSITION_COORDS.LEFT_FIELD.x);
+
+    for (const position of OUTFIELD_POSITIONS) {
+      for (let count = 1; count <= 3; count += 1) {
+        for (const { x } of outfieldSpotCoords(position, count)) {
+          expect(x).toBeGreaterThanOrEqual(left);
+          expect(x).toBeLessThanOrEqual(right);
+        }
+      }
+    }
+  });
+
   it("keeps every fanned marker inside the box and clear of the infield", () => {
     for (const position of OUTFIELD_POSITIONS) {
       for (let count = 1; count <= 3; count += 1) {
@@ -272,21 +343,29 @@ describe("outfieldHaloRadius", () => {
     );
   });
 
-  it("returns null for a centre-field trio — the crowded-zone degradation", () => {
-    // CF's fan runs along the arc's flat middle, so its trio neighbours stand
-    // just 40px apart: no ring worth reading fits. The marker still bolds the
-    // name and steps up, and the sr-only mirror still says "(your player)".
-    expect(outfieldHaloRadius(outfieldSpotCoords("CENTER_FIELD", 3))).toBeNull();
+  it("returns null for a trio — the crowded-zone degradation", () => {
+    // Three at one spot stand ~40px apart, which is markers touching: no ring
+    // worth reading fits. The marker still bolds the name and steps up, and
+    // the sr-only mirror still says "(your player)".
+    for (const position of OUTFIELD_POSITIONS) {
+      expect(outfieldHaloRadius(outfieldSpotCoords(position, 3))).toBeNull();
+    }
   });
 
-  it("keeps a shrunken ring for a corner trio, where the arc's slope buys room", () => {
-    // LF/RF fans descend the bow, so the same 40px of x-spread is ~50px of
-    // real distance — enough for a smaller-than-standard ring.
-    for (const position of ["LEFT_FIELD", "RIGHT_FIELD"] as const) {
-      const radius = outfieldHaloRadius(outfieldSpotCoords(position, 3));
-      expect(radius).not.toBeNull();
-      expect(radius!).toBeLessThan(DIAMOND_GEOMETRY.haloRadius);
-    }
+  it("sizes the ring around the guarded markers, not the whole outfield", () => {
+    // The regression: one three-deep spot used to null the radius for every
+    // marker on the board, so a parent whose kid stood ALONE at LF lost the
+    // highlight to a cluster their child is nowhere near — on the page whose
+    // entire job is "where is my kid".
+    const loneLeft = outfieldSpotCoords("LEFT_FIELD", 1);
+    const centreTrio = outfieldSpotCoords("CENTER_FIELD", 3);
+    const board = [...loneLeft, ...centreTrio];
+
+    expect(outfieldHaloRadius(board, loneLeft)).toBe(
+      DIAMOND_GEOMETRY.haloRadius,
+    );
+    // A kid inside the crowd still gets no ring — there is genuinely no room.
+    expect(outfieldHaloRadius(board, [centreTrio[0]])).toBeNull();
   });
 
   it("is what zoneHaloRadius computes for the plain zone", () => {

--- a/src/components/diamond-geometry.test.ts
+++ b/src/components/diamond-geometry.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect } from "vitest";
 
+import type { Position } from "@/generated/prisma/enums";
+import { OUTFIELD_POSITIONS } from "@/lib/positions";
+
 import {
   DIAMOND_GEOMETRY,
   FIELD_ART,
   POSITION_COORDS,
+  outfieldHaloRadius,
+  outfieldSpotCoords,
   outfieldZoneCoords,
   positionPercent,
+  zoneHaloRadius,
 } from "./diamond-geometry";
 
 /// The back point of the infield polygon. Nothing in the outfield zone may
@@ -144,6 +150,199 @@ describe("outfieldZoneCoords", () => {
         expect(y + DIAMOND_GEOMETRY.markerRadius).toBeLessThanOrEqual(
           INFIELD_BACK,
         );
+      }
+    }
+  });
+
+  it("skips its shallow row in deep mode, leaving it to the named spots", () => {
+    // The shallow row sits AT the LF/CF/RF coordinates; when a named spot has
+    // players on it, a shallow zone marker would land on top of them.
+    const shallowRow = Math.max(...outfieldZoneCoords(3).map((c) => c.y));
+    for (let count = 1; count <= 8; count += 1) {
+      const coords = outfieldZoneCoords(count, { deep: true });
+      expect(coords).toHaveLength(count);
+      for (const { y } of coords) {
+        expect(y).toBeGreaterThan(shallowRow);
+        expect(y + DIAMOND_GEOMETRY.markerRadius).toBeLessThanOrEqual(
+          INFIELD_BACK,
+        );
+      }
+    }
+  });
+});
+
+describe("outfieldSpotCoords", () => {
+  const distance = (
+    a: { x: number; y: number },
+    b: { x: number; y: number },
+  ) => Math.hypot(a.x - b.x, a.y - b.y);
+
+  it("returns nothing for a non-outfield position or an empty spot", () => {
+    expect(outfieldSpotCoords("PITCHER", 2)).toEqual([]);
+    expect(outfieldSpotCoords("CENTER_FIELD", 0)).toEqual([]);
+  });
+
+  it("puts a lone kid exactly on the spot — indistinguishable from the fixed diamond", () => {
+    for (const position of OUTFIELD_POSITIONS) {
+      const [coord] = outfieldSpotCoords(position, 1);
+      expect(coord.x).toBeCloseTo(POSITION_COORDS[position].x);
+      expect(coord.y).toBeCloseTo(POSITION_COORDS[position].y);
+    }
+  });
+
+  it("fans a pair wide enough to keep the full guarded halo", () => {
+    // A pair 55px apart clears haloRadius 25 with the 3px stroke: the rings
+    // neither touch each other nor reach the neighbouring marker.
+    const reach =
+      DIAMOND_GEOMETRY.haloRadius + DIAMOND_GEOMETRY.haloStrokeWidth / 2;
+    for (const position of OUTFIELD_POSITIONS) {
+      const [a, b] = outfieldSpotCoords(position, 2);
+      const gap = distance(a, b);
+      expect(gap).toBeGreaterThanOrEqual(2 * reach);
+      expect(gap).toBeGreaterThanOrEqual(
+        reach + DIAMOND_GEOMETRY.markerRadius,
+      );
+    }
+  });
+
+  it("keeps three full spots — nine markers — clear of each other", () => {
+    // Neighbouring markers must never overlap: two 20px-radius circles need
+    // 40px of separation. The tightest observed pair is a trio's own
+    // neighbours at ~40.4px, the same crowded-zone floor the two-row zone
+    // reaches at 15–16 players.
+    const all = OUTFIELD_POSITIONS.flatMap((position) =>
+      outfieldSpotCoords(position, 3),
+    );
+    expect(all).toHaveLength(9);
+    for (let i = 0; i < all.length; i += 1) {
+      for (let j = i + 1; j < all.length; j += 1) {
+        expect(distance(all[i], all[j])).toBeGreaterThanOrEqual(
+          2 * DIAMOND_GEOMETRY.markerRadius,
+        );
+      }
+    }
+  });
+
+  it("keeps every fanned marker inside the box and clear of the infield", () => {
+    for (const position of OUTFIELD_POSITIONS) {
+      for (let count = 1; count <= 3; count += 1) {
+        for (const { x, y } of outfieldSpotCoords(position, count)) {
+          expect(x - DIAMOND_GEOMETRY.markerRadius).toBeGreaterThanOrEqual(0);
+          expect(x + DIAMOND_GEOMETRY.markerRadius).toBeLessThanOrEqual(
+            DIAMOND_GEOMETRY.width,
+          );
+          expect(y - DIAMOND_GEOMETRY.markerRadius).toBeGreaterThanOrEqual(0);
+          expect(y + DIAMOND_GEOMETRY.markerRadius).toBeLessThanOrEqual(
+            INFIELD_BACK,
+          );
+        }
+      }
+    }
+  });
+
+  it("stays clear of a deep zone row drawn below the spots", () => {
+    // The mixed board: full named spots plus up to 8 unpinned kids in the one
+    // remaining row. No marker pair may overlap across the two layouts.
+    const spots = OUTFIELD_POSITIONS.flatMap((position) =>
+      outfieldSpotCoords(position, 3),
+    );
+    for (let zoneCount = 1; zoneCount <= 8; zoneCount += 1) {
+      const zone = outfieldZoneCoords(zoneCount, { deep: true });
+      for (const spot of spots) {
+        for (const marker of zone) {
+          expect(distance(spot, marker)).toBeGreaterThanOrEqual(
+            2 * DIAMOND_GEOMETRY.markerRadius,
+          );
+        }
+      }
+    }
+  });
+});
+
+describe("outfieldHaloRadius", () => {
+  it("gives a lone pinned outfielder the full halo", () => {
+    expect(outfieldHaloRadius(outfieldSpotCoords("CENTER_FIELD", 1))).toBe(
+      DIAMOND_GEOMETRY.haloRadius,
+    );
+  });
+
+  it("keeps the full halo for a fanned pair", () => {
+    expect(outfieldHaloRadius(outfieldSpotCoords("LEFT_FIELD", 2))).toBe(
+      DIAMOND_GEOMETRY.haloRadius,
+    );
+  });
+
+  it("returns null for a centre-field trio — the crowded-zone degradation", () => {
+    // CF's fan runs along the arc's flat middle, so its trio neighbours stand
+    // just 40px apart: no ring worth reading fits. The marker still bolds the
+    // name and steps up, and the sr-only mirror still says "(your player)".
+    expect(outfieldHaloRadius(outfieldSpotCoords("CENTER_FIELD", 3))).toBeNull();
+  });
+
+  it("keeps a shrunken ring for a corner trio, where the arc's slope buys room", () => {
+    // LF/RF fans descend the bow, so the same 40px of x-spread is ~50px of
+    // real distance — enough for a smaller-than-standard ring.
+    for (const position of ["LEFT_FIELD", "RIGHT_FIELD"] as const) {
+      const radius = outfieldHaloRadius(outfieldSpotCoords(position, 3));
+      expect(radius).not.toBeNull();
+      expect(radius!).toBeLessThan(DIAMOND_GEOMETRY.haloRadius);
+    }
+  });
+
+  it("is what zoneHaloRadius computes for the plain zone", () => {
+    for (const count of [1, 3, 5, 8, 12, 15]) {
+      expect(outfieldHaloRadius(outfieldZoneCoords(count))).toEqual(
+        zoneHaloRadius(count),
+      );
+    }
+  });
+
+  it("never lets a ring touch another outfield or infield marker, whatever the board", () => {
+    // Every mixed board a real roster can produce: 0–3 kids per named spot,
+    // the rest in the zone (deep when any spot is taken).
+    const reachOf = (radius: number) =>
+      radius + DIAMOND_GEOMETRY.haloStrokeWidth / 2;
+    const infield = (
+      ["PITCHER", "FIRST_BASE", "SECOND_BASE", "THIRD_BASE", "SHORTSTOP"] as Position[]
+    ).map((position) => POSITION_COORDS[position]);
+
+    for (const lf of [0, 1, 2, 3]) {
+      for (const cf of [0, 1, 2, 3]) {
+        for (const rf of [0, 1, 2, 3]) {
+          for (const zoneCount of [0, 2, 5, 8]) {
+            const coords = [
+              ...outfieldSpotCoords("LEFT_FIELD", lf),
+              ...outfieldSpotCoords("CENTER_FIELD", cf),
+              ...outfieldSpotCoords("RIGHT_FIELD", rf),
+              ...outfieldZoneCoords(zoneCount, {
+                deep: lf + cf + rf > 0,
+              }),
+            ];
+            const radius = outfieldHaloRadius(coords);
+            if (radius === null) {
+              continue;
+            }
+            const reach = reachOf(radius);
+            for (let i = 0; i < coords.length; i += 1) {
+              for (let j = i + 1; j < coords.length; j += 1) {
+                const gap = Math.hypot(
+                  coords[i].x - coords[j].x,
+                  coords[i].y - coords[j].y,
+                );
+                expect(gap).toBeGreaterThanOrEqual(2 * reach);
+              }
+              for (const fielder of infield) {
+                const gap = Math.hypot(
+                  coords[i].x - fielder.x,
+                  coords[i].y - fielder.y,
+                );
+                expect(gap).toBeGreaterThanOrEqual(
+                  reach + DIAMOND_GEOMETRY.markerRadius,
+                );
+              }
+            }
+          }
+        }
       }
     }
   });

--- a/src/components/diamond-geometry.ts
+++ b/src/components/diamond-geometry.ts
@@ -158,35 +158,47 @@ const OUTFIELD_ZONE = {
 } as const;
 
 /**
- * Where an allPlay team's outfielders stand.
+ * Where an allPlay team's GENERAL outfielders stand — the kids the coach
+ * hasn't pinned to a named LF/CF/RF spot (those draw via `outfieldSpotCoords`
+ * instead). The count is whatever the chart leaves over, and it moves with
+ * the team. Markers are laid out in rows across the grass, each row bowed the
+ * way an outfield actually plays: centre deepest, the ends drawn down toward
+ * the foul lines.
  *
- * That outfield is one zone rather than three named spots (#11), so the count
- * is whatever the infield leaves over — five on a twelve-player roster, but it
- * moves with the team. Markers are laid out in rows across the grass, each row
- * bowed the way an outfield actually plays: centre deepest, the ends drawn down
- * toward the foul lines.
- *
- * A row of three lands exactly on the LF/CF/RF coordinates above, which is the
- * point — a team that happens to field three outfielders reads as the standard
+ * A row of three lands exactly on the LF/CF/RF coordinates above, which is
+ * the point — a wholly unpinned outfield of three reads as the standard
  * diamond rather than as some other chart.
  *
  * Returns one coordinate per player, in the order given.
  */
 export function outfieldZoneCoords(
   count: number,
+  options: {
+    /**
+     * Draw the zone one row deeper, leaving the shallow row to the named
+     * outfield spots. The zone's shallow row sits AT the LF/CF/RF coordinates
+     * — that is its calibration — so when any of those spots has players
+     * standing on it, a shallow zone marker would land on top of them. The
+     * cost is that everything squeezes into the one remaining row (a third
+     * row would reach the middle infielders — see `maxRows`), which packs
+     * markers tighter than two rows would; past ~7 unpinned players the
+     * degradation is the crowded-zone one, halo first (`zoneHaloRadius`).
+     */
+    deep?: boolean;
+  } = {},
 ): { x: number; y: number }[] {
   if (count <= 0) {
     return [];
   }
 
-  const rows = Math.min(
-    OUTFIELD_ZONE.maxRows,
-    Math.ceil(count / OUTFIELD_ZONE.perRowTarget),
-  );
+  const firstRow = options.deep ? 1 : 0;
+  const rows = options.deep
+    ? OUTFIELD_ZONE.maxRows
+    : Math.min(OUTFIELD_ZONE.maxRows, Math.ceil(count / OUTFIELD_ZONE.perRowTarget));
   const coords: { x: number; y: number }[] = [];
   let placed = 0;
 
-  for (let row = 0; row < rows; row += 1) {
+  for (let row = firstRow; row < rows; row += 1) {
     // Spread the remainder over the rows that are left, so the deeper row takes
     // the extra player when the count doesn't divide evenly.
     const inRow = Math.ceil((count - placed) / (rows - row));
@@ -209,6 +221,73 @@ export function outfieldZoneCoords(
   }
 
   return coords;
+}
+
+/**
+ * The outfield arc the zone's row of three is calibrated to, as a function:
+ * offset -1 is exactly LF, 0 is CF, +1 is RF, and everything between falls on
+ * the same bow (`OUTFIELD_ZONE.arc` down per squared offset). Named spots and
+ * the zone both draw on this curve, which is what keeps a stack fanned around
+ * centre field looking like outfielders rather than like markers floating
+ * over grass.
+ */
+function arcPoint(offset: number): { x: number; y: number } {
+  // The unit is the row-of-three's half-spread: two gaps at spreadPerGap, so
+  // offset ±1 lands on x = 200 ± 125 — exactly LF and RF.
+  const unit = OUTFIELD_ZONE.spreadPerGap * 2;
+  return {
+    x: DIAMOND_GEOMETRY.width / 2 + offset * unit,
+    y: OUTFIELD_ZONE.depth + OUTFIELD_ZONE.arc * offset * offset,
+  };
+}
+
+/// Where each named outfield spot sits on that arc.
+const SPOT_ARC_OFFSET: Readonly<Partial<Record<Position, number>>> = {
+  LEFT_FIELD: -1,
+  CENTER_FIELD: 0,
+  RIGHT_FIELD: 1,
+};
+
+/// Half the arc-offset spread of a fanned pair / trio at one named spot, in
+/// arc units (125px each). A pair stands 55px apart — wide enough that the
+/// full `haloRadius` ring still fits both kids, and the widest fan whose
+/// outermost trio markers stay clear of a full neighbouring spot. A trio's
+/// neighbours stand 40px apart in x; at CF that is the whole distance and the
+/// halo goes (`outfieldHaloRadius` returns null — the crowded zone's own
+/// degradation at 15+ players), while LF/RF trios descend the bow and keep a
+/// shrunken ring.
+const SPOT_FAN = { pair: 0.22, trio: 0.32 } as const;
+
+/**
+ * Where the players pinned to one named outfield spot stand (#11 revision:
+ * an allPlay team's LF/CF/RF each hold up to three).
+ *
+ * One player stands exactly on the spot — `POSITION_COORDS[position]`, which
+ * `arcPoint(SPOT_ARC_OFFSET)` reproduces — so a board with single outfielders
+ * is pixel-identical to the fixed diamond. Two or three fan symmetrically
+ * around the spot along the outfield arc, tightly enough that three full
+ * spots (nine markers) stay clear of each other.
+ *
+ * Returns one coordinate per player, in the order given; empty for a
+ * position that is not a named outfield spot.
+ */
+export function outfieldSpotCoords(
+  position: Position,
+  count: number,
+): { x: number; y: number }[] {
+  const centre = SPOT_ARC_OFFSET[position];
+  if (centre === undefined || count <= 0) {
+    return [];
+  }
+  if (count === 1) {
+    return [arcPoint(centre)];
+  }
+  const fan = count === 2 ? SPOT_FAN.pair : SPOT_FAN.trio;
+  return Array.from({ length: count }, (_, index) => {
+    // -1 at the left end of the fan, +1 at the right, matching the zone rows.
+    const offset = (index / (count - 1)) * 2 - 1;
+    return arcPoint(centre + offset * fan);
+  });
 }
 
 /// How far a ring at `radius` reaches from its marker's centre — the stroke
@@ -238,7 +317,20 @@ function haloReach(radius: number): number {
 /// and the `sr-only` mirror still says "(your player)" — the ring is the fast
 /// path, never the only one.
 export function zoneHaloRadius(count: number): number | null {
-  const coords = outfieldZoneCoords(count);
+  return outfieldHaloRadius(outfieldZoneCoords(count));
+}
+
+/**
+ * The largest halo that fits around ANY of the given outfield markers, or
+ * `null` when none does — `zoneHaloRadius`'s engine, exported for the board
+ * that mixes named-spot fans with a deep zone row. One radius for the whole
+ * outfield, deliberately: it is a function of how tightly the markers pack,
+ * not of which marker is guarded, and two different-sized rings on one board
+ * would read as two different claims about the kids inside them.
+ */
+export function outfieldHaloRadius(
+  coords: readonly { x: number; y: number }[],
+): number | null {
   if (coords.length === 0) {
     return null;
   }
@@ -248,8 +340,9 @@ export function zoneHaloRadius(count: number): number | null {
     for (let j = i + 1; j < coords.length; j += 1) {
       minGap = Math.min(minGap, distance(coords[i], coords[j]));
     }
-    // The zone shares a board with the allPlay infield. LF/CF/RF are excluded
-    // by construction — the zone is drawn *at* those coordinates.
+    // The outfield shares a board with the allPlay infield. LF/CF/RF are
+    // excluded — the outfield is drawn *at* (and fanned around) those
+    // coordinates.
     for (const position of ALL_PLAY_INFIELD_POSITIONS) {
       minGap = Math.min(minGap, distance(coords[i], POSITION_COORDS[position]));
     }

--- a/src/components/diamond-geometry.ts
+++ b/src/components/diamond-geometry.ts
@@ -248,15 +248,37 @@ const SPOT_ARC_OFFSET: Readonly<Partial<Record<Position, number>>> = {
   RIGHT_FIELD: 1,
 };
 
-/// Half the arc-offset spread of a fanned pair / trio at one named spot, in
-/// arc units (125px each). A pair stands 55px apart — wide enough that the
-/// full `haloRadius` ring still fits both kids, and the widest fan whose
-/// outermost trio markers stay clear of a full neighbouring spot. A trio's
-/// neighbours stand 40px apart in x; at CF that is the whole distance and the
-/// halo goes (`outfieldHaloRadius` returns null — the crowded zone's own
-/// degradation at 15+ players), while LF/RF trios descend the bow and keep a
-/// shrunken ring.
-const SPOT_FAN = { pair: 0.22, trio: 0.32 } as const;
+/// The furthest a marker may sit from the centre line, in arc units — the same
+/// bound `OUTFIELD_ZONE.maxSpread` puts on a zone row, restated in this
+/// module's other coordinate. Names are centred under their marker, so a fan
+/// that ignored it would push the outermost NAME off the 400-wide box while
+/// every circle still fitted: the silent clipping this file already guards
+/// against for the catcher.
+const MAX_ARC_OFFSET =
+  OUTFIELD_ZONE.maxSpread / (OUTFIELD_ZONE.spreadPerGap * 2);
+
+/**
+ * Spacing between neighbours in one spot's fan, in arc units.
+ *
+ * Two numbers because the arc is not equally steep everywhere. Neighbours must
+ * stay `2 * markerRadius` apart in real distance, and a corner fan descends the
+ * bow — so 0.27 of an offset already buys 40px there, while CF's flat middle
+ * needs the full 0.32 (= 40px of pure x) to clear the same gap. Using CF's
+ * number at the corners would push a trio past `MAX_ARC_OFFSET`, and clamping
+ * it back would then collide with the CF fan next door; using the corner
+ * number at CF would overlap two markers outright. Both are pinned by
+ * `outfieldSpotCoords`'s tests, which check every pair on a nine-marker board.
+ */
+const SPOT_FAN_SPACING = { pair: 0.44, cornerTrio: 0.27, centreTrio: 0.32 } as const;
+
+function fanSpacing(centre: number, count: number): number {
+  if (count <= 2) {
+    return SPOT_FAN_SPACING.pair;
+  }
+  return centre === 0
+    ? SPOT_FAN_SPACING.centreTrio
+    : SPOT_FAN_SPACING.cornerTrio;
+}
 
 /**
  * Where the players pinned to one named outfield spot stand (#11 revision:
@@ -264,12 +286,19 @@ const SPOT_FAN = { pair: 0.22, trio: 0.32 } as const;
  *
  * One player stands exactly on the spot — `POSITION_COORDS[position]`, which
  * `arcPoint(SPOT_ARC_OFFSET)` reproduces — so a board with single outfielders
- * is pixel-identical to the fixed diamond. Two or three fan symmetrically
- * around the spot along the outfield arc, tightly enough that three full
- * spots (nine markers) stay clear of each other.
+ * is pixel-identical to the fixed diamond. Two or three fan along the outfield
+ * arc, tightly enough that three full spots (nine markers) stay clear of each
+ * other.
  *
- * Returns one coordinate per player, in the order given; empty for a
- * position that is not a named outfield spot.
+ * **The fan is centred on the spot and then slid back inside
+ * `MAX_ARC_OFFSET`**, which is why a corner pair or trio is not symmetric about
+ * its own spot: LF's outermost kid stands on the name-safe edge and the rest
+ * fan in toward centre field. Symmetry there would put a marker at x=35, whose
+ * centred name runs off the box — and the marker circle still fits, so nothing
+ * would fail visibly.
+ *
+ * Returns one coordinate per player, in the order given; empty for a position
+ * that is not a named outfield spot.
  */
 export function outfieldSpotCoords(
   position: Position,
@@ -282,13 +311,44 @@ export function outfieldSpotCoords(
   if (count === 1) {
     return [arcPoint(centre)];
   }
-  const fan = count === 2 ? SPOT_FAN.pair : SPOT_FAN.trio;
-  return Array.from({ length: count }, (_, index) => {
-    // -1 at the left end of the fan, +1 at the right, matching the zone rows.
-    const offset = (index / (count - 1)) * 2 - 1;
-    return arcPoint(centre + offset * fan);
-  });
+
+  const spacing = fanSpacing(centre, count);
+  const offsets = Array.from(
+    { length: count },
+    (_, index) => centre + (index - (count - 1) / 2) * spacing,
+  );
+
+  // Slide the whole fan — never squeeze it — so the spacing above keeps its
+  // guarantee while the ends stay inside the name-safe band.
+  const overshootLeft = -MAX_ARC_OFFSET - offsets[0];
+  const overshootRight = offsets[offsets.length - 1] - MAX_ARC_OFFSET;
+  const shift =
+    overshootLeft > 0 ? overshootLeft : overshootRight > 0 ? -overshootRight : 0;
+
+  return offsets.map((offset) => arcPoint(offset + shift));
 }
+
+/**
+ * Can `count` general-outfield players share the single deep row without their
+ * markers overlapping?
+ *
+ * The deep row is all the zone gets once a named spot is occupied: its shallow
+ * row sits AT the LF/CF/RF coordinates, and a third row would reach the middle
+ * infielders at y=252 (`OUTFIELD_ZONE.maxRows`). One row holds eight at the
+ * board's usual 41.4px floor and nine at 36.25px — under the 40px two markers
+ * need, which is an overlap, not a degradation.
+ *
+ * Reachable without an outlandish roster: a coach who pins outfielders BEFORE
+ * placing the infield leaves nine unpinned on a twelve-player team. `Diamond`
+ * answers it by giving up the pinned coordinates for that board rather than
+ * drawing markers on top of each other — see its `crowded` branch.
+ */
+export function deepZoneFits(count: number): boolean {
+  return count <= DEEP_ZONE_ROW_CAPACITY;
+}
+
+/// Eight: the last count whose single deep row keeps two markers 40px apart.
+const DEEP_ZONE_ROW_CAPACITY = 8;
 
 /// How far a ring at `radius` reaches from its marker's centre — the stroke
 /// straddles the radius, so half of it sits outside.
@@ -321,30 +381,42 @@ export function zoneHaloRadius(count: number): number | null {
 }
 
 /**
- * The largest halo that fits around ANY of the given outfield markers, or
- * `null` when none does — `zoneHaloRadius`'s engine, exported for the board
- * that mixes named-spot fans with a deep zone row. One radius for the whole
- * outfield, deliberately: it is a function of how tightly the markers pack,
- * not of which marker is guarded, and two different-sized rings on one board
- * would read as two different claims about the kids inside them.
+ * The largest halo that fits around the guarded markers on an outfield laid
+ * out at `coords` — `zoneHaloRadius`'s engine, exported for the board that
+ * mixes named-spot fans with a zone row.
+ *
+ * **Measured around the guarded markers, not the whole outfield.** One radius
+ * still covers the board, because two different-sized rings would read as two
+ * different claims about the kids inside them — but the crowding that decides
+ * it is the crowding those kids actually stand in. Taking the minimum over
+ * every pair instead let one three-deep spot on the far side of the field
+ * erase the ring around a guarded kid standing alone at LF: the parent lost
+ * the highlight to a cluster their child is nowhere near.
+ *
+ * `guarded` defaults to every marker, which is what `zoneHaloRadius` wants —
+ * it answers "could this zone hold a ring at all" for a whole-zone layout.
  */
 export function outfieldHaloRadius(
   coords: readonly { x: number; y: number }[],
+  guarded: readonly { x: number; y: number }[] = coords,
 ): number | null {
-  if (coords.length === 0) {
+  if (coords.length === 0 || guarded.length === 0) {
     return null;
   }
 
   let minGap = Infinity;
-  for (let i = 0; i < coords.length; i += 1) {
-    for (let j = i + 1; j < coords.length; j += 1) {
-      minGap = Math.min(minGap, distance(coords[i], coords[j]));
+  for (const marker of guarded) {
+    for (const other of coords) {
+      if (other === marker) {
+        continue;
+      }
+      minGap = Math.min(minGap, distance(marker, other));
     }
     // The outfield shares a board with the allPlay infield. LF/CF/RF are
     // excluded — the outfield is drawn *at* (and fanned around) those
     // coordinates.
     for (const position of ALL_PLAY_INFIELD_POSITIONS) {
-      minGap = Math.min(minGap, distance(coords[i], POSITION_COORDS[position]));
+      minGap = Math.min(minGap, distance(marker, POSITION_COORDS[position]));
     }
   }
 

--- a/src/lib/chart-role.test.ts
+++ b/src/lib/chart-role.test.ts
@@ -82,8 +82,14 @@ describe("chartRole on an allPlay team", () => {
     );
   });
 
-  it("reads a stale CENTER_FIELD or CATCHER row as OF", () => {
-    expect(chartRole(entry(5, "CENTER_FIELD"), allPlay)).toBe("Bats 5th · OF");
+  it("reads a named outfield row as its own spot — CF, not OF", () => {
+    // LF/CF/RF are placeable allPlay spots since the named-outfield revision,
+    // so a pinned kid's line says which one.
+    expect(chartRole(entry(5, "CENTER_FIELD"), allPlay)).toBe("Bats 5th · CF");
+    expect(chartRole(entry(null, "LEFT_FIELD"), allPlay)).toBe("LF");
+  });
+
+  it("reads a stale CATCHER row as OF — the coach pitches", () => {
     expect(chartRole(entry(5, "CATCHER"), allPlay)).toBe("Bats 5th · OF");
   });
 

--- a/src/lib/chart-role.ts
+++ b/src/lib/chart-role.ts
@@ -50,13 +50,14 @@ export type ChartRoleOptions = {
  *
  * The position label goes through the team's fielded set rather than straight
  * to `POSITION_LABELS`, for the same reason `computeReadiness` filters
- * uncovered spots through it: an allPlay team's stale `CENTER_FIELD` or
- * `CATCHER` row is not a spot that team fields. Printing "CF" beside the name
- * would assert a position the readiness page simultaneously refuses to check —
- * and contradict the view page and the editor, which both show that player in
- * the outfield. On an allPlay team everyone outside the infield is in the
- * outfield, `position = null` included, which is exactly what the next save
- * will write.
+ * uncovered spots through it: an allPlay team's stale `CATCHER` row is not a
+ * spot that team fields. Printing "C" beside the name would assert a position
+ * the readiness page simultaneously refuses to check — and contradict the
+ * view page and the editor, which both show that player in the outfield. A
+ * named outfield row IS fielded there since the spots became placeable, so a
+ * kid pinned to centre field reads "CF"; everyone else off the chart is in
+ * the general outfield, `position = null` included, which is exactly what the
+ * next save will write.
  */
 export function chartRole(
   entry: Pick<ChartViewEntry, "battingOrder" | "position">,

--- a/src/lib/chart-view.test.ts
+++ b/src/lib/chart-view.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildChartView,
   hasChartSet,
+  seatedEntryIds,
   type ChartViewEntry,
 } from "@/lib/chart-view";
 import type { Position } from "@/generated/prisma/enums";
@@ -211,6 +212,33 @@ describe("buildChartView", () => {
     ]);
     expect(view.unassigned).toEqual([]);
     expect(view.hasChart).toBe(true);
+  });
+
+  it("seats the same player whatever order the rows arrive in", () => {
+    // The regression: the capacity cut ran over `getChart`'s unordered
+    // findMany, so an over-capacity spot — three kids left at CF the moment
+    // allPlay is switched off — seated whichever row Postgres happened to
+    // return first. Same team, same data, a different centre fielder on a
+    // refresh. Sorting BEFORE the cut is what makes the pick deterministic.
+    const named = (playerId: string, jerseyNumber: number): ChartViewEntry => ({
+      entryId: `re-${playerId}`,
+      playerId,
+      playerName: playerId,
+      jerseyNumber,
+      battingOrder: null,
+      position: "CENTER_FIELD",
+    });
+    const rows = [named("cal", 9), named("dee", 3), named("eli", 5)];
+
+    const seatedIn = (order: ChartViewEntry[]) =>
+      buildChartView(order, noRsvps, false)
+        .byPosition.get("CENTER_FIELD")!
+        .map((player) => player.playerId);
+
+    // Lowest jersey wins, from any starting order — including the reverse.
+    expect(seatedIn(rows)).toEqual(["dee"]);
+    expect(seatedIn([...rows].reverse())).toEqual(["dee"]);
+    expect(seatedIn([rows[2], rows[0], rows[1]])).toEqual(["dee"]);
   });
 
   it("pools anyone past an outfield spot's capacity instead of dropping them", () => {
@@ -503,5 +531,69 @@ describe("hasChartSet", () => {
   it("is true as soon as one player has a slot or a position", () => {
     expect(hasChartSet([entry(1, null), entry(null, null)])).toBe(true);
     expect(hasChartSet([entry(null, "PITCHER"), entry(null, null)])).toBe(true);
+  });
+});
+
+describe("seatedEntryIds", () => {
+  const at = (
+    playerId: string,
+    jerseyNumber: number,
+    position: Position | null,
+  ): ChartViewEntry => ({
+    entryId: `re-${playerId}`,
+    playerId,
+    playerName: playerId,
+    jerseyNumber,
+    battingOrder: null,
+    position,
+  });
+
+  it("is exactly who buildChartView seats, so the pages cannot disagree", () => {
+    const entries = [
+      at("ava", 1, "PITCHER"),
+      at("ben", 2, "CENTER_FIELD"),
+      at("cal", 3, "CENTER_FIELD"),
+      at("dee", 4, null),
+      // Not a spot an allPlay team fields — the coach pitches.
+      at("eli", 5, "CATCHER"),
+    ];
+
+    const view = buildChartView(entries, noRsvps, true);
+    const seatedByView = new Set(
+      [...view.byPosition.values()].flat().map((player) => player.entryId),
+    );
+
+    expect(seatedEntryIds(entries, true)).toEqual(seatedByView);
+    expect(seatedEntryIds(entries, true)).toEqual(
+      new Set(["re-ava", "re-ben", "re-cal"]),
+    );
+  });
+
+  it("omits the kids an over-capacity spot cannot seat", () => {
+    // The bug this exists for: with allPlay off, one kid stands at CF and the
+    // other two are substitutes — so team home must not print "CF" for all
+    // three while /view seats one.
+    const entries = [
+      at("ava", 1, "CENTER_FIELD"),
+      at("ben", 2, "CENTER_FIELD"),
+      at("cal", 3, "CENTER_FIELD"),
+    ];
+
+    expect(seatedEntryIds(entries, false)).toEqual(new Set(["re-ava"]));
+    expect(seatedEntryIds(entries, true)).toEqual(
+      new Set(["re-ava", "re-ben", "re-cal"]),
+    );
+  });
+
+  it("does not depend on the order the rows arrive in", () => {
+    const entries = [
+      at("cal", 9, "CENTER_FIELD"),
+      at("dee", 3, "CENTER_FIELD"),
+    ];
+
+    expect(seatedEntryIds(entries, false)).toEqual(
+      seatedEntryIds([...entries].reverse(), false),
+    );
+    expect(seatedEntryIds(entries, false)).toEqual(new Set(["re-dee"]));
   });
 });

--- a/src/lib/chart-view.test.ts
+++ b/src/lib/chart-view.test.ts
@@ -93,9 +93,9 @@ describe("buildChartView", () => {
   it("maps assigned positions to their player", () => {
     const view = buildChartView(fullChart, noRsvps, false);
 
-    expect(view.byPosition.get("SHORTSTOP")?.playerId).toBe("ava");
-    expect(view.byPosition.get("PITCHER")?.playerId).toBe("ben");
-    expect(view.byPosition.get("FIRST_BASE")?.playerId).toBe("cy");
+    expect(view.byPosition.get("SHORTSTOP")?.[0].playerId).toBe("ava");
+    expect(view.byPosition.get("PITCHER")?.[0].playerId).toBe("ben");
+    expect(view.byPosition.get("FIRST_BASE")?.[0].playerId).toBe("cy");
     expect(view.byPosition.has("CATCHER")).toBe(false);
   });
 
@@ -123,7 +123,7 @@ describe("buildChartView", () => {
       "declined",
       "no-response",
     ]);
-    expect(view.byPosition.get("SHORTSTOP")?.rsvpState).toBe("declined");
+    expect(view.byPosition.get("SHORTSTOP")?.[0].rsvpState).toBe("declined");
   });
 
   it("never reorders, renumbers, or drops anyone based on rsvp state", () => {
@@ -189,28 +189,50 @@ describe("buildChartView", () => {
     expect(buildChartView([], noRsvps, false).hasChart).toBe(false);
   });
 
-  it("pools an allPlay team's stale named-outfield row instead of seating it", () => {
-    // The view page draws its outfield zone at the very coordinates a named
-    // outfield marker occupies, so seating this player would stack two markers
-    // on one spot and make both names unreadable. The editor already shows them
-    // in its zone; this is what keeps the two diamonds telling one story.
-    const stale: ChartViewEntry[] = [
-      {
-        entryId: "re-cal",
-        playerId: "cal",
-        playerName: "Cal",
-        jerseyNumber: 3,
-        battingOrder: 1,
-        position: "CENTER_FIELD",
-      },
-    ];
+  it("seats an allPlay team's named-outfield rows, stacked and sorted", () => {
+    // LF/CF/RF are placeable spots under allPlay since the named-outfield
+    // revision. The stack sorts jersey-then-name for the same reason the
+    // pool does: getChart has no orderBy, and an unsorted stack reshuffles
+    // between requests.
+    const named = (playerId: string, jerseyNumber: number | null): ChartViewEntry => ({
+      entryId: `re-${playerId}`,
+      playerId,
+      playerName: playerId,
+      jerseyNumber,
+      battingOrder: null,
+      position: "CENTER_FIELD",
+    });
 
-    const view = buildChartView(stale, noRsvps, true);
+    const view = buildChartView([named("zoe", 9), named("cal", 3)], noRsvps, true);
 
-    expect(view.byPosition.has("CENTER_FIELD")).toBe(false);
-    expect(view.unassigned.map((p) => p.playerId)).toEqual(["cal"]);
-    // Nobody vanishes, and the chart still counts as set.
+    expect(view.byPosition.get("CENTER_FIELD")?.map((p) => p.playerId)).toEqual([
+      "cal",
+      "zoe",
+    ]);
+    expect(view.unassigned).toEqual([]);
     expect(view.hasChart).toBe(true);
+  });
+
+  it("pools anyone past an outfield spot's capacity instead of dropping them", () => {
+    const named = (playerId: string, jerseyNumber: number): ChartViewEntry => ({
+      entryId: `re-${playerId}`,
+      playerId,
+      playerName: playerId,
+      jerseyNumber,
+      battingOrder: null,
+      position: "CENTER_FIELD",
+    });
+
+    const four = [named("a", 1), named("b", 2), named("c", 3), named("d", 4)];
+    const view = buildChartView(four, noRsvps, true);
+
+    expect(view.byPosition.get("CENTER_FIELD")).toHaveLength(3);
+    expect(view.unassigned.map((p) => p.playerId)).toEqual(["d"]);
+
+    // allPlay off: the same spot holds one, so three of the four pool.
+    const selective = buildChartView(four, noRsvps, false);
+    expect(selective.byPosition.get("CENTER_FIELD")).toHaveLength(1);
+    expect(selective.unassigned).toHaveLength(3);
   });
 
   it("pools an allPlay team's stale catcher row — the coach pitches", () => {
@@ -245,16 +267,16 @@ describe("buildChartView", () => {
 
     const view = buildChartView(named, noRsvps, false);
 
-    expect(view.byPosition.get("CENTER_FIELD")?.playerId).toBe("cal");
+    expect(view.byPosition.get("CENTER_FIELD")?.[0].playerId).toBe("cal");
     expect(view.unassigned).toEqual([]);
   });
 
   it("keeps the allPlay infield seated", () => {
     const view = buildChartView(fullChart, noRsvps, true);
 
-    expect(view.byPosition.get("SHORTSTOP")?.playerId).toBe("ava");
-    expect(view.byPosition.get("PITCHER")?.playerId).toBe("ben");
-    expect(view.byPosition.get("FIRST_BASE")?.playerId).toBe("cy");
+    expect(view.byPosition.get("SHORTSTOP")?.[0].playerId).toBe("ava");
+    expect(view.byPosition.get("PITCHER")?.[0].playerId).toBe("ben");
+    expect(view.byPosition.get("FIRST_BASE")?.[0].playerId).toBe("cy");
     expect(view.unassigned.map((p) => p.playerId)).toEqual(["eli"]);
   });
 
@@ -362,7 +384,7 @@ describe("buildChartView diamond names", () => {
 
     const view = buildChartView(entries, noRsvps, false);
 
-    expect(view.byPosition.get("SHORTSTOP")?.diamondName).toBe("Ava C.");
+    expect(view.byPosition.get("SHORTSTOP")?.[0].diamondName).toBe("Ava C.");
     expect(view.unassigned[0].diamondName).toBe("Ava R.");
   });
 

--- a/src/lib/chart-view.ts
+++ b/src/lib/chart-view.ts
@@ -91,6 +91,74 @@ export function byJerseyThenName(
   return a.jerseyNumber - b.jerseyNumber;
 }
 
+/// The seating rule, in one place: who the diamond puts at which spot, and who
+/// it leaves over. Shared by `buildChartView` and `seatedEntryIds` so a page
+/// asking "is this kid seated?" cannot answer it differently from the page
+/// that draws the board.
+///
+/// Order in, order out. Callers sort first (see `buildChartView`) — this
+/// function must never be handed `getChart`'s raw order, because the capacity
+/// cut below takes the first arrivals and would otherwise seat a different one
+/// of three over-capacity centre fielders on every request.
+function seat<T extends Pick<ChartViewEntry, "position">>(
+  players: readonly T[],
+  allPlay: boolean,
+): { byPosition: Map<Position, T[]>; unseated: T[] } {
+  const fielded = fieldedPositions(allPlay);
+  const byPosition = new Map<Position, T[]>();
+  const unseated: T[] = [];
+
+  for (const player of players) {
+    // First arrivals up to the spot's capacity, matching buildPositionsDraft;
+    // anyone past it is pooled rather than dropped.
+    const seated =
+      player.position !== null ? byPosition.get(player.position) : undefined;
+    if (
+      player.position !== null &&
+      fielded.has(player.position) &&
+      (seated?.length ?? 0) < positionCapacity(player.position, allPlay)
+    ) {
+      if (seated) {
+        seated.push(player);
+      } else {
+        byPosition.set(player.position, [player]);
+      }
+    } else {
+      unseated.push(player);
+    }
+  }
+
+  return { byPosition, unseated };
+}
+
+/**
+ * Which roster spots the diamond actually seats — the entry ids `/view` draws
+ * at a named position, as opposed to the ones it shows in the outfield zone or
+ * on the bench.
+ *
+ * Exists because a stored `position` is no longer enough to answer "where does
+ * this kid play". A spot has a capacity now, and a board can hold more rows
+ * than it: three kids saved at CF the moment `allPlay` is switched off. The
+ * pages that print a one-line chart role (team home's marquee, the readiness
+ * list) would otherwise read that column straight and tell all three families
+ * "CF" while `/view`, two taps away, seats one of them and lists the other two
+ * as substitutes.
+ *
+ * Sorts internally, so a caller may hand it `getChart`'s rows as they came.
+ */
+export function seatedEntryIds(
+  entries: readonly Pick<
+    ChartViewEntry,
+    "entryId" | "jerseyNumber" | "playerName" | "position"
+  >[],
+  allPlay: boolean,
+): Set<string> {
+  const { byPosition } = seat([...entries].sort(byJerseyThenName), allPlay);
+  return new Set(
+    [...byPosition.values()].flat().map((player) => player.entryId),
+  );
+}
+
 /**
  * @param allPlay Which spots this team actually fields. The read-side twin of
  * `buildPositionsDraft`'s parameter of the same name, and it does the same job:
@@ -112,54 +180,35 @@ export function buildChartView(
   const diamondNames = buildDiamondNames(
     entries.map((entry) => ({ id: entry.playerId, playerName: entry.playerName })),
   );
-  const players = entries.map((entry) => ({
-    ...entry,
-    rsvpState: rsvpStates.get(entry.playerId) ?? "no-response",
-    // Computed across every entry, not just the seated ones: a bench player
-    // named Ava makes the shortstop named Ava ambiguous just the same.
-    diamondName: diamondNames.get(entry.playerId) ?? entry.playerName,
-  }));
+  const players = entries
+    .map((entry) => ({
+      ...entry,
+      rsvpState: rsvpStates.get(entry.playerId) ?? "no-response",
+      // Computed across every entry, not just the seated ones: a bench player
+      // named Ava makes the shortstop named Ava ambiguous just the same.
+      diamondName: diamondNames.get(entry.playerId) ?? entry.playerName,
+    }))
+    // Sorted BEFORE anything is seated, not after. `getChart` is a findMany
+    // with no orderBy, so with more rows at a spot than it can hold — three
+    // kids left at CF after allPlay was switched off — taking "the first
+    // arrivals" out of Postgres's order would seat a different one of them on
+    // each request, with no data change behind it. Sorting first makes the
+    // choice deterministic AND the same one the editor makes, since the
+    // positions page hands `buildPositionsDraft` a `sortRoster`ed list.
+    .sort(byJerseyThenName);
 
   const lineup = players
     .filter((player) => player.battingOrder !== null)
     .sort((a, b) => a.battingOrder! - b.battingOrder!);
 
-  const fielded = fieldedPositions(allPlay);
-  const byPosition = new Map<Position, ChartViewPlayer[]>();
-  const unseated: ChartViewPlayer[] = [];
-  for (const player of players) {
-    // First arrivals up to the spot's capacity, matching buildPositionsDraft;
-    // anyone past it is pooled rather than dropped.
-    const seated =
-      player.position !== null ? byPosition.get(player.position) : undefined;
-    if (
-      player.position !== null &&
-      fielded.has(player.position) &&
-      (seated?.length ?? 0) < positionCapacity(player.position, allPlay)
-    ) {
-      if (seated) {
-        seated.push(player);
-      } else {
-        byPosition.set(player.position, [player]);
-      }
-    } else {
-      unseated.push(player);
-    }
-  }
+  const { byPosition, unseated } = seat(players, allPlay);
 
-  // Stacks sort like the pool does, and for the same reason: `getChart` is a
-  // findMany with no orderBy, so an unsorted stack of three centre fielders
-  // would reshuffle between two requests.
-  for (const seated of byPosition.values()) {
-    seated.sort(byJerseyThenName);
-  }
-
-  // Sorted, not left in the order `getChart` handed over: that is a findMany
-  // with no orderBy, so Postgres is free to return the rows differently between
-  // two requests and the outfield cluster would visibly reshuffle. Jersey then
-  // name is `sortRoster`'s order (roster-rules.ts), which is what the coach
-  // arranged in the editor's zone.
-  const unassigned = unseated.sort(byJerseyThenName);
+  // Already in jersey-then-name order — `players` was sorted above, and both
+  // loops below preserve it. That order is `sortRoster`'s (roster-rules.ts),
+  // which is what the coach arranged in the editor's zone; leaving it as
+  // `getChart` handed it over would let the outfield cluster visibly reshuffle
+  // between two requests.
+  const unassigned = unseated;
 
   return { lineup, byPosition, unassigned, hasChart: hasChartSet(entries) };
 }

--- a/src/lib/chart-view.ts
+++ b/src/lib/chart-view.ts
@@ -1,6 +1,6 @@
 import { Position } from "@/generated/prisma/enums";
 import { buildDiamondNames } from "@/lib/diamond-names";
-import { fieldedPositions } from "@/lib/positions";
+import { fieldedPositions, positionCapacity } from "@/lib/positions";
 import type { RsvpState } from "@/lib/rsvp";
 
 /// The view page's read-only render model (#8).
@@ -48,13 +48,18 @@ export type ChartViewPlayer = ChartViewEntry & {
 export type ChartView = {
   /// Rostered players in the standing batting order, ascending.
   lineup: ChartViewPlayer[];
-  /// Every position that has an assigned player, keyed by position.
-  byPosition: Map<Position, ChartViewPlayer>;
+  /// Every position that has assigned players, keyed by position — a list
+  /// because an allPlay team's LF/CF/RF each stack to three
+  /// (`positionCapacity`); everywhere else the list is a single player. Each
+  /// stack is in jersey-then-name order, since nothing persisted orders
+  /// players within a spot (`positionSlot` is a uniqueness mechanism, not
+  /// state) and an unsorted stack would reshuffle between requests.
+  byPosition: Map<Position, ChartViewPlayer[]>;
   /// Everyone the diamond doesn't seat, in the roster's jersey-then-name order.
   /// What this means depends on the team's `allPlay` setting, which is why it
-  /// isn't named here: on an allPlay team it's the outfield (LF/CF/RF are one
-  /// zone and hold everyone left over — see `droppablePositions` in chart.ts),
-  /// and otherwise it's the bench. The page decides how to say it.
+  /// isn't named here: on an allPlay team it's the general outfield (whoever
+  /// the coach hasn't pinned to a named spot — see `droppablePositions` in
+  /// chart.ts), and otherwise it's the bench. The page decides how to say it.
   unassigned: ChartViewPlayer[];
   /// True when at least one roster entry has a batting order or a position
   /// set — a partial chart (entered incrementally by hand during the
@@ -90,15 +95,14 @@ export function byJerseyThenName(
  * @param allPlay Which spots this team actually fields. The read-side twin of
  * `buildPositionsDraft`'s parameter of the same name, and it does the same job:
  * a player stored at a position the team doesn't field — an allPlay team's
- * stale LF/CF/RF or CATCHER row, hand-set during #9 or left behind when allPlay
- * was switched on — is pooled rather than seated.
+ * stale CATCHER row, hand-set during #9 or left behind when allPlay was
+ * switched on — is pooled rather than seated, as is anyone past a spot's
+ * capacity (a named outfield stack after allPlay was switched off).
  *
- * That is what keeps the two diamonds telling one story. The editor already
- * shows those players in its outfield zone, and the view page draws its zone at
- * the very coordinates a named outfield marker would occupy, so seating them
- * here would stack two markers on one spot and make both names unreadable.
- * Nobody vanishes either way — they are in the outfield, which is where the
- * coach's next save will put them.
+ * That is what keeps the two diamonds telling one story: the editor already
+ * shows those same players in its zone. Nobody vanishes either way — they are
+ * in the outfield (or on the bench), which is where the coach's next save
+ * will put them.
  */
 export function buildChartView(
   entries: readonly ChartViewEntry[],
@@ -121,21 +125,33 @@ export function buildChartView(
     .sort((a, b) => a.battingOrder! - b.battingOrder!);
 
   const fielded = fieldedPositions(allPlay);
-  const byPosition = new Map<Position, ChartViewPlayer>();
+  const byPosition = new Map<Position, ChartViewPlayer[]>();
   const unseated: ChartViewPlayer[] = [];
   for (const player of players) {
-    // First writer wins, matching buildPositionsDraft. The unique index makes a
-    // collision unreachable from a real read, but the loser is pooled rather
-    // than dropped if it ever happens.
+    // First arrivals up to the spot's capacity, matching buildPositionsDraft;
+    // anyone past it is pooled rather than dropped.
+    const seated =
+      player.position !== null ? byPosition.get(player.position) : undefined;
     if (
       player.position !== null &&
       fielded.has(player.position) &&
-      !byPosition.has(player.position)
+      (seated?.length ?? 0) < positionCapacity(player.position, allPlay)
     ) {
-      byPosition.set(player.position, player);
+      if (seated) {
+        seated.push(player);
+      } else {
+        byPosition.set(player.position, [player]);
+      }
     } else {
       unseated.push(player);
     }
+  }
+
+  // Stacks sort like the pool does, and for the same reason: `getChart` is a
+  // findMany with no orderBy, so an unsorted stack of three centre fielders
+  // would reshuffle between two requests.
+  for (const seated of byPosition.values()) {
+    seated.sort(byJerseyThenName);
   }
 
   // Sorted, not left in the order `getChart` handed over: that is a findMany

--- a/src/lib/chart.test.ts
+++ b/src/lib/chart.test.ts
@@ -41,10 +41,10 @@ function fielder(entryId: string, position: Position | null = null) {
 /// can start from an arbitrary board state.
 function draftOf(
   allPlay: boolean,
-  assigned: Partial<Record<Position, string>>,
+  assigned: Partial<Record<Position, readonly string[]>>,
   pool: string[] = [],
 ): PositionsDraft {
-  return { positions: droppablePositions(allPlay), assigned, pool };
+  return { positions: droppablePositions(allPlay), allPlay, assigned, pool };
 }
 
 describe("slotCount", () => {
@@ -459,19 +459,22 @@ describe("save then reload round trip", () => {
 });
 
 describe("droppablePositions", () => {
-  it("is the five infield spots under allPlay — no catcher, and the outfield is one zone", () => {
+  it("is everything but the catcher under allPlay — the coach pitches, and LF/CF/RF are placeable spots", () => {
     expect(droppablePositions(true)).toEqual([
       "PITCHER",
       "FIRST_BASE",
       "SECOND_BASE",
       "THIRD_BASE",
       "SHORTSTOP",
+      "LEFT_FIELD",
+      "CENTER_FIELD",
+      "RIGHT_FIELD",
     ]);
   });
 
   it("is all nine when allPlay is off", () => {
     expect(droppablePositions(false)).toHaveLength(9);
-    expect(droppablePositions(false)).toContain("CENTER_FIELD");
+    expect(droppablePositions(false)).toContain("CATCHER");
   });
 });
 
@@ -481,18 +484,32 @@ describe("buildPositionsDraft", () => {
       [fielder("a", "PITCHER"), fielder("b"), fielder("c", "SHORTSTOP")],
       false,
     );
-    expect(draft.assigned).toEqual({ PITCHER: "a", SHORTSTOP: "c" });
+    expect(draft.assigned).toEqual({ PITCHER: ["a"], SHORTSTOP: ["c"] });
     expect(draft.pool).toEqual(["b"]);
   });
 
-  it("pools named outfield players under allPlay instead of seating them", () => {
+  it("stacks named outfield players under allPlay, in entry order", () => {
+    const draft = buildPositionsDraft(
+      [
+        fielder("a", "PITCHER"),
+        fielder("b", "LEFT_FIELD"),
+        fielder("c", "LEFT_FIELD"),
+        fielder("d"),
+      ],
+      true,
+    );
+    expect(draft.assigned).toEqual({ PITCHER: ["a"], LEFT_FIELD: ["b", "c"] });
+    expect(draft.pool).toEqual(["d"]);
+  });
+
+  it("pools a catcher row under allPlay instead of seating it", () => {
     // Hand-set during #9, or left behind when allPlay was switched on. The
     // coach sees them in the outfield zone before anything is written.
     const draft = buildPositionsDraft(
-      [fielder("a", "PITCHER"), fielder("b", "LEFT_FIELD"), fielder("c")],
+      [fielder("a", "PITCHER"), fielder("b", "CATCHER"), fielder("c")],
       true,
     );
-    expect(draft.assigned).toEqual({ PITCHER: "a" });
+    expect(draft.assigned).toEqual({ PITCHER: ["a"] });
     expect(draft.pool).toEqual(["b", "c"]);
   });
 
@@ -504,13 +521,40 @@ describe("buildPositionsDraft", () => {
     expect(draft.pool).toEqual(["c", "a", "b"]);
   });
 
-  it("pools a second claimant rather than dropping them", () => {
-    const draft = buildPositionsDraft(
+  it("pools a claimant past a spot's capacity rather than dropping them", () => {
+    const infield = buildPositionsDraft(
       [fielder("a", "PITCHER"), fielder("b", "PITCHER")],
       true,
     );
-    expect(draft.assigned).toEqual({ PITCHER: "a" });
-    expect(draft.pool).toEqual(["b"]);
+    expect(infield.assigned).toEqual({ PITCHER: ["a"] });
+    expect(infield.pool).toEqual(["b"]);
+
+    // A named outfield stack of three is over capacity the instant allPlay is
+    // switched off — first arrivals keep the spot, the rest wait in the pool.
+    const outfield = buildPositionsDraft(
+      [
+        fielder("a", "CENTER_FIELD"),
+        fielder("b", "CENTER_FIELD"),
+        fielder("c", "CENTER_FIELD"),
+      ],
+      false,
+    );
+    expect(outfield.assigned).toEqual({ CENTER_FIELD: ["a"] });
+    expect(outfield.pool).toEqual(["b", "c"]);
+  });
+
+  it("caps an outfield stack at three even under allPlay", () => {
+    const draft = buildPositionsDraft(
+      [
+        fielder("a", "CENTER_FIELD"),
+        fielder("b", "CENTER_FIELD"),
+        fielder("c", "CENTER_FIELD"),
+        fielder("d", "CENTER_FIELD"),
+      ],
+      true,
+    );
+    expect(draft.assigned).toEqual({ CENTER_FIELD: ["a", "b", "c"] });
+    expect(draft.pool).toEqual(["d"]);
   });
 
   it("handles an empty roster and a fully unset chart", () => {
@@ -523,32 +567,38 @@ describe("buildPositionsDraft", () => {
 });
 
 describe("positionOf", () => {
-  const base = draftOf(false, { PITCHER: "a" }, ["x"]);
+  const base = draftOf(false, { PITCHER: ["a"] }, ["x"]);
 
   it("finds a seated player, and reports null otherwise", () => {
     expect(positionOf(base, "a")).toBe("PITCHER");
     expect(positionOf(base, "x")).toBe(null);
     expect(positionOf(base, "nope")).toBe(null);
   });
+
+  it("finds every member of an outfield stack", () => {
+    const stacked = draftOf(true, { CENTER_FIELD: ["a", "b"] });
+    expect(positionOf(stacked, "a")).toBe("CENTER_FIELD");
+    expect(positionOf(stacked, "b")).toBe("CENTER_FIELD");
+  });
 });
 
 describe("placeAtPosition", () => {
-  const base = draftOf(false, { PITCHER: "a", CATCHER: "b" }, ["x", "y"]);
+  const base = draftOf(false, { PITCHER: ["a"], CATCHER: ["b"] }, ["x", "y"]);
 
   it("swaps two seated players", () => {
     const next = placeAtPosition(base, "a", "CATCHER");
-    expect(next.assigned).toEqual({ PITCHER: "b", CATCHER: "a" });
+    expect(next.assigned).toEqual({ PITCHER: ["b"], CATCHER: ["a"] });
     expect(next.pool).toEqual(["x", "y"]);
   });
 
   it("moves a seated player to an empty spot, emptying their old one", () => {
     const next = placeAtPosition(base, "a", "SHORTSTOP");
-    expect(next.assigned).toEqual({ CATCHER: "b", SHORTSTOP: "a" });
+    expect(next.assigned).toEqual({ CATCHER: ["b"], SHORTSTOP: ["a"] });
   });
 
   it("swaps a pooled player with a seated one", () => {
     const next = placeAtPosition(base, "x", "PITCHER");
-    expect(next.assigned).toEqual({ PITCHER: "x", CATCHER: "b" });
+    expect(next.assigned).toEqual({ PITCHER: ["x"], CATCHER: ["b"] });
     // The displaced player takes the dragged player's place in the pool.
     expect(next.pool).toEqual(["a", "y"]);
   });
@@ -556,15 +606,45 @@ describe("placeAtPosition", () => {
   it("seats a pooled player at an empty spot", () => {
     const next = placeAtPosition(base, "y", "SHORTSTOP");
     expect(next.assigned).toEqual({
-      PITCHER: "a",
-      CATCHER: "b",
-      SHORTSTOP: "y",
+      PITCHER: ["a"],
+      CATCHER: ["b"],
+      SHORTSTOP: ["y"],
     });
     expect(next.pool).toEqual(["x"]);
   });
 
-  it("ignores a drop on the player's own position", () => {
+  it("lets a pooled player join an outfield spot that has room, displacing nobody", () => {
+    const allPlay = draftOf(true, { LEFT_FIELD: ["a", "b"] }, ["x"]);
+    const next = placeAtPosition(allPlay, "x", "LEFT_FIELD");
+    expect(next.assigned).toEqual({ LEFT_FIELD: ["a", "b", "x"] });
+    expect(next.pool).toEqual([]);
+  });
+
+  it("lets a seated player join an outfield spot that has room", () => {
+    const allPlay = draftOf(true, { PITCHER: ["a"], CENTER_FIELD: ["b"] });
+    const next = placeAtPosition(allPlay, "a", "CENTER_FIELD");
+    expect(next.assigned).toEqual({ CENTER_FIELD: ["b", "a"] });
+  });
+
+  it("swaps with a full outfield spot's most recent arrival", () => {
+    const allPlay = draftOf(true, { RIGHT_FIELD: ["a", "b", "c"] }, ["x"]);
+    const next = placeAtPosition(allPlay, "x", "RIGHT_FIELD");
+    expect(next.assigned).toEqual({ RIGHT_FIELD: ["a", "b", "x"] });
+    // The displaced player takes the dragged player's place in the pool.
+    expect(next.pool).toEqual(["c"]);
+  });
+
+  it("caps an infield spot at one under allPlay — the old swap grammar", () => {
+    const allPlay = draftOf(true, { PITCHER: ["a"] }, ["x"]);
+    const next = placeAtPosition(allPlay, "x", "PITCHER");
+    expect(next.assigned).toEqual({ PITCHER: ["x"] });
+    expect(next.pool).toEqual(["a"]);
+  });
+
+  it("ignores a drop on the player's own position, stacked or not", () => {
     expect(placeAtPosition(base, "a", "PITCHER")).toBe(base);
+    const stacked = draftOf(true, { CENTER_FIELD: ["a", "b"] });
+    expect(placeAtPosition(stacked, "a", "CENTER_FIELD")).toBe(stacked);
   });
 
   it("ignores unknown entries", () => {
@@ -573,25 +653,36 @@ describe("placeAtPosition", () => {
 
   it("refuses a position this board doesn't have", () => {
     // The structural half of Decision 1: an allPlay draft cannot be talked
-    // into holding an outfield assignment, whatever calls it.
-    const allPlay = draftOf(true, { PITCHER: "a" }, ["x"]);
-    expect(placeAtPosition(allPlay, "x", "LEFT_FIELD")).toBe(allPlay);
+    // into holding a catcher assignment, whatever calls it.
+    const allPlay = draftOf(true, { PITCHER: ["a"] }, ["x"]);
+    expect(placeAtPosition(allPlay, "x", "CATCHER")).toBe(allPlay);
   });
 
   it("never mutates its input", () => {
     placeAtPosition(base, "x", "PITCHER");
-    expect(base.assigned).toEqual({ PITCHER: "a", CATCHER: "b" });
+    expect(base.assigned).toEqual({ PITCHER: ["a"], CATCHER: ["b"] });
     expect(base.pool).toEqual(["x", "y"]);
+
+    const stacked = draftOf(true, { RIGHT_FIELD: ["a", "b", "c"] }, ["x"]);
+    placeAtPosition(stacked, "x", "RIGHT_FIELD");
+    expect(stacked.assigned).toEqual({ RIGHT_FIELD: ["a", "b", "c"] });
+    expect(stacked.pool).toEqual(["x"]);
   });
 });
 
 describe("unassignPosition", () => {
-  const base = draftOf(true, { PITCHER: "a", CATCHER: "b" }, ["x"]);
+  const base = draftOf(true, { PITCHER: ["a"], LEFT_FIELD: ["b", "c"] }, ["x"]);
 
   it("empties the spot and appends the player to the pool", () => {
     const next = unassignPosition(base, "a");
-    expect(next.assigned).toEqual({ CATCHER: "b" });
+    expect(next.assigned).toEqual({ LEFT_FIELD: ["b", "c"] });
     expect(next.pool).toEqual(["x", "a"]);
+  });
+
+  it("removes one player from a stack, keeping the rest seated", () => {
+    const next = unassignPosition(base, "b");
+    expect(next.assigned).toEqual({ PITCHER: ["a"], LEFT_FIELD: ["c"] });
+    expect(next.pool).toEqual(["x", "b"]);
   });
 
   it("is a no-op for a pooled or unknown player", () => {
@@ -600,54 +691,80 @@ describe("unassignPosition", () => {
   });
 
   it("never mutates its input", () => {
-    unassignPosition(base, "a");
-    expect(base.assigned).toEqual({ PITCHER: "a", CATCHER: "b" });
+    unassignPosition(base, "b");
+    expect(base.assigned).toEqual({ PITCHER: ["a"], LEFT_FIELD: ["b", "c"] });
   });
 });
 
 describe("samePositions", () => {
   it("compares the diamond and ignores pool order", () => {
-    expect(samePositions({ PITCHER: "a" }, { PITCHER: "a" })).toBe(true);
-    expect(samePositions({ PITCHER: "a" }, { PITCHER: "b" })).toBe(false);
-    expect(samePositions({ PITCHER: "a" }, {})).toBe(false);
+    expect(samePositions({ PITCHER: ["a"] }, { PITCHER: ["a"] })).toBe(true);
+    expect(samePositions({ PITCHER: ["a"] }, { PITCHER: ["b"] })).toBe(false);
+    expect(samePositions({ PITCHER: ["a"] }, {})).toBe(false);
     expect(samePositions({}, {})).toBe(true);
     expect(
-      samePositions({ PITCHER: "a", CATCHER: "b" }, { CATCHER: "b", PITCHER: "a" }),
+      samePositions(
+        { PITCHER: ["a"], CATCHER: ["b"] },
+        { CATCHER: ["b"], PITCHER: ["a"] },
+      ),
     ).toBe(true);
+  });
+
+  it("ignores arrival order within a stack — nothing persisted distinguishes it", () => {
+    expect(
+      samePositions({ CENTER_FIELD: ["a", "b"] }, { CENTER_FIELD: ["b", "a"] }),
+    ).toBe(true);
+    expect(
+      samePositions({ CENTER_FIELD: ["a", "b"] }, { CENTER_FIELD: ["a", "c"] }),
+    ).toBe(false);
+    expect(
+      samePositions({ CENTER_FIELD: ["a", "b"] }, { CENTER_FIELD: ["a"] }),
+    ).toBe(false);
+  });
+
+  it("treats an absent key and an empty stack as the same board", () => {
+    expect(samePositions({ CENTER_FIELD: [] }, {})).toBe(true);
   });
 });
 
 describe("storedPositions", () => {
-  it("reads the positions the rows actually hold", () => {
+  it("reads the positions the rows actually hold, stacks included", () => {
     expect(
       storedPositions([
         { entryId: "a", position: "PITCHER" },
         { entryId: "b", position: null },
         { entryId: "c", position: "SHORTSTOP" },
+        { entryId: "d", position: "CENTER_FIELD" },
+        { entryId: "e", position: "CENTER_FIELD" },
       ]),
-    ).toEqual({ PITCHER: "a", SHORTSTOP: "c" });
+    ).toEqual({
+      PITCHER: ["a"],
+      SHORTSTOP: ["c"],
+      CENTER_FIELD: ["d", "e"],
+    });
   });
 
   it("keeps a position the board can't drop on", () => {
     // The whole point: buildPositionsDraft pools this row under allPlay, so
-    // only storedPositions can still see that the database says CENTER_FIELD.
-    const entries = [{ entryId: "a", position: "CENTER_FIELD" as const }];
+    // only storedPositions can still see that the database says CATCHER.
+    const entries = [{ entryId: "a", position: "CATCHER" as const }];
 
-    expect(storedPositions(entries)).toEqual({ CENTER_FIELD: "a" });
+    expect(storedPositions(entries)).toEqual({ CATCHER: ["a"] });
     expect(buildPositionsDraft(entries, true).assigned).toEqual({});
   });
 
   it("differs from a freshly built allPlay draft exactly when a stale row exists", () => {
     // This inequality is what enables Save on load; the equality below is what
     // keeps it disabled when there is genuinely nothing to write.
-    const stale = [{ entryId: "a", position: "LEFT_FIELD" as const }];
+    const stale = [{ entryId: "a", position: "CATCHER" as const }];
     expect(
       samePositions(buildPositionsDraft(stale, true).assigned, storedPositions(stale)),
     ).toBe(false);
 
     const clean = [
       { entryId: "a", position: "PITCHER" as const },
-      { entryId: "b", position: null },
+      { entryId: "b", position: "LEFT_FIELD" as const },
+      { entryId: "c", position: null },
     ];
     expect(
       samePositions(buildPositionsDraft(clean, true).assigned, storedPositions(clean)),
@@ -676,22 +793,22 @@ describe("storedPositions", () => {
 });
 
 describe("resolvePositionDrop", () => {
-  const base = draftOf(false, { PITCHER: "a", CATCHER: "b" }, ["x"]);
+  const base = draftOf(false, { PITCHER: ["a"], CATCHER: ["b"] }, ["x"]);
 
   it("drops onto a position target by its enum name", () => {
     const next = resolvePositionDrop(base, "x", "SHORTSTOP");
-    expect(next.assigned.SHORTSTOP).toBe("x");
+    expect(next.assigned.SHORTSTOP).toEqual(["x"]);
     expect(next.pool).toEqual([]);
   });
 
   it("drops onto a seated player's chip by resolving to their position", () => {
     const next = resolvePositionDrop(base, "a", "b");
-    expect(next.assigned).toEqual({ PITCHER: "b", CATCHER: "a" });
+    expect(next.assigned).toEqual({ PITCHER: ["b"], CATCHER: ["a"] });
   });
 
   it("drops onto the zone", () => {
     const next = resolvePositionDrop(base, "a", POSITION_POOL_ID);
-    expect(next.assigned).toEqual({ CATCHER: "b" });
+    expect(next.assigned).toEqual({ CATCHER: ["b"] });
     expect(next.pool).toEqual(["x", "a"]);
   });
 
@@ -701,48 +818,82 @@ describe("resolvePositionDrop", () => {
     expect(resolvePositionDrop(base, "a", "not-a-target")).toBe(base);
   });
 
-  it("ignores an outfield target under allPlay", () => {
+  it("stacks onto an outfield target under allPlay", () => {
+    const allPlay = draftOf(true, { RIGHT_FIELD: ["a"] }, ["x"]);
+    const next = resolvePositionDrop(allPlay, "x", "RIGHT_FIELD");
+    expect(next.assigned).toEqual({ RIGHT_FIELD: ["a", "x"] });
+  });
+
+  it("resolves a drop on a stacked player's chip to their spot, joining while there is room", () => {
+    const allPlay = draftOf(true, { RIGHT_FIELD: ["a", "b"] }, ["x"]);
+    const next = resolvePositionDrop(allPlay, "x", "b");
+    expect(next.assigned).toEqual({ RIGHT_FIELD: ["a", "b", "x"] });
+  });
+
+  it("ignores a catcher target under allPlay", () => {
     const allPlay = draftOf(true, {}, ["x"]);
-    expect(resolvePositionDrop(allPlay, "x", "RIGHT_FIELD")).toBe(allPlay);
+    expect(resolvePositionDrop(allPlay, "x", "CATCHER")).toBe(allPlay);
   });
 });
 
 describe("nextDroppableId", () => {
-  const infield = droppablePositions(true);
+  const allPlayBoard = droppablePositions(true);
 
   it("cycles forward through the positions and then the zone", () => {
-    expect(nextDroppableId(infield, "PITCHER", 1)).toBe("FIRST_BASE");
-    expect(nextDroppableId(infield, "SHORTSTOP", 1)).toBe(POSITION_POOL_ID);
-    expect(nextDroppableId(infield, POSITION_POOL_ID, 1)).toBe("PITCHER");
+    expect(nextDroppableId(allPlayBoard, "PITCHER", 1)).toBe("FIRST_BASE");
+    expect(nextDroppableId(allPlayBoard, "SHORTSTOP", 1)).toBe("LEFT_FIELD");
+    expect(nextDroppableId(allPlayBoard, "RIGHT_FIELD", 1)).toBe(
+      POSITION_POOL_ID,
+    );
+    expect(nextDroppableId(allPlayBoard, POSITION_POOL_ID, 1)).toBe("PITCHER");
   });
 
   it("cycles backward too", () => {
-    expect(nextDroppableId(infield, "FIRST_BASE", -1)).toBe("PITCHER");
-    expect(nextDroppableId(infield, "PITCHER", -1)).toBe(POSITION_POOL_ID);
+    expect(nextDroppableId(allPlayBoard, "FIRST_BASE", -1)).toBe("PITCHER");
+    expect(nextDroppableId(allPlayBoard, "PITCHER", -1)).toBe(POSITION_POOL_ID);
   });
 
-  it("reaches the outfield only when allPlay is off", () => {
-    expect(nextDroppableId(droppablePositions(false), "SHORTSTOP", 1)).toBe(
-      "LEFT_FIELD",
+  it("reaches the catcher only when allPlay is off", () => {
+    expect(nextDroppableId(droppablePositions(false), "PITCHER", 1)).toBe(
+      "CATCHER",
     );
+    expect(nextDroppableId(allPlayBoard, "PITCHER", 1)).toBe("FIRST_BASE");
   });
 
   it("starts at the first target for an id that isn't a droppable", () => {
-    expect(nextDroppableId(infield, "some-entry-id", 1)).toBe("PITCHER");
+    expect(nextDroppableId(allPlayBoard, "some-entry-id", 1)).toBe("PITCHER");
   });
 });
 
 describe("validatePositions", () => {
-  const roster = ["a", "b", "c"];
+  const roster = ["a", "b", "c", "d", "e"];
 
   it("accepts a chart and returns assignments in scorebook order", () => {
     expect(
-      validatePositions({ SHORTSTOP: "c", PITCHER: "a" }, roster, true),
+      validatePositions({ SHORTSTOP: ["c"], PITCHER: ["a"] }, roster, true),
     ).toEqual({
       ok: true,
       assignments: [
-        { entryId: "a", position: "PITCHER" },
-        { entryId: "c", position: "SHORTSTOP" },
+        { entryId: "a", position: "PITCHER", positionSlot: 0 },
+        { entryId: "c", position: "SHORTSTOP", positionSlot: 0 },
+      ],
+    });
+  });
+
+  it("numbers an outfield stack's slots in submitted order", () => {
+    expect(
+      validatePositions(
+        { CENTER_FIELD: ["b", "d", "e"], PITCHER: ["a"] },
+        roster,
+        true,
+      ),
+    ).toEqual({
+      ok: true,
+      assignments: [
+        { entryId: "a", position: "PITCHER", positionSlot: 0 },
+        { entryId: "b", position: "CENTER_FIELD", positionSlot: 0 },
+        { entryId: "d", position: "CENTER_FIELD", positionSlot: 1 },
+        { entryId: "e", position: "CENTER_FIELD", positionSlot: 2 },
       ],
     });
   });
@@ -752,57 +903,79 @@ describe("validatePositions", () => {
       ok: true,
       assignments: [],
     });
-    expect(validatePositions({ PITCHER: "a" }, roster, false)).toEqual({
+    expect(validatePositions({ PITCHER: ["a"] }, roster, false)).toEqual({
       ok: true,
-      assignments: [{ entryId: "a", position: "PITCHER" }],
+      assignments: [{ entryId: "a", position: "PITCHER", positionSlot: 0 }],
     });
   });
 
   it("rejects ids not on this roster", () => {
-    expect(validatePositions({ PITCHER: "intruder" }, roster, true)).toEqual({
+    expect(validatePositions({ PITCHER: ["intruder"] }, roster, true)).toEqual({
       ok: false,
       reason: "unknown-entry",
     });
   });
 
-  it("rejects the same player at two positions", () => {
+  it("rejects the same player at two positions, or twice in one stack", () => {
     expect(
-      validatePositions({ PITCHER: "a", SHORTSTOP: "a" }, roster, true),
+      validatePositions({ PITCHER: ["a"], SHORTSTOP: ["a"] }, roster, true),
+    ).toEqual({ ok: false, reason: "duplicate-entry" });
+    expect(
+      validatePositions({ CENTER_FIELD: ["a", "a"] }, roster, true),
     ).toEqual({ ok: false, reason: "duplicate-entry" });
   });
 
   it("rejects the catcher for an allPlay team — the coach pitches", () => {
-    expect(validatePositions({ CATCHER: "a" }, roster, true)).toEqual({
+    expect(validatePositions({ CATCHER: ["a"] }, roster, true)).toEqual({
       ok: false,
       reason: "invalid-position",
     });
   });
 
   it("accepts the catcher when allPlay is off", () => {
-    expect(validatePositions({ CATCHER: "a" }, roster, false)).toEqual({
+    expect(validatePositions({ CATCHER: ["a"] }, roster, false)).toEqual({
       ok: true,
-      assignments: [{ entryId: "a", position: "CATCHER" }],
+      assignments: [{ entryId: "a", position: "CATCHER", positionSlot: 0 }],
     });
   });
 
-  it("rejects a named outfield position for an allPlay team", () => {
-    // allPlay toggled on mid-edit: the coach should see the board they're
-    // actually saving, not have three assignments quietly dropped.
-    expect(validatePositions({ LEFT_FIELD: "a" }, roster, true)).toEqual({
+  it("accepts up to three at a named outfield spot for an allPlay team, and rejects a fourth", () => {
+    expect(
+      validatePositions({ LEFT_FIELD: ["a", "b", "c"] }, roster, true),
+    ).toEqual({
+      ok: true,
+      assignments: [
+        { entryId: "a", position: "LEFT_FIELD", positionSlot: 0 },
+        { entryId: "b", position: "LEFT_FIELD", positionSlot: 1 },
+        { entryId: "c", position: "LEFT_FIELD", positionSlot: 2 },
+      ],
+    });
+    expect(
+      validatePositions({ LEFT_FIELD: ["a", "b", "c", "d"] }, roster, true),
+    ).toEqual({ ok: false, reason: "position-full" });
+  });
+
+  it("caps that same outfield spot at one when allPlay is off", () => {
+    // allPlay toggled off mid-edit: the stack the editor built is no longer a
+    // board this team can field, and the coach should see what it has become.
+    expect(validatePositions({ LEFT_FIELD: ["a"] }, roster, false)).toEqual({
+      ok: true,
+      assignments: [{ entryId: "a", position: "LEFT_FIELD", positionSlot: 0 }],
+    });
+    expect(
+      validatePositions({ LEFT_FIELD: ["a", "b"] }, roster, false),
+    ).toEqual({ ok: false, reason: "position-full" });
+  });
+
+  it("rejects two players at one infield spot whatever the setting", () => {
+    expect(validatePositions({ PITCHER: ["a", "b"] }, roster, true)).toEqual({
       ok: false,
-      reason: "invalid-position",
-    });
-  });
-
-  it("accepts that same outfield position when allPlay is off", () => {
-    expect(validatePositions({ LEFT_FIELD: "a" }, roster, false)).toEqual({
-      ok: true,
-      assignments: [{ entryId: "a", position: "LEFT_FIELD" }],
+      reason: "position-full",
     });
   });
 
   it("rejects a key that isn't a position at all", () => {
-    expect(validatePositions({ SHORTSTOPP: "a" }, roster, false)).toEqual({
+    expect(validatePositions({ SHORTSTOPP: ["a"] }, roster, false)).toEqual({
       ok: false,
       reason: "invalid-position",
     });
@@ -825,43 +998,55 @@ describe("positions save then reload round trip", () => {
     );
   }
 
-  it("reloads an allPlay board to exactly what was persisted", () => {
-    const roster = ["a", "b", "c"];
+  it("reloads an allPlay board, stacked outfield included, to exactly what was persisted", () => {
+    const roster = ["a", "b", "c", "d", "e"];
     const result = validatePositions(
-      { PITCHER: "a", SHORTSTOP: "b" },
+      { PITCHER: ["a"], SHORTSTOP: ["b"], CENTER_FIELD: ["c", "d"] },
       roster,
       true,
     );
     if (!result.ok) throw new Error("expected ok");
 
     const draft = reload(roster, result.assignments, true);
-    expect(draft.assigned).toEqual({ PITCHER: "a", SHORTSTOP: "b" });
-    // 'c' persisted as null and comes back in the outfield zone.
-    expect(draft.pool).toEqual(["c"]);
+    expect(draft.assigned).toEqual({
+      PITCHER: ["a"],
+      SHORTSTOP: ["b"],
+      CENTER_FIELD: ["c", "d"],
+    });
+    // 'e' persisted as null and comes back in the general outfield zone.
+    expect(draft.pool).toEqual(["e"]);
   });
 
   it("survives a second save with no edits (idempotent)", () => {
     const roster = ["a", "b", "c"];
-    const first = validatePositions({ PITCHER: "a", SHORTSTOP: "c" }, roster, false);
+    const first = validatePositions(
+      { PITCHER: ["a"], SHORTSTOP: ["c"] },
+      roster,
+      false,
+    );
     if (!first.ok) throw new Error("expected ok");
 
     const draft = reload(roster, first.assignments, false);
-    const second = validatePositions(draft.assigned as Record<string, string>, roster, false);
+    const second = validatePositions(
+      draft.assigned as Record<string, string[]>,
+      roster,
+      false,
+    );
     if (!second.ok) throw new Error("expected ok");
 
     expect(second.assignments).toEqual(first.assignments);
   });
 
-  it("collapses an allPlay team's stale outfield row on the next save", () => {
+  it("collapses an allPlay team's stale catcher row on the next save", () => {
     const roster = ["a", "b"];
     const draft = buildPositionsDraft(
-      [fielder("a", "PITCHER"), fielder("b", "LEFT_FIELD")],
+      [fielder("a", "PITCHER"), fielder("b", "CATCHER")],
       true,
     );
     expect(draft.pool).toEqual(["b"]);
 
     const result = validatePositions(
-      draft.assigned as Record<string, string>,
+      draft.assigned as Record<string, string[]>,
       roster,
       true,
     );
@@ -869,7 +1054,7 @@ describe("positions save then reload round trip", () => {
     // leaves them null — in the outfield, where the editor already showed them.
     expect(result).toEqual({
       ok: true,
-      assignments: [{ entryId: "a", position: "PITCHER" }],
+      assignments: [{ entryId: "a", position: "PITCHER", positionSlot: 0 }],
     });
   });
 });

--- a/src/lib/chart.ts
+++ b/src/lib/chart.ts
@@ -1,12 +1,17 @@
 import type { Position } from "@/generated/prisma/enums";
-import { ALL_PLAY_INFIELD_POSITIONS, ALL_POSITIONS } from "@/lib/positions";
+import {
+  ALL_PLAY_POSITIONS,
+  ALL_POSITIONS,
+  positionCapacity,
+} from "@/lib/positions";
 
 /// Pure chart editing logic: the batting order (#10) and the positions
 /// diamond (#11).
 ///
 /// The batting draft model is a fixed array of slots (index i = batting slot
 /// i + 1) plus an unassigned pool; the positions draft model is a
-/// position → entry map plus a pool. Both hold `RosterEntry` ids. Everything
+/// position → entry-ids map plus a pool (one id per spot, except an allPlay
+/// team's outfield spots, which stack to three). Both hold `RosterEntry` ids. Everything
 /// here is DB-free and DOM-free: each dnd-kit component is a thin shell that
 /// maps drag events onto these functions (`resolveDrop`,
 /// `resolvePositionDrop`), and the server actions re-run the matching
@@ -298,13 +303,23 @@ export type PositionsDraft = {
   /// The droppable positions on this board, in scorebook order. Carried on the
   /// draft rather than passed alongside it so every mutation below can reject
   /// a position the board doesn't have — under allPlay that is what makes
-  /// "an outfield assignment is unrepresentable" structural instead of a rule
+  /// "a catcher assignment is unrepresentable" structural instead of a rule
   /// each caller has to remember.
   positions: readonly Position[];
-  /// position → entry id, for filled spots only.
-  assigned: Partial<Record<Position, string>>;
+  /// Whether this is an allPlay board — carried for the same reason as
+  /// `positions`: per-spot capacity (`positionCapacity`) is a property of the
+  /// board, and a mutation that had to be told the capacity per call could be
+  /// told the wrong one.
+  allPlay: boolean;
+  /// position → entry ids, for filled spots only — a key is present only while
+  /// its array is non-empty. One entry everywhere except an allPlay team's
+  /// LF/CF/RF, which stack to `OUTFIELD_SPOT_CAPACITY`. Array order is arrival
+  /// order and is presentation only: nothing persisted distinguishes two
+  /// orderings of the same spot (see `samePositions`).
+  assigned: Partial<Record<Position, readonly string[]>>;
   /// Everyone else, in the order the caller supplied (roster order): the
-  /// outfield zone under allPlay, the bench otherwise. Both persist as null.
+  /// general outfield zone under allPlay, the bench otherwise. Both persist as
+  /// null.
   pool: string[];
 };
 
@@ -316,18 +331,16 @@ export type PositionChartEntry = {
 /**
  * Which positions are drop targets.
  *
- * Under allPlay the outfield is ONE zone holding every remaining player
- * (product-brief.md:94), and `RosterEntry_teamId_position_key` allows only one
- * player per named position — so LF/CF/RF are not droppable and are never
- * written for an allPlay team. Those players persist as `position = null`,
- * which is unambiguous because an allPlay team has no bench.
- *
- * An allPlay team has no catcher either — the coach pitches — so C is not
- * droppable there for the same reason, and a catcher lands in the outfield
- * along with everyone else off the infield.
+ * An allPlay team has no catcher — the coach pitches — so C is not droppable
+ * there, and a catcher row lands in the general outfield along with everyone
+ * else the board doesn't seat. LF/CF/RF ARE droppable under allPlay (revised
+ * with the named-outfield-spots change): each stacks to
+ * `OUTFIELD_SPOT_CAPACITY`, and whoever the coach leaves unpinned persists as
+ * `position = null` — the general outfield zone, which is unambiguous because
+ * an allPlay team has no bench.
  */
 export function droppablePositions(allPlay: boolean): readonly Position[] {
-  return allPlay ? ALL_PLAY_INFIELD_POSITIONS : ALL_POSITIONS;
+  return allPlay ? ALL_PLAY_POSITIONS : ALL_POSITIONS;
 }
 
 /// Where `entryId` currently stands, or null if they're in the pool or absent.
@@ -336,7 +349,7 @@ export function positionOf(
   entryId: string,
 ): Position | null {
   for (const position of draft.positions) {
-    if (draft.assigned[position] === entryId) {
+    if (draft.assigned[position]?.includes(entryId)) {
       return position;
     }
   }
@@ -347,12 +360,12 @@ export function positionOf(
  * Initial draft from the current chart.
  *
  * An entry whose stored position isn't droppable on this board lands in the
- * pool — that is how an allPlay team's stale LF/CF/RF rows (hand-set during
- * #9, or left behind when allPlay was switched on) show up in the outfield
- * zone. They are only collapsed to null when the coach actually saves, so
- * nothing changes behind their back. A position claimed twice can't come out
- * of the database (unique index), but the second entry is pooled rather than
- * dropped if it ever does.
+ * pool — that is how an allPlay team's stale CATCHER row (hand-set during #9,
+ * or left behind when allPlay was switched on) shows up in the outfield zone.
+ * It is only collapsed to null when the coach actually saves, so nothing
+ * changes behind their back. Likewise a spot holding more entries than its
+ * capacity (a named outfield stack after allPlay was switched OFF) keeps the
+ * first arrivals and pools the rest rather than dropping anyone.
  */
 export function buildPositionsDraft(
   entries: readonly PositionChartEntry[],
@@ -360,7 +373,7 @@ export function buildPositionsDraft(
 ): PositionsDraft {
   const positions = droppablePositions(allPlay);
   const droppable = new Set(positions);
-  const assigned: Partial<Record<Position, string>> = {};
+  const assigned: Partial<Record<Position, string[]>> = {};
   const pool: string[] = [];
 
   for (const entry of entries) {
@@ -368,29 +381,30 @@ export function buildPositionsDraft(
     if (
       position !== null &&
       droppable.has(position) &&
-      assigned[position] === undefined
+      (assigned[position]?.length ?? 0) < positionCapacity(position, allPlay)
     ) {
-      assigned[position] = entry.entryId;
+      (assigned[position] ??= []).push(entry.entryId);
     } else {
       pool.push(entry.entryId);
     }
   }
 
-  return { positions, assigned, pool };
+  return { positions, allPlay, assigned, pool };
 }
 
 /**
  * Put `entryId` at `position`, the one mutation the diamond performs — the
- * same swap grammar as `placeInSlot`:
+ * swap grammar of `placeInSlot`, generalised to spots with room to spare:
  *
- *   - entry stood elsewhere → the two SWAP (the displaced player takes the
- *     dragged player's old position, which may leave that spot empty).
- *   - entry was pooled, position occupied → still a swap: the displaced player
- *     takes the entry's place in the pool.
- *   - entry was pooled, position empty → the entry just takes it.
+ *   - position has room (an allPlay outfield spot below capacity, or any
+ *     empty spot) → the entry simply joins it, leaving wherever it stood.
+ *   - position is full → the entry SWAPS with the spot's most recent arrival:
+ *     the displaced player takes the dragged player's old place (their old
+ *     position, or their spot in the pool). At capacity 1 this is exactly the
+ *     old grammar, so the infield behaves as it always has.
  *
- * Positions off this board, unknown entries, and self-drops return the draft
- * unchanged. Never mutates its input.
+ * Positions off this board, unknown entries, and drops onto a spot the entry
+ * already holds return the draft unchanged. Never mutates its input.
  */
 export function placeAtPosition(
   draft: PositionsDraft,
@@ -412,27 +426,37 @@ export function placeAtPosition(
 
   const assigned = { ...draft.assigned };
   const pool = [...draft.pool];
-  const occupant = assigned[position];
+  const target = [...(assigned[position] ?? [])];
+  const capacity = positionCapacity(position, draft.allPlay);
 
-  assigned[position] = entryId;
+  // Room to join, or a full spot's last arrival to displace.
+  const displaced =
+    target.length < capacity ? undefined : target.pop();
+  target.push(entryId);
+  assigned[position] = target;
+
   if (from !== null) {
-    if (occupant !== undefined) {
-      assigned[from] = occupant;
+    const source = (assigned[from] ?? []).filter((id) => id !== entryId);
+    if (displaced !== undefined) {
+      source.push(displaced);
+    }
+    if (source.length > 0) {
+      assigned[from] = source;
     } else {
       delete assigned[from];
     }
-  } else if (occupant !== undefined) {
-    pool.splice(fromPool, 1, occupant);
+  } else if (displaced !== undefined) {
+    pool.splice(fromPool, 1, displaced);
   } else {
     pool.splice(fromPool, 1);
   }
 
-  return { positions: draft.positions, assigned, pool };
+  return { positions: draft.positions, allPlay: draft.allPlay, assigned, pool };
 }
 
 /// Drop onto the zone: the entry leaves the diamond. Under allPlay that means
-/// the outfield, otherwise the bench — both are `position = null`. No-op for an
-/// entry already pooled.
+/// the general outfield, otherwise the bench — both are `position = null`.
+/// No-op for an entry already pooled.
 export function unassignPosition(
   draft: PositionsDraft,
   entryId: string,
@@ -443,19 +467,38 @@ export function unassignPosition(
   }
 
   const assigned = { ...draft.assigned };
-  delete assigned[from];
-  return { positions: draft.positions, assigned, pool: [...draft.pool, entryId] };
+  const remaining = (assigned[from] ?? []).filter((id) => id !== entryId);
+  if (remaining.length > 0) {
+    assigned[from] = remaining;
+  } else {
+    delete assigned[from];
+  }
+  return {
+    positions: draft.positions,
+    allPlay: draft.allPlay,
+    assigned,
+    pool: [...draft.pool, entryId],
+  };
 }
 
 /// Compare two boards. Only the diamond matters — pool order is presentation,
-/// since every pooled player persists as the same null. Spans all nine
-/// positions, not just the droppable ones, so it can also compare a draft
-/// against what the database holds (see `storedPositions`).
+/// since every pooled player persists as the same null — and WHO holds a spot
+/// matters while the order they arrived in does not: nothing persisted
+/// distinguishes two orderings of one outfield stack (`positionSlot` is a
+/// uniqueness mechanism, renumbered on every save). Spans all nine positions,
+/// not just the droppable ones, so it can also compare a draft against what
+/// the database holds (see `storedPositions`).
 export function samePositions(
-  a: Partial<Record<Position, string>>,
-  b: Partial<Record<Position, string>>,
+  a: Partial<Record<Position, readonly string[]>>,
+  b: Partial<Record<Position, readonly string[]>>,
 ): boolean {
-  return ALL_POSITIONS.every((position) => a[position] === b[position]);
+  return ALL_POSITIONS.every((position) => {
+    const atA = a[position] ?? [];
+    const atB = b[position] ?? [];
+    return (
+      atA.length === atB.length && atA.every((entryId) => atB.includes(entryId))
+    );
+  });
 }
 
 /**
@@ -464,20 +507,21 @@ export function samePositions(
  *
  * This is the only honest answer to "would saving change anything?", and it is
  * not `buildPositionsDraft(...).assigned`: that pools an allPlay team's stale
- * LF/CF/RF row, so a freshly-loaded draft compares equal to itself while the
- * stored row still says CENTER_FIELD. Gating Save on the draft alone would
- * disable the one button that collapses that row, stranding it until the coach
+ * CATCHER row (and any over-capacity outfield stack left by an allPlay
+ * toggle), so a freshly-loaded draft compares equal to itself while the
+ * stored row still says CATCHER. Gating Save on the draft alone would disable
+ * the one button that collapses that row, stranding it until the coach
  * happened to make an unrelated change.
  */
 export function storedPositions(
   entries: readonly PositionChartEntry[],
-): Partial<Record<Position, string>> {
-  const stored: Partial<Record<Position, string>> = {};
+): Partial<Record<Position, string[]>> {
+  const stored: Partial<Record<Position, string[]>> = {};
   for (const entry of entries) {
-    // First writer wins, matching buildPositionsDraft. The unique index makes
-    // a collision unreachable from a real read.
-    if (entry.position !== null && stored[entry.position] === undefined) {
-      stored[entry.position] = entry.entryId;
+    // Every row is kept, capacity or not — this is the database's answer, and
+    // `samePositions` is order-insensitive, so entry order doesn't matter.
+    if (entry.position !== null) {
+      (stored[entry.position] ??= []).push(entry.entryId);
     }
   }
   return stored;
@@ -536,20 +580,25 @@ export function nextDroppableId(
 export type PositionAssignment = {
   entryId: string;
   position: Position;
+  /// 0 everywhere except an allPlay outfield stack, where the spot's players
+  /// number 0..n-1 in submitted order. Exists to satisfy the unique index
+  /// `[teamId, position, positionSlot]`; nothing reads it back.
+  positionSlot: number;
 };
 
 export type PositionsInvalidReason =
   | "unknown-entry"
   | "duplicate-entry"
-  | "invalid-position";
+  | "invalid-position"
+  | "position-full";
 
 export type PositionsValidation =
   | { ok: true; assignments: PositionAssignment[] }
   | { ok: false; reason: PositionsInvalidReason };
 
 /**
- * Validate a submitted position → entry map against the roster and allPlay
- * flag the server loaded itself.
+ * Validate a submitted position → entry-ids map against the roster and
+ * allPlay flag the server loaded itself.
  *
  * **A partial chart is valid.** Unlike `validateBattingOrder`, there is no
  * "everyone must be placed" rule to enforce under allPlay: an empty shortstop
@@ -557,12 +606,16 @@ export type PositionsValidation =
  * outfield. "No chart set yet" is a real state the view page renders (#8), and
  * #9's weekend produced half-entered charts on purpose.
  *
- * A named outfield position submitted for an allPlay team is `invalid-position`
- * rather than something to quietly drop — it means the setting was toggled
- * mid-edit, and the coach should see the board they're actually saving.
+ * A CATCHER submitted for an allPlay team is `invalid-position` rather than
+ * something to quietly drop — it means the setting was toggled mid-edit, and
+ * the coach should see the board they're actually saving. A spot holding more
+ * entries than `positionCapacity` allows is `position-full` by the same logic:
+ * the honest boards the editor builds can't produce it (two at shortstop, or
+ * four at an outfield spot — including three at LF/CF/RF the instant allPlay
+ * is toggled off), so the coach should see what the board has become.
  */
 export function validatePositions(
-  submitted: Readonly<Record<string, string>>,
+  submitted: Readonly<Record<string, readonly string[]>>,
   rosterEntryIds: readonly string[],
   allPlay: boolean,
 ): PositionsValidation {
@@ -582,18 +635,23 @@ export function validatePositions(
   // Scorebook order, not the submitted key order, so the write is the same
   // regardless of how the client happened to serialize the map.
   for (const position of positions) {
-    const entryId = submitted[position];
-    if (entryId === undefined) {
+    const entryIds = submitted[position];
+    if (entryIds === undefined) {
       continue;
     }
-    if (!roster.has(entryId)) {
-      return { ok: false, reason: "unknown-entry" };
+    if (entryIds.length > positionCapacity(position, allPlay)) {
+      return { ok: false, reason: "position-full" };
     }
-    if (seen.has(entryId)) {
-      return { ok: false, reason: "duplicate-entry" };
+    for (const [positionSlot, entryId] of entryIds.entries()) {
+      if (!roster.has(entryId)) {
+        return { ok: false, reason: "unknown-entry" };
+      }
+      if (seen.has(entryId)) {
+        return { ok: false, reason: "duplicate-entry" };
+      }
+      seen.add(entryId);
+      assignments.push({ entryId, position, positionSlot });
     }
-    seen.add(entryId);
-    assignments.push({ entryId, position });
   }
 
   return { ok: true, assignments };

--- a/src/lib/positions.ts
+++ b/src/lib/positions.ts
@@ -28,9 +28,11 @@ export const INFIELD_POSITIONS: readonly Position[] = [
  * The infield an allPlay team actually fields: no catcher.
  *
  * allPlay is the coach-pitch end of youth baseball, where the coach pitches and
- * nobody crouches behind the plate — so C is not a spot a coach can fill, the
- * same way LF/CF/RF aren't (the outfield is one zone there). Drawing it as
- * "Open" would show every parent a hole in the lineup that cannot be filled.
+ * nobody crouches behind the plate — so C is not a spot a coach can fill.
+ * Drawing it as "Open" would show every parent a hole in the lineup that
+ * cannot be filled. (LF/CF/RF used to be excluded the same way, as one
+ * anonymous zone; they became placeable spots with the named-outfield
+ * revision — see ALL_PLAY_POSITIONS.)
  *
  * Filtered rather than relisted so it can't drift out of scorebook order, or
  * out of sync with INFIELD_POSITIONS.
@@ -45,15 +47,54 @@ export const OUTFIELD_POSITIONS: readonly Position[] = [
 ] as const;
 
 /**
- * The label inside an outfielder's marker on an allPlay diamond.
+ * The label inside a general outfielder's marker on an allPlay diamond.
  *
- * Not a `Position`: the allPlay outfield is one zone holding however many
- * players the infield leaves over, and every one of them persists as
- * `position = null`. It lives here anyway because it is drawn in the same
- * circles as the position abbreviations, and AGENTS.md's rule is that diamond
- * labels come from this module rather than being written by hand.
+ * Not a `Position`: an allPlay outfielder the coach hasn't pinned to LF/CF/RF
+ * plays the general outfield zone and persists as `position = null`. It lives
+ * here anyway because it is drawn in the same circles as the position
+ * abbreviations, and AGENTS.md's rule is that diamond labels come from this
+ * module rather than being written by hand.
  */
 export const OUTFIELD_ZONE_LABEL = "OF";
+
+/**
+ * How many kids one named outfield spot holds on an allPlay team.
+ *
+ * At the coach-pitch level everyone fields, so a twelve-kid roster puts six
+ * or seven in the outfield — three named spots at one kid each could never
+ * seat them, which is why the outfield used to be a single anonymous zone.
+ * Letting each spot stack to three keeps every kid placeable BY NAME on any
+ * realistic roster (5 infield + 9 outfield = 14) while the general zone
+ * (`position = null`) still catches whoever the coach leaves unpinned.
+ *
+ * Enforced in `validatePositions` (chart.ts), not by the database — the
+ * unique index `[teamId, position, positionSlot]` guarantees one row per
+ * slot, but nothing SQL-shaped caps the slot number itself.
+ */
+export const OUTFIELD_SPOT_CAPACITY = 3;
+
+/// Everything an allPlay team fields: the coach-pitch infield (no catcher)
+/// plus the three named outfield spots. Composed rather than relisted, same
+/// as ALL_PLAY_INFIELD_POSITIONS, so it can't drift out of scorebook order.
+export const ALL_PLAY_POSITIONS: readonly Position[] = [
+  ...ALL_PLAY_INFIELD_POSITIONS,
+  ...OUTFIELD_POSITIONS,
+] as const;
+
+/**
+ * How many players may stand at one position on this team's board.
+ *
+ * One everywhere, except the named outfield spots on an allPlay team, which
+ * stack to `OUTFIELD_SPOT_CAPACITY`. A capacity for a position the team
+ * doesn't field at all (allPlay CATCHER) is still 1 — "is this position on
+ * the board" is `fieldedPositions` / `droppablePositions`' question, not
+ * this function's.
+ */
+export function positionCapacity(position: Position, allPlay: boolean): number {
+  return allPlay && OUTFIELD_POSITIONS.includes(position)
+    ? OUTFIELD_SPOT_CAPACITY
+    : 1;
+}
 
 /// All nine, in scorebook order.
 export const ALL_POSITIONS: readonly Position[] = [
@@ -66,9 +107,12 @@ export const ALL_POSITIONS: readonly Position[] = [
  *
  * The rule `buildChartView` and `buildPositionsDraft` both already apply, named
  * once so a third and fourth caller can't drift from it: an allPlay team fields
- * the infield minus the catcher, and a row stored at any other position — a
- * stale `CENTER_FIELD` or `CATCHER`, hand-seeded during #9 or left behind when
- * allPlay was switched on — is a spot that team has no way to fill.
+ * everything except the catcher (the coach pitches, nobody crouches behind the
+ * plate), and a row stored at a position outside this set — a stale `CATCHER`
+ * left behind when allPlay was switched on — is a spot that team has no way to
+ * fill. LF/CF/RF joined the allPlay set when the named outfield spots became
+ * placeable (each stacking to `OUTFIELD_SPOT_CAPACITY`); before that they were
+ * one anonymous zone and a named-outfield row was itself stale.
  *
  * Anything deciding whether a position is real for a team, or *labelling* one,
  * has to ask this question. Reporting such a spot as uncovered invents a hole,
@@ -76,7 +120,7 @@ export const ALL_POSITIONS: readonly Position[] = [
  * field a position the same screen refuses to check.
  */
 export function fieldedPositions(allPlay: boolean): Set<Position> {
-  return new Set(allPlay ? ALL_PLAY_INFIELD_POSITIONS : ALL_POSITIONS);
+  return new Set(allPlay ? ALL_PLAY_POSITIONS : ALL_POSITIONS);
 }
 
 export function positionLabel(position: Position): string {

--- a/src/lib/readiness.test.ts
+++ b/src/lib/readiness.test.ts
@@ -245,13 +245,13 @@ describe("computeReadiness and the positions a team actually fields", () => {
   });
 
   it("does not uncover a spot an allPlay team never fields", () => {
-    // A stale CENTER_FIELD row — hand-seeded during #9, or left behind when
-    // allPlay was switched on. That kid is in the outfield zone everywhere else
-    // in the app; reporting CF uncovered would hand the coach a hole they have
-    // no way to fill.
+    // A stale CATCHER row — hand-seeded during #9, or left behind when allPlay
+    // was switched on. That kid is in the outfield zone everywhere else in the
+    // app; reporting C uncovered would hand the coach a hole they have no way
+    // to fill.
     const stale: ChartEntry[] = [
       { playerId: "ava", playerName: "Ava", battingOrder: 1, position: "PITCHER" },
-      { playerId: "cal", playerName: "Cal", battingOrder: 2, position: "CENTER_FIELD" },
+      { playerId: "cal", playerName: "Cal", battingOrder: 2, position: "CATCHER" },
     ];
     const rsvps = new Map<string, RsvpState>([
       ["ava", "attending"],
@@ -264,6 +264,50 @@ describe("computeReadiness and the positions a team actually fields", () => {
     // Still named as out — nobody disappears, only the phantom hole does.
     expect(result.declined.map((e) => e.playerId)).toEqual(["cal"]);
     expect(result.ready).toBe(false);
+  });
+
+  it("uncovers an allPlay team's named outfield spot when its only kid declined", () => {
+    // LF/CF/RF are fielded allPlay spots since the named-outfield revision, so
+    // a pinned centre fielder staying home is a real hole worth naming.
+    const chart: ChartEntry[] = [
+      { playerId: "ava", playerName: "Ava", battingOrder: 1, position: "PITCHER" },
+      { playerId: "cal", playerName: "Cal", battingOrder: 2, position: "CENTER_FIELD" },
+    ];
+    const rsvps = new Map<string, RsvpState>([["cal", "declined"]]);
+
+    const result = computeReadiness(chart, rsvps, true);
+
+    expect(result.uncoveredPositions).toEqual(["CENTER_FIELD"]);
+    expect(result.ready).toBe(false);
+  });
+
+  it("keeps a stacked outfield spot covered while any kid there is still coming", () => {
+    // Named outfield spots seat up to three. One of two centre fielders
+    // staying home doesn't empty centre field — but both of them does.
+    const chart: ChartEntry[] = [
+      { playerId: "cal", playerName: "Cal", battingOrder: 1, position: "CENTER_FIELD" },
+      { playerId: "dee", playerName: "Dee", battingOrder: 2, position: "CENTER_FIELD" },
+    ];
+
+    const oneOut = computeReadiness(
+      chart,
+      new Map<string, RsvpState>([["cal", "declined"]]),
+      true,
+    );
+    expect(oneOut.uncoveredPositions).toEqual([]);
+    // The decline itself still surfaces; only the hole is not claimed.
+    expect(oneOut.declined.map((e) => e.playerId)).toEqual(["cal"]);
+    expect(oneOut.ready).toBe(false);
+
+    const bothOut = computeReadiness(
+      chart,
+      new Map<string, RsvpState>([
+        ["cal", "declined"],
+        ["dee", "declined"],
+      ]),
+      true,
+    );
+    expect(bothOut.uncoveredPositions).toEqual(["CENTER_FIELD"]);
   });
 
   it("does uncover that same spot for a team that fields it", () => {

--- a/src/lib/readiness.test.ts
+++ b/src/lib/readiness.test.ts
@@ -281,6 +281,42 @@ describe("computeReadiness and the positions a team actually fields", () => {
     expect(result.ready).toBe(false);
   });
 
+  it("answers the same whatever order the chart rows arrive in", () => {
+    // The regression: an over-capacity spot (three kids left at CF after
+    // allPlay was switched off) used to be truncated to its capacity over
+    // `getChart`'s unordered rows, so "is CF uncovered" depended on which row
+    // came back first — the same team and the same RSVPs, a different answer
+    // on a refresh. Every row stored there is asked instead.
+    const at = (playerId: string): ChartEntry => ({
+      playerId,
+      playerName: playerId,
+      battingOrder: null,
+      position: "CENTER_FIELD",
+    });
+    const rows = [at("cal"), at("dee"), at("eli")];
+    // One of the three is coming; the other two are out.
+    const rsvps = new Map<string, RsvpState>([
+      ["cal", "declined"],
+      ["dee", "attending"],
+      ["eli", "declined"],
+    ]);
+
+    for (const order of [rows, [...rows].reverse(), [rows[1], rows[2], rows[0]]]) {
+      expect(computeReadiness(order, rsvps, false).uncoveredPositions).toEqual(
+        [],
+      );
+    }
+
+    const allOut = new Map<string, RsvpState>(
+      rows.map((row) => [row.playerId, "declined" as RsvpState]),
+    );
+    for (const order of [rows, [...rows].reverse()]) {
+      expect(computeReadiness(order, allOut, false).uncoveredPositions).toEqual([
+        "CENTER_FIELD",
+      ]);
+    }
+  });
+
   it("keeps a stacked outfield spot covered while any kid there is still coming", () => {
     // Named outfield spots seat up to three. One of two centre fielders
     // staying home doesn't empty centre field — but both of them does.

--- a/src/lib/readiness.ts
+++ b/src/lib/readiness.ts
@@ -1,9 +1,5 @@
 import { Position } from "@/generated/prisma/enums";
-import {
-  ALL_POSITIONS,
-  fieldedPositions,
-  positionCapacity,
-} from "@/lib/positions";
+import { ALL_POSITIONS, fieldedPositions } from "@/lib/positions";
 import type { RsvpState } from "@/lib/rsvp";
 
 /// The next-game readiness check.
@@ -125,21 +121,28 @@ export function computeReadiness<T extends ChartEntry>(
   // named in `declined`; nobody disappears, only the phantom hole does.
   const fielded = fieldedPositions(allPlay);
 
+  // EVERY row stored at a fielded position, with no cap applied — unlike
+  // `buildChartView`, which has to pick which of them the diamond seats.
+  //
+  // Deliberate, and the reason is determinism. `getChart` is a findMany with no
+  // orderBy, so an over-capacity spot (three kids left at CF after allPlay was
+  // switched off) hands this function its rows in whatever order Postgres
+  // chose. Truncating to the capacity would then make "is CF uncovered" depend
+  // on which row came back first — the same team, the same RSVPs, a different
+  // answer on a refresh. Asking about all of them instead is order-independent
+  // by construction, and it is also the more honest question: a spot with
+  // somebody coming to stand on it is not a hole, whichever of them the
+  // diamond happens to draw.
   const assigned = new Map<Position, T[]>();
   for (const entry of chart) {
-    // First arrivals up to the spot's capacity, matching buildChartView —
-    // one everywhere except an allPlay team's outfield spots.
-    const holders = entry.position !== null ? assigned.get(entry.position) : undefined;
-    if (
-      entry.position !== null &&
-      fielded.has(entry.position) &&
-      (holders?.length ?? 0) < positionCapacity(entry.position, allPlay)
-    ) {
-      if (holders) {
-        holders.push(entry);
-      } else {
-        assigned.set(entry.position, [entry]);
-      }
+    if (entry.position === null || !fielded.has(entry.position)) {
+      continue;
+    }
+    const holders = assigned.get(entry.position);
+    if (holders) {
+      holders.push(entry);
+    } else {
+      assigned.set(entry.position, [entry]);
     }
   }
 

--- a/src/lib/readiness.ts
+++ b/src/lib/readiness.ts
@@ -1,5 +1,9 @@
 import { Position } from "@/generated/prisma/enums";
-import { ALL_POSITIONS, fieldedPositions } from "@/lib/positions";
+import {
+  ALL_POSITIONS,
+  fieldedPositions,
+  positionCapacity,
+} from "@/lib/positions";
 import type { RsvpState } from "@/lib/rsvp";
 
 /// The next-game readiness check.
@@ -44,8 +48,11 @@ export type Readiness<T extends ChartEntry> = {
   /// Chart-affecting players who haven't answered. Reported, never alarming:
   /// these are the players `uncoveredPositions` deliberately says nothing about.
   awaiting: T[];
-  /// Positions left empty because the assigned player **declined**. In
-  /// scorebook order, and limited to the spots this team actually fields.
+  /// Positions left empty because everyone assigned there **declined** — for
+  /// most spots that is the one assigned player, but an allPlay team's named
+  /// outfield spots seat up to three, and a spot with a teammate still
+  /// standing on it is not uncovered. In scorebook order, and limited to the
+  /// spots this team actually fields.
   uncoveredPositions: Position[];
   /// The batting order for this game with declined players removed and ranks
   /// closed up. No-response players stay in it — see `chartState` below.
@@ -118,24 +125,34 @@ export function computeReadiness<T extends ChartEntry>(
   // named in `declined`; nobody disappears, only the phantom hole does.
   const fielded = fieldedPositions(allPlay);
 
-  const assigned = new Map<Position, T>();
+  const assigned = new Map<Position, T[]>();
   for (const entry of chart) {
-    // First writer wins, matching buildChartView. The unique index makes a
-    // collision unreachable from a real read.
+    // First arrivals up to the spot's capacity, matching buildChartView —
+    // one everywhere except an allPlay team's outfield spots.
+    const holders = entry.position !== null ? assigned.get(entry.position) : undefined;
     if (
       entry.position !== null &&
       fielded.has(entry.position) &&
-      !assigned.has(entry.position)
+      (holders?.length ?? 0) < positionCapacity(entry.position, allPlay)
     ) {
-      assigned.set(entry.position, entry);
+      if (holders) {
+        holders.push(entry);
+      } else {
+        assigned.set(entry.position, [entry]);
+      }
     }
   }
 
   // Filtered from ALL_POSITIONS rather than assembled, so the result is in
-  // scorebook order however the chart rows arrived.
+  // scorebook order however the chart rows arrived. A stacked spot is
+  // uncovered only when EVERY kid standing there declined: one of three
+  // centre fielders staying home doesn't empty centre field.
   const uncoveredPositions = ALL_POSITIONS.filter((position) => {
-    const holder = assigned.get(position);
-    return holder !== undefined && stateOf(holder) === "declined";
+    const holders = assigned.get(position);
+    return (
+      holders !== undefined &&
+      holders.every((holder) => stateOf(holder) === "declined")
+    );
   });
 
   const inOrder = chart

--- a/src/lib/roster.test.ts
+++ b/src/lib/roster.test.ts
@@ -631,8 +631,8 @@ describe("savePositions", () => {
     updateRosterEntry.mockReturnValueOnce("upd-a").mockReturnValueOnce("upd-b");
 
     await savePositions("team-1", [
-      { entryId: "entry-a", position: "PITCHER" },
-      { entryId: "entry-b", position: "SECOND_BASE" },
+      { entryId: "entry-a", position: "PITCHER", positionSlot: 0 },
+      { entryId: "entry-b", position: "SECOND_BASE", positionSlot: 0 },
     ]);
 
     // Moving one player onto a position another player is moving off of would
@@ -644,25 +644,25 @@ describe("savePositions", () => {
 
     expect(updateManyRosterEntries).toHaveBeenCalledWith({
       where: { teamId: "team-1" },
-      data: { position: null },
+      data: { position: null, positionSlot: 0 },
     });
   });
 
   it("scopes every phase-2 update by teamId", async () => {
     await savePositions("team-1", [
-      { entryId: "entry-a", position: "CATCHER" },
-      { entryId: "entry-b", position: "SHORTSTOP" },
+      { entryId: "entry-a", position: "CATCHER", positionSlot: 0 },
+      { entryId: "entry-b", position: "SHORTSTOP", positionSlot: 0 },
     ]);
 
     expect(updateRosterEntry).toHaveBeenNthCalledWith(1, {
       where: { id: "entry-a", teamId: "team-1" },
-      data: { position: "CATCHER" },
+      data: { position: "CATCHER", positionSlot: 0 },
     });
     // A forged or stale entryId matches no row under this where clause and
     // throws P2025, rolling the whole save back.
     expect(updateRosterEntry).toHaveBeenNthCalledWith(2, {
       where: { id: "entry-b", teamId: "team-1" },
-      data: { position: "SHORTSTOP" },
+      data: { position: "SHORTSTOP", positionSlot: 0 },
     });
   });
 
@@ -677,16 +677,39 @@ describe("savePositions", () => {
     // An allPlay team: five infielders placed, everyone else in the outfield.
     // The outfielders get no statement at all, which is what makes the saved
     // chart identical to the board the coach was looking at.
-    await savePositions("team-1", [{ entryId: "entry-a", position: "PITCHER" }]);
+    await savePositions("team-1", [
+      { entryId: "entry-a", position: "PITCHER", positionSlot: 0 },
+    ]);
 
     expect(updateRosterEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes each outfield stack member to their own slot", async () => {
+    // The widened unique index is (teamId, position, positionSlot), so three
+    // centre fielders coexist only because their slots differ.
+    await savePositions("team-1", [
+      { entryId: "entry-a", position: "CENTER_FIELD", positionSlot: 0 },
+      { entryId: "entry-b", position: "CENTER_FIELD", positionSlot: 1 },
+      { entryId: "entry-c", position: "CENTER_FIELD", positionSlot: 2 },
+    ]);
+
+    expect(updateRosterEntry).toHaveBeenNthCalledWith(2, {
+      where: { id: "entry-b", teamId: "team-1" },
+      data: { position: "CENTER_FIELD", positionSlot: 1 },
+    });
+    expect(updateRosterEntry).toHaveBeenNthCalledWith(3, {
+      where: { id: "entry-c", teamId: "team-1" },
+      data: { position: "CENTER_FIELD", positionSlot: 2 },
+    });
   });
 
   it("propagates transaction failures", async () => {
     transaction.mockRejectedValue(Object.assign(new Error("gone"), { code: "P2025" }));
 
     await expect(
-      savePositions("team-1", [{ entryId: "entry-a", position: "PITCHER" }]),
+      savePositions("team-1", [
+        { entryId: "entry-a", position: "PITCHER", positionSlot: 0 },
+      ]),
     ).rejects.toMatchObject({ code: "P2025" });
   });
 });

--- a/src/lib/roster.ts
+++ b/src/lib/roster.ts
@@ -285,31 +285,41 @@ export async function saveBattingOrder(
  * Persist the standing positions chart (#11) — the same trap as
  * `saveBattingOrder`, on a different column.
  *
- * `RosterEntry_teamId_position_key` is likewise a `CREATE UNIQUE INDEX`
- * (migration 20260728053521_001, line 196) and so cannot be DEFERRABLE. Moving
- * a player from SS to 2B while someone else moves off 2B transiently duplicates
- * a value and throws P2002 mid-transaction, so the write is the same two
- * phases inside one array-form transaction: null every position for the team,
- * then write the final values.
+ * `RosterEntry_teamId_position_positionSlot_key` is likewise a
+ * `CREATE UNIQUE INDEX` (migration 20260827120000) and so cannot be
+ * DEFERRABLE. Moving a player from SS to 2B while someone else moves off 2B
+ * transiently duplicates a value and throws P2002 mid-transaction, so the
+ * write is the same two phases inside one array-form transaction: null every
+ * position for the team (resetting every slot to 0 — the slot is meaningless
+ * without a position), then write the final values.
+ *
+ * `positionSlot` rides along solely to satisfy that index: always 0 for an
+ * infield spot, 0..2 for an allPlay outfield stack, numbered by
+ * `validatePositions`. Nothing reads it back — within-spot display order is
+ * derived (jersey-then-name) on read.
  *
  * Players left off the diamond need no phase-2 statement — phase 1 already
  * nulled them, which is exactly the state the editor showed: the bench, or the
- * outfield on an allPlay team (see `droppablePositions` in chart.ts). Values
- * come from `validatePositions`, never raw from the client.
+ * general outfield on an allPlay team (see `droppablePositions` in chart.ts).
+ * Values come from `validatePositions`, never raw from the client.
  */
 export async function savePositions(
   teamId: string,
-  assignments: readonly { entryId: string; position: Position }[],
+  assignments: readonly {
+    entryId: string;
+    position: Position;
+    positionSlot: number;
+  }[],
 ): Promise<void> {
   await db.$transaction([
     db.rosterEntry.updateMany({
       where: { teamId },
-      data: { position: null },
+      data: { position: null, positionSlot: 0 },
     }),
-    ...assignments.map(({ entryId, position }) =>
+    ...assignments.map(({ entryId, position, positionSlot }) =>
       db.rosterEntry.update({
         where: { id: entryId, teamId },
-        data: { position },
+        data: { position, positionSlot },
       }),
     ),
   ]);


### PR DESCRIPTION
## Summary

On an allPlay board the outfield was one anonymous zone: a coach could place the infield
but had no way to say *which* outfield spot a kid plays. LF, CF and RF become real drop
targets there, each seating up to three players, while everyone the coach leaves unpinned
still plays the general outfield zone — placement is optional and nobody sits.

## Key Decisions

**A `positionSlot` column, not a new model.** `RosterEntry @@unique([teamId, position])`
allowed exactly one row per spot, which is what made "the outfield is one zone" structural
rather than a rule. Widening it to `[teamId, position, positionSlot]` is the smallest change
that lets three kids share centre field while keeping *one kid per infield spot*
database-enforced — infield writes always use slot 0. The alternative (a per-spot join
table) reintroduces the per-game lineup rows Decision 16 deliberately removed.

**The slot is plumbing, not state.** Nothing reads it back: display order inside a spot is
derived jersey-then-name, `savePositions` renumbers 0..n-1 on every save, and
`samePositions` ignores it, so reordering two kids within one spot is not a chart edit and
cannot raise a false `chart-changed` conflict against another coach. The drag order within
an outfield spot deliberately carries no meaning.

**Capacity lives in `validatePositions`, not the schema.** A CHECK constraint on
"at most three rows per (team, position)" isn't expressible in Prisma's schema, so the cap
is a validation rule (`position-full`) re-checked server-side against the freshly loaded
`allPlay` flag — the same posture the catcher rule already had.

**The general zone moves deeper when spots are occupied.** The zone's shallow row sits *at*
the LF/CF/RF coordinates — that coincidence is deliberate, so three unpinned outfielders
read as the standard diamond. It also means drawing both shallow would stack two markers on
one point, silently. `outfieldZoneCoords(..., {deep})` is what makes that unreachable, and
`deepZoneFits` is where it gives up and falls back rather than overlapping.

## What's in Scope

- **Schema + migration** — `positionSlot Int @default(0)`, the widened unique index, and a
  hand-written migration verified against `prisma migrate diff`. Additive with a default, so
  existing rows land on slot 0 with no backfill.
- **Pure model** (`chart.ts`, `positions.ts`) — `PositionsDraft.assigned` holds entry-id
  arrays; drops *join* a spot with room and swap with its most recent arrival when it is
  full, which reduces to the previous swap grammar at capacity 1, so the infield behaves
  exactly as before.
- **Editor** — each outfield spot's chalk box stacks up to three chips; payload and
  lost-update baseline become arrays per position.
- **`/view`** — pinned kids fan around their spot along the outfield arc; the zone drops to
  its deep row whenever a spot is occupied; the guarded-player halo is sized from the
  markers actually on the board.
- **Readiness / team home** — a stacked spot is uncovered only when *every* kid standing
  there declined; a pinned kid's chart line now reads `CF` rather than `OF`; both pages ask
  `seatedEntryIds` rather than reading the `position` column straight.
- **Docs** — the product brief's Positions bullet is revised (dated), and AGENTS.md gains
  the outfield-spot model and the slot-is-plumbing rule.

### Out of Scope

- Naming or ordering roles within a spot (no "starter" vs "backup") — the slot number
  exists only for uniqueness and is deliberately meaningless.
- Any per-game override. The chart stays standing (Decision 16).

## Bugs Found and Fixed During Self-Review

Reviewing the first commit (`c337e96`) against the crowded and toggled-setting boards caught
five issues, all fixed in `cd50c45`. They share a root cause worth naming: widening the
unique index made states representable that the old index had made impossible, and several
call sites still read the `position` column as if it were the whole answer.

1. **Nondeterministic seating** (`chart-view.ts`, `readiness.ts`) — the capacity cut ran over
   `getChart`'s unordered `findMany`, so with more rows at a spot than it can hold (reachable
   by toggling allPlay off on a stacked board) *which* kid was seated changed between requests
   with no data change. `buildChartView` now sorts before the cut, which also makes it agree
   with the editor; `computeReadiness` no longer truncates at all — a spot is uncovered when
   every row stored there declined, order-independent by construction.
2. **Overlapping markers in the deep zone** — deep mode forfeits a row, so 9+ unpinned players
   packed to 36px against a 40px marker diameter. Reachable by pinning outfielders before
   filling the infield. Past `deepZoneFits`, the board lays every outfielder out in the
   standard two-row zone instead, each keeping its own label.
3. **Team home contradicting `/view`** — `chartRole` / `isBenched` / the card hero gated on
   `fieldedPositions` with no capacity check, so three kids stacked at CF with allPlay off had
   all three families told "CF" while `/view` seated one and listed two as Substitutes. Both
   pages now go through `seatedEntryIds`, which shares `/view`'s seating routine.
4. **Names clipping at the box edge** — the fan ignored `maxSpread`, putting a corner trio's
   outer marker at x=35 against the 55–345 band that bound exists to protect. The circle still
   fitted, so nothing looked wrong. The fan slides inward instead, with per-spot spacing (the
   arc is steeper at the corners than at CF) keeping neighbours 40px apart.
5. **A guarded kid losing their ring to crowding elsewhere** — one three-deep spot made the
   halo radius null for the *whole* outfield, so a parent whose kid stood alone at LF lost the
   highlight. `outfieldHaloRadius` now measures around the guarded markers themselves.

Each has a regression test that fails against the pre-fix code; the geometry tests now assert
*both* sides of the `deepZoneFits` boundary rather than stopping at the last passing count —
the anti-pattern `CROWDED_ZONE_SIZES` already warns about, and exactly how the 36px deep row
got through the first time.

## Known Gaps / Follow-ups

- **A trio at one spot draws no guarded halo.** Three kids at one spot stand ~40px apart,
  which leaves no readable ring. The marker still bolds the name, steps up, and says
  "(your player)" to a screen reader. This is the crowded-zone degradation the zone already
  had, now reachable at a smaller roster; AGENTS.md's stale "needs an 18+ roster" bound is
  corrected rather than the hole being closed.
- **The fence stays chalk whenever the reader has a guarded kid**, even in the rare case
  where no ring draws. Flipping it to banana would put *two* bananas on the page whenever
  that same kid also has a batting row (which is banana already), trading one design-plan §2
  violation for another.
- No real-device pass on a phone; the fan and deep-row spacing are verified by geometry
  tests, not by eye on glass.

## Test Plan

Replace `:teamId` below with a real team id.

- [x] This repo's full check gate (`AGENTS.md` → `## Commands`): `pnpm check` — lint,
      typecheck, 1961 tests — plus `pnpm exec next build`. Green locally and in CI.
- [x] **The migration applied against live Postgres.** Not verifiable from the dev container,
      but the Vercel preview deploy on `cd50c45` runs `prisma migrate deploy && next build`
      and completed successfully — and since Preview and Production share one `DATABASE_URL`
      (AGENTS.md), that *is* the real database. The column and widened index are live.
- [ ] With `allPlay` on, open `/t/:teamId/chart/positions`: drag three players onto **CF**,
      confirm all three chips sit in the CF box and a fourth drag swaps with the last one
      rather than stacking. Save, then reload — the same three are still at CF.
- [ ] Open `/t/:teamId/view` as a parent of one of them: the three fan around centre field
      labelled `CF`, anyone unpinned draws deeper as `OF`, and no two markers overlap.
- [ ] Edge case — **settings toggled mid-edit**: with three kids saved at CF, turn `allPlay`
      off in team settings, then submit the still-open positions editor. Expect the
      `position-full` banner ("a spot now holds more players than it can"), and confirm
      nothing was written.
- [ ] Edge case — **two coaches**: open the editor in two tabs, save in one, then save the
      other. Expect `chart-changed` and the first coach's board intact. Reordering two chips
      *within* one outfield spot must **not** trigger it.
- [ ] Edge case — **crowded board**: pin three kids to CF *before* placing the infield on a
      12-player roster, then open `/t/:teamId/view`. Every kid should be drawn exactly once,
      with no two markers on the same point.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QaFDy8rCTRYgeL4SLtBFD