### PR TITLE
Dress every email in the app's own brand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -557,33 +557,48 @@ production — the dev command can prompt, generate new migrations, and reset th
 - **Every email wears one shell, and its palette is frozen hex that a test re-derives.**
   `EmailLayout` (cream page, charcoal scoreboard cap carrying the team name, warm card,
   seam-red rule) plus `EmailKit`'s motifs — `FactPanel` is the ticket stub, `StitchRule`
-  the seam, `ScoreboardPanel` the readiness scoreboard, `SlotDot` the jersey dot — are the
-  email translation of design-plan.md §5, and no template styles its own `<Body>` any
-  more. Colours come from `src/emails/brand.ts` and nowhere else: a mail client gives an
-  email no cascade to resolve `hsl(var(--x))` from, drops `prefers-color-scheme`, and
-  never sees a Tailwind class, so the palette is **light-theme hex, copied**, exactly as
-  `app/manifest.ts` copies two of them. `brand.test.ts` redoes the conversion out of
-  `globals.css` (via `@/lib/hsl-to-hex`, shared with `manifest.test.ts`) and fails when a
-  token moves, because nothing at runtime would ever notice.
+  the seam, `ScoreboardPanel` the readiness scoreboard, `EdgePanel` the state-edged row,
+  `SlotDot` the jersey dot — are the email translation of design-plan.md §5, and no
+  template styles its own `<Body>` any more. Colours come from `src/emails/brand.ts` and
+  nowhere else: a mail client gives an email no cascade to resolve `hsl(var(--x))` from,
+  drops `prefers-color-scheme`, and never sees a Tailwind class, so the palette is
+  **light-theme hex, copied**, exactly as `app/manifest.ts` copies two of them.
+  `brand.test.ts` redoes the conversion out of `globals.css` (via `@/lib/light-theme`,
+  the one parser of that file, shared with `manifest.test.ts`) and fails when a token
+  moves, because nothing at runtime would ever notice. The three RSVP colours are
+  cross-checked against `rsvp-style.ts` the same way, so the inbox cannot become a third
+  opinion on what "not going" looks like.
 
   Three things look like omissions and are decisions. **No images** — not the crest, not
   the field art: images are off by default in most inboxes, so brand carried in a PNG is
   brand that is blank for half the roster, and every remote fetch reports back when a
   family opened their mail. **No web font**, for the same beacon reason; `EMAIL_FONT.display`
-  is a bold slab *stack* that lands on Georgia for most readers. **No dark variant**, and
-  `color-scheme: light` in the head asks clients not to invert cream-and-navy into mud.
+  is a bold slab *stack* that lands on Georgia for most readers. **No dark variant, and no
+  pretence one can be requested**: `color-scheme: light` in the head is honoured by Apple
+  Mail and ignored by the Gmail and Outlook apps, which recolour on their own — darkening
+  light grounds, lifting dark text, leaving saturated colours alone. The palette is
+  arranged to survive that pass rather than prevent it, which is why **the call to action
+  is navy ground with banana lettering and keyline, never a banana ground with navy text**:
+  the latter comes out of Gmail's pass as light text on yellow, the one pairing §3 forbids.
   The cream ground is painted by a full-width `Section` **as well as** `Body`, because
-  Gmail drops `<body>` styling and a cream card on a white page looks like a bug.
+  Gmail drops `<body>` styling and a cream card on a white page looks like a bug. Outlook
+  desktop's Word engine additionally ignores padding on tables and `white-space` on
+  paragraphs, so the card is tighter there and a coach's typed line breaks collapse; known,
+  and left alone rather than paid for with MSO conditional comments in every template.
 
   §2's one-banana budget applies per email and `templates.test.tsx` enforces it by
-  counting banana *backgrounds* in the rendered markup: the invitation, the added-to-team
-  notice, both announcements and the reminder each spend theirs on the single call to
-  action; the sign-in code spends its own as floodlight-on-charcoal in the scoreboard
-  panel rather than a button (there is nothing to tap, by design); and the team message
-  and the announcement receipt are §7 calm surfaces with **no** banana at all — a yellow
-  button over somebody's typed message is the app talking over the coach. That suite also
-  pins that every template with a button still repeats its URL as plain text, which is
-  what a stripped-link client and a forwarded message leave a parent with.
+  counting the `data-banana` marker that only `BananaButton` and `ScoreboardPanel` may
+  carry: the invitation, the added-to-team notice, both announcements and the reminder
+  each spend theirs on the call to action; the sign-in code spends its own as
+  floodlight-on-charcoal in the scoreboard panel (there is nothing to tap, by design);
+  and the team message and the announcement receipt are §7 calm surfaces with **no**
+  banana at all — a yellow button over somebody's typed message is the app talking over
+  the coach. Nothing else in `src/emails/` may reference `EMAIL_COLOR.banana` or
+  `EMAIL_COLOR.floodlight`. That suite also asserts every colour in the rendered markup is
+  in the palette (so no hand-typed white can reach the banana), that every template names
+  the team on the cap except the pre-team sign-in code (`teamName` is required as
+  `string | null` for that reason), and that every template with a URL repeats it as plain
+  text — which `BananaButton` and `QuietLink` do themselves, so no template has to remember.
 
 - **`List-Unsubscribe` is set on two sends, and which two is a claim, not an oversight.**
   `sendEmail` takes an optional `listUnsubscribe` address; the all-parents broadcast and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ prisma/            # schema.prisma — the domain model, heavily commented
 public/            # Static assets: the crest, the PWA icon set, and sw.js (see Gotchas)
 src/app/           # Next.js App Router pages and layouts
 src/lib/           # Domain logic. Pure, DB-free modules live here with co-located tests
-src/emails/        # React Email templates plus their pure props builders
+src/emails/        # React Email templates, their pure props builders, and the shared brand shell
 src/generated/     # Prisma client output — gitignored, regenerate with pnpm db:generate
 src/components/    # Shared UI: shadcn primitives in ui/, plus the diamond and its geometry
 docs/design/       # The design plan and its SVG mockups — kept in step with the code by a test
@@ -554,6 +554,37 @@ production — the dev command can prompt, generate new migrations, and reset th
   whenever the draft builder normalized something — a stale `CATCHER` row under allPlay,
   or nine slots holding what used to be ten batters — and gating Save on the Cancel question
   leaves the coach looking at a change they cannot commit.
+- **Every email wears one shell, and its palette is frozen hex that a test re-derives.**
+  `EmailLayout` (cream page, charcoal scoreboard cap carrying the team name, warm card,
+  seam-red rule) plus `EmailKit`'s motifs — `FactPanel` is the ticket stub, `StitchRule`
+  the seam, `ScoreboardPanel` the readiness scoreboard, `SlotDot` the jersey dot — are the
+  email translation of design-plan.md §5, and no template styles its own `<Body>` any
+  more. Colours come from `src/emails/brand.ts` and nowhere else: a mail client gives an
+  email no cascade to resolve `hsl(var(--x))` from, drops `prefers-color-scheme`, and
+  never sees a Tailwind class, so the palette is **light-theme hex, copied**, exactly as
+  `app/manifest.ts` copies two of them. `brand.test.ts` redoes the conversion out of
+  `globals.css` (via `@/lib/hsl-to-hex`, shared with `manifest.test.ts`) and fails when a
+  token moves, because nothing at runtime would ever notice.
+
+  Three things look like omissions and are decisions. **No images** — not the crest, not
+  the field art: images are off by default in most inboxes, so brand carried in a PNG is
+  brand that is blank for half the roster, and every remote fetch reports back when a
+  family opened their mail. **No web font**, for the same beacon reason; `EMAIL_FONT.display`
+  is a bold slab *stack* that lands on Georgia for most readers. **No dark variant**, and
+  `color-scheme: light` in the head asks clients not to invert cream-and-navy into mud.
+  The cream ground is painted by a full-width `Section` **as well as** `Body`, because
+  Gmail drops `<body>` styling and a cream card on a white page looks like a bug.
+
+  §2's one-banana budget applies per email and `templates.test.tsx` enforces it by
+  counting banana *backgrounds* in the rendered markup: the invitation, the added-to-team
+  notice, both announcements and the reminder each spend theirs on the single call to
+  action; the sign-in code spends its own as floodlight-on-charcoal in the scoreboard
+  panel rather than a button (there is nothing to tap, by design); and the team message
+  and the announcement receipt are §7 calm surfaces with **no** banana at all — a yellow
+  button over somebody's typed message is the app talking over the coach. That suite also
+  pins that every template with a button still repeats its URL as plain text, which is
+  what a stripped-link client and a forwarded message leave a parent with.
+
 - **`List-Unsubscribe` is set on two sends, and which two is a claim, not an oversight.**
   `sendEmail` takes an optional `listUnsubscribe` address; the all-parents broadcast and
   the day-of reminder cron pass one, and nothing else does. RFC 2369 says the header

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -347,6 +347,14 @@ off one screen and typed into another and there is deliberately nothing to tap; 
 message and the announcement receipt are calm surfaces with none, because a yellow button
 over somebody's typed message is the app talking over the coach.
 
+The call to action is the one place the email inverts the app's pairing on purpose: **navy
+ground, banana lettering and keyline**, not a banana ground with navy text. The Gmail and
+Outlook apps recolour dark-mode mail on their own — they darken light grounds, lift dark
+text towards white and leave saturated colours alone — and a yellow button with navy text
+comes out of that pass as light text on Banana Yellow, the pairing §3 forbids. Built this
+way round, the button survives the pass unchanged, and what a dark-mode phone gets is a
+night-game version of the same card rather than an inverted CTA.
+
 Voice follows §9 exactly: eyebrows may play ("Today" in seam red is the one alarm in the
 directory), while dates, times and the three RSVP sentences stay frozen — `rsvpReminderLabel`
 still carries each kid's state in words, and the colour on the row is the second carrier,

--- a/docs/design/design-plan.md
+++ b/docs/design/design-plan.md
@@ -322,6 +322,36 @@ floodlight-yellow Geist Mono figures, uncovered positions in red. It's read-only
 **Roster/members/directory/settings** — calm pages: warm tokens, stitch dividers, jersey
 dots on roster rows, no bananas. Admin should feel tidy, not loud.
 
+**Email (post-ship addition)** — the inbox is the app's *first* surface: a parent meets a
+message from this app before they ever open a page, and the eight templates were plain
+white sans-serif with a near-black button — a different product arriving in the family's
+inbox. They now wear one shell (`src/emails/EmailLayout.tsx`): cream page stock, a
+charcoal scoreboard cap carrying the **team name** in slab caps, a warm card, a seam-red
+rule above the footer. §5's motifs are translated into things a mail client can actually
+draw (`src/emails/EmailKit.tsx`): the ticket stub becomes clay stock with a Field Green
+edge holding when/where, the stitch divider becomes a dashed seam-red rule, the scoreboard
+stays a scoreboard, the jersey dot numbers each date of a repeat-weekly run.
+
+Three constraints shape all of it, and each is a decision rather than a shortcoming. The
+palette is **frozen light-theme hex** in `src/emails/brand.ts` — an email has no cascade
+to resolve `hsl(var(--…))` from, `prefers-color-scheme` is dropped by most clients that
+matter, and Tailwind class names arrive with nothing to resolve them; `brand.test.ts`
+re-derives every value from `globals.css` so the copy cannot rot. There are **no images**
+and **no web font**: images are off by default in most inboxes and every remote fetch
+reports back when a family opened their mail, so the identity is carried by type, colour
+and rules, and `--font-display`'s Alfa Slab degrades to a bold system slab stack. And
+**§2's banana is budgeted per email** — the invitation, the added-to-team notice, both
+announcements and the day-of reminder spend theirs on the one call to action; the sign-in
+code spends its own as floodlight figures on the scoreboard panel, since a code is read
+off one screen and typed into another and there is deliberately nothing to tap; the team
+message and the announcement receipt are calm surfaces with none, because a yellow button
+over somebody's typed message is the app talking over the coach.
+
+Voice follows §9 exactly: eyebrows may play ("Today" in seam red is the one alarm in the
+directory), while dates, times and the three RSVP sentences stay frozen — `rsvpReminderLabel`
+still carries each kid's state in words, and the colour on the row is the second carrier,
+never the only one.
+
 **Empty states everywhere** — chalk box + one line of voice: "Nobody on the roster yet.
 Every dynasty starts somewhere." Copy stays informative first, funny second; parents skim.
 

--- a/src/app/manifest.test.ts
+++ b/src/app/manifest.test.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { hslToHex } from "@/lib/hsl-to-hex";
+
 import manifest from "./manifest";
 
 /**
@@ -21,7 +23,11 @@ import manifest from "./manifest";
  *    copied from the *light* theme in `globals.css`. That is exactly the shape
  *    of duplication that rots — see `design-plan-drift.test.ts` for the same
  *    problem one directory up — so the conversion is redone here and compared
- *    rather than trusted.
+ *    rather than trusted. The conversion itself is `@/lib/hsl-to-hex`, shared
+ *    with `src/emails/brand.test.ts`, which freezes the same light theme for
+ *    the same reason: two hand-rolled converters that disagree would fail
+ *    exactly one of these suites and give a reader no way to tell which one
+ *    was lying.
  */
 
 const repoRoot = process.cwd();
@@ -39,44 +45,6 @@ function lightToken(name: string): string {
     );
   }
   return match[1].trim();
-}
-
-/// `H S% L%` (the shape every token in globals.css uses) to `#RRGGBB`.
-function hslToHex(triple: string): string {
-  const match = /^(\d+(?:\.\d+)?) (\d+(?:\.\d+)?)% (\d+(?:\.\d+)?)%$/.exec(
-    triple,
-  );
-  if (!match) {
-    throw new Error(`Not an HSL triple: ${triple}`);
-  }
-
-  const h = Number(match[1]);
-  const s = Number(match[2]) / 100;
-  const l = Number(match[3]) / 100;
-
-  const c = (1 - Math.abs(2 * l - 1)) * s;
-  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-  const m = l - c / 2;
-
-  const [r, g, b] = (
-    [
-      [c, x, 0],
-      [x, c, 0],
-      [0, c, x],
-      [0, x, c],
-      [x, 0, c],
-      [c, 0, x],
-    ] as const
-  )[Math.floor(h / 60) % 6];
-
-  return `#${[r, g, b]
-    .map((channel) =>
-      Math.round((channel + m) * 255)
-        .toString(16)
-        .padStart(2, "0")
-        .toUpperCase(),
-    )
-    .join("")}`;
 }
 
 describe("web app manifest", () => {

--- a/src/app/manifest.test.ts
+++ b/src/app/manifest.test.ts
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { hslToHex } from "@/lib/hsl-to-hex";
+import { lightThemeHex } from "@/lib/light-theme";
 
 import manifest from "./manifest";
 
@@ -23,29 +23,14 @@ import manifest from "./manifest";
  *    copied from the *light* theme in `globals.css`. That is exactly the shape
  *    of duplication that rots — see `design-plan-drift.test.ts` for the same
  *    problem one directory up — so the conversion is redone here and compared
- *    rather than trusted. The conversion itself is `@/lib/hsl-to-hex`, shared
- *    with `src/emails/brand.test.ts`, which freezes the same light theme for
- *    the same reason: two hand-rolled converters that disagree would fail
- *    exactly one of these suites and give a reader no way to tell which one
- *    was lying.
+ *    rather than trusted. The parser and the conversion are `@/lib/light-theme`,
+ *    shared with `src/emails/brand.test.ts`, which freezes the same light
+ *    theme for the same reason: two hand-rolled readers that disagree would
+ *    fail exactly one of these suites and give a reader no way to tell which
+ *    one was lying.
  */
 
 const repoRoot = process.cwd();
-const globalsCss = readFileSync(join(repoRoot, "src/app/globals.css"), "utf8");
-
-/// The light-theme value of one token, as written in the `:root` block. Reads
-/// the first match deliberately: `:root` comes before the dark override in the
-/// file, so this is the light value even though the token name repeats.
-function lightToken(name: string): string {
-  const match = new RegExp(`--${name}:\\s*([^;]+);`).exec(globalsCss);
-  if (!match) {
-    throw new Error(
-      `--${name} is not in globals.css — this parser, not the stylesheet, ` +
-        "is probably what needs updating.",
-    );
-  }
-  return match[1].trim();
-}
 
 describe("web app manifest", () => {
   const result = manifest();
@@ -71,8 +56,8 @@ describe("web app manifest", () => {
   });
 
   it("uses the light-theme background and primary tokens as its colours", () => {
-    expect(result.background_color).toBe(hslToHex(lightToken("background")));
-    expect(result.theme_color).toBe(hslToHex(lightToken("primary")));
+    expect(result.background_color).toBe(lightThemeHex("background"));
+    expect(result.theme_color).toBe(lightThemeHex("primary"));
   });
 
   it("carries the icon sizes iOS and Android home screens ask for", () => {

--- a/src/app/t/[teamId]/roster/invite/actions.test.ts
+++ b/src/app/t/[teamId]/roster/invite/actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@react-email/components";
 
 const requireTeamAccess = vi.fn();
 const getRosterEntry = vi.fn();
@@ -179,15 +180,23 @@ describe("bulkInviteGuardiansAction sending", () => {
       }),
     );
 
-    const withMessage = sendEmail.mock.calls[0][0];
-    expect(JSON.stringify(withMessage.react)).toContain("See you at the field!");
+    // Rendered, not serialised: the action calls the template as a function,
+    // so `react` is already the layout element and the coach's note lives
+    // inside a kit component several levels down. (An earlier version looked
+    // for a `whiteSpace` style in `JSON.stringify(react)`, which stopped
+    // seeing anything once the template delegated that to `NoteBlock` — and
+    // passed, vacuously, in both cases.) The dashed chalk box is the note's
+    // frame, so its absence is what "omitted when blank" looks like.
+    const withMessage = await render(sendEmail.mock.calls[0][0].react);
+    expect(withMessage).toContain("See you at the field!");
+    expect(withMessage).toContain("1px dashed");
 
     sendEmail.mockClear();
     await submit(
       form({ teamId: "team-1", message: "   ", "email-entry-1": "a@example.com" }),
     );
-    const without = sendEmail.mock.calls[0][0];
-    expect(JSON.stringify(without.react)).not.toContain("whiteSpace");
+    const without = await render(sendEmail.mock.calls[0][0].react);
+    expect(without).not.toContain("1px dashed");
   });
 
   it("keeps only the first row per entry, so a forged POST can't fan out", async () => {

--- a/src/app/t/[teamId]/schedule/actions.ts
+++ b/src/app/t/[teamId]/schedule/actions.ts
@@ -626,7 +626,12 @@ async function sendReceipt(input: {
     const outcome = await sendEmail({
       to: input.coachEmail,
       subject,
-      react: AnnouncementReceiptEmail({ summary, needsAttention, scheduleUrl: link }),
+      react: AnnouncementReceiptEmail({
+        teamName: input.teamName,
+        summary,
+        needsAttention,
+        scheduleUrl: link,
+      }),
     });
     if (!outcome.ok) {
       console.error(`Announcement receipt failed to send: ${outcome.reason}`);

--- a/src/emails/AddedToTeamEmail.tsx
+++ b/src/emails/AddedToTeamEmail.tsx
@@ -1,17 +1,13 @@
-import {
-  Body,
-  Button,
-  Container,
-  Head,
-  Html,
-  Preview,
-  Text,
-} from "@react-email/components";
+import { BananaButton, EmailHeading, EmailText, LinkFallback } from "./EmailKit";
+import { EmailLayout } from "./EmailLayout";
 
-/// Plain and short, like InvitationEmail — but no expiry line and no "accept"
-/// language, because there is nothing to accept. The recipient already has an
-/// account (Decision 15 step 4): they're being told where a kid they guard
-/// now plays, not invited to sign up.
+/// Short, like InvitationEmail — but no expiry line and no "accept" language,
+/// because there is nothing to accept. The recipient already has an account
+/// (Decision 15 step 4): they're being told where a kid they guard now plays,
+/// not invited to sign up.
+///
+/// Its banana goes on the one link, for the same reason the invitation's does:
+/// the message is one sentence long and the tap is the whole of it.
 
 export type AddedToTeamEmailProps = {
   teamName: string;
@@ -20,34 +16,24 @@ export type AddedToTeamEmailProps = {
 
 export function AddedToTeamEmail({ teamName, teamUrl }: AddedToTeamEmailProps) {
   return (
-    <Html>
-      <Head />
-      <Preview>You&apos;ve been added to {teamName}</Preview>
-      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
-        <Container>
-          <Text>You&apos;ve been added to {teamName}.</Text>
-          <Button
-            href={teamUrl}
-            style={{
-              background: "#111827",
-              color: "#ffffff",
-              padding: "12px 20px",
-              borderRadius: "6px",
-              textDecoration: "none",
-            }}
-          >
-            View team
-          </Button>
-          <Text>
-            Or paste this link into your browser: <br />
-            {teamUrl}
-          </Text>
-          <Text>
-            You already have an account — sign in with the email address this
-            was sent to.
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailLayout
+      preview={`You've been added to ${teamName}`}
+      teamName={teamName}
+      footnote={`You're getting this because a player you're listed for is on ${teamName}'s roster.`}
+    >
+      <EmailHeading
+        eyebrow="New team"
+        title={`You're on ${teamName}`}
+        subtitle="Your player was added to the roster, so the schedule is yours now too."
+      />
+
+      <BananaButton href={teamUrl}>View team</BananaButton>
+      <LinkFallback href={teamUrl} />
+
+      <EmailText quiet>
+        You already have an account — sign in with the email address this was
+        sent to.
+      </EmailText>
+    </EmailLayout>
   );
 }

--- a/src/emails/AddedToTeamEmail.tsx
+++ b/src/emails/AddedToTeamEmail.tsx
@@ -1,4 +1,5 @@
-import { BananaButton, EmailHeading, EmailText, LinkFallback } from "./EmailKit";
+import { rosterFootnote } from "./copy";
+import { BananaButton, EmailHeading, EmailText } from "./EmailKit";
 import { EmailLayout } from "./EmailLayout";
 
 /// Short, like InvitationEmail — but no expiry line and no "accept" language,
@@ -19,7 +20,7 @@ export function AddedToTeamEmail({ teamName, teamUrl }: AddedToTeamEmailProps) {
     <EmailLayout
       preview={`You've been added to ${teamName}`}
       teamName={teamName}
-      footnote={`You're getting this because a player you're listed for is on ${teamName}'s roster.`}
+      footnote={rosterFootnote(teamName)}
     >
       <EmailHeading
         eyebrow="New team"
@@ -28,7 +29,6 @@ export function AddedToTeamEmail({ teamName, teamUrl }: AddedToTeamEmailProps) {
       />
 
       <BananaButton href={teamUrl}>View team</BananaButton>
-      <LinkFallback href={teamUrl} />
 
       <EmailText quiet>
         You already have an account — sign in with the email address this was

--- a/src/emails/AnnouncementReceiptEmail.tsx
+++ b/src/emails/AnnouncementReceiptEmail.tsx
@@ -1,8 +1,5 @@
-import type { CSSProperties } from "react";
-import { Section, Text } from "@react-email/components";
-
-import { EMAIL_COLOR, EMAIL_FONT } from "./brand";
-import { EmailHeading, EmailText, QuietLink } from "./EmailKit";
+import { EMAIL_COLOR } from "./brand";
+import { EdgePanel, EmailHeading, EmailText, QuietLink } from "./EmailKit";
 import { EmailLayout } from "./EmailLayout";
 
 /// The coach's copy of what happened when their event was announced (#45).
@@ -20,12 +17,16 @@ import { EmailLayout } from "./EmailLayout";
 /// details in a mailbox for no reason.
 
 export type AnnouncementReceiptEmailProps = {
+  /// On the cap, because the brief's coach runs more than one team and a
+  /// receipt that names none is a receipt for nothing in particular.
+  teamName: string;
   summary: string;
   needsAttention: boolean;
   scheduleUrl: string;
 };
 
 export function AnnouncementReceiptEmail({
+  teamName,
   summary,
   needsAttention,
   scheduleUrl,
@@ -33,6 +34,7 @@ export function AnnouncementReceiptEmail({
   return (
     <EmailLayout
       preview={summary}
+      teamName={teamName}
       footnote="You're getting this because you added the event."
     >
       <EmailHeading
@@ -41,16 +43,9 @@ export function AnnouncementReceiptEmail({
         title={needsAttention ? "Some parents weren't told" : "Announcement sent"}
       />
 
-      <Section
-        style={{
-          ...statusPanelStyle,
-          borderLeft: `4px solid ${
-            needsAttention ? EMAIL_COLOR.stitch : EMAIL_COLOR.green
-          }`,
-        }}
-      >
-        <Text style={statusTextStyle}>{summary}</Text>
-      </Section>
+      <EdgePanel edge={needsAttention ? EMAIL_COLOR.stitch : EMAIL_COLOR.green}>
+        {summary}
+      </EdgePanel>
 
       {needsAttention ? (
         <EmailText>
@@ -64,17 +59,3 @@ export function AnnouncementReceiptEmail({
   );
 }
 
-const statusPanelStyle: CSSProperties = {
-  backgroundColor: EMAIL_COLOR.page,
-  borderRadius: "0 10px 10px 0",
-  padding: "14px 16px",
-  margin: "0 0 20px",
-};
-
-const statusTextStyle: CSSProperties = {
-  fontFamily: EMAIL_FONT.body,
-  fontSize: "16px",
-  lineHeight: "24px",
-  color: EMAIL_COLOR.ink,
-  margin: 0,
-};

--- a/src/emails/AnnouncementReceiptEmail.tsx
+++ b/src/emails/AnnouncementReceiptEmail.tsx
@@ -1,16 +1,16 @@
-import {
-  Body,
-  Container,
-  Head,
-  Html,
-  Link,
-  Preview,
-  Text,
-} from "@react-email/components";
+import type { CSSProperties } from "react";
+import { Section, Text } from "@react-email/components";
+
+import { EMAIL_COLOR, EMAIL_FONT } from "./brand";
+import { EmailHeading, EmailText, QuietLink } from "./EmailKit";
+import { EmailLayout } from "./EmailLayout";
 
 /// The coach's copy of what happened when their event was announced (#45).
-/// Plain like every other template here — it is a receipt, read once, usually
-/// on a phone, and most of the time deleted.
+/// Read once, usually on a phone, and most of the time deleted — so it is a
+/// **calm** email in the design-plan.md §7 sense: no banana, no button, one
+/// status panel that is field green when the run was clean and seam red when it
+/// was not. The colour is never the only carrier; the summary sentence says the
+/// same thing in words.
 ///
 /// Addressed to one person about their own action, so it carries **no**
 /// `List-Unsubscribe`: RFC 2369's header describes a list the recipient belongs
@@ -31,28 +31,50 @@ export function AnnouncementReceiptEmail({
   scheduleUrl,
 }: AnnouncementReceiptEmailProps) {
   return (
-    <Html>
-      <Head />
-      <Preview>{summary}</Preview>
-      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
-        <Container>
-          <Text style={{ fontSize: "18px", fontWeight: "bold" }}>
-            {needsAttention ? "Some parents weren't told" : "Announcement sent"}
-          </Text>
-          <Text>{summary}</Text>
+    <EmailLayout
+      preview={summary}
+      footnote="You're getting this because you added the event."
+    >
+      <EmailHeading
+        eyebrow="Announcement"
+        tone={needsAttention ? "stitch" : "green"}
+        title={needsAttention ? "Some parents weren't told" : "Announcement sent"}
+      />
 
-          {needsAttention ? (
-            <Text>
-              Check those families&apos; email addresses on the roster, or reach
-              them another way — nothing will retry on its own.
-            </Text>
-          ) : null}
+      <Section
+        style={{
+          ...statusPanelStyle,
+          borderLeft: `4px solid ${
+            needsAttention ? EMAIL_COLOR.stitch : EMAIL_COLOR.green
+          }`,
+        }}
+      >
+        <Text style={statusTextStyle}>{summary}</Text>
+      </Section>
 
-          <Text>
-            <Link href={scheduleUrl}>{scheduleUrl}</Link>
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+      {needsAttention ? (
+        <EmailText>
+          Check those families&apos; email addresses on the roster, or reach
+          them another way — nothing will retry on its own.
+        </EmailText>
+      ) : null}
+
+      <QuietLink href={scheduleUrl}>Open the schedule</QuietLink>
+    </EmailLayout>
   );
 }
+
+const statusPanelStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.page,
+  borderRadius: "0 10px 10px 0",
+  padding: "14px 16px",
+  margin: "0 0 20px",
+};
+
+const statusTextStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.body,
+  fontSize: "16px",
+  lineHeight: "24px",
+  color: EMAIL_COLOR.ink,
+  margin: 0,
+};

--- a/src/emails/EmailKit.tsx
+++ b/src/emails/EmailKit.tsx
@@ -1,0 +1,398 @@
+import type { CSSProperties, ReactNode } from "react";
+import {
+  Button,
+  Column,
+  Hr,
+  Link,
+  Row,
+  Section,
+  Text,
+} from "@react-email/components";
+
+import { EMAIL_COLOR, EMAIL_FONT } from "./brand";
+
+/// The pieces every email is built from — the email-safe translation of
+/// design-plan.md §5's texture vocabulary. Each motif here is the same idea as
+/// its on-screen counterpart, rebuilt out of the three things a mail client can
+/// be trusted with: a background colour, a border, and text.
+///
+///   - **Stitch divider** → `StitchRule`. On screen it is two dashed SVG arcs;
+///     here it is a dashed seam-red rule, because SVG is dropped outright by
+///     Outlook and inconsistently supported everywhere else.
+///   - **Ticket stub** → `FactPanel`. The perforated RSVP-able surface, flattened
+///     to clay stock with a Field Green edge. This is where the when and where
+///     live, which is the whole reason a parent opened the message.
+///   - **Chalk box** → `NoteBlock`, for text a human typed (a coach's note, an
+///     event's notes) so it reads as quoted rather than as app copy.
+///   - **Scoreboard** → `ScoreboardPanel`. Charcoal in both themes, floodlight
+///     mono figures. Used for the one number an email exists to deliver.
+///   - **Jersey dot** → `SlotDot`, the batting-slot disc, spent here on the
+///     index of each date in a repeat-weekly announcement.
+///
+/// Everything is inline style objects rather than classes: a `<style>` block is
+/// stripped by Gmail's webmail, and Tailwind never had a chance — the class
+/// names would arrive with nothing to resolve them.
+
+/// A page-level heading: a small monospaced eyebrow, then the slab headline,
+/// then one optional line of context.
+///
+/// The eyebrow is the layer that lets the headline stay a real sentence. "New
+/// on the schedule" as a 26px slab and "Game vs Robert" underneath reads as two
+/// competing titles; as an eyebrow it reads as a stamp on an envelope.
+export function EmailHeading({
+  eyebrow,
+  title,
+  subtitle,
+  tone = "green",
+}: {
+  eyebrow: string;
+  title: string;
+  /// The team name, usually — the line that tells a parent with kids on two
+  /// teams which one this is about.
+  subtitle?: string;
+  /// `stitch` is for the one eyebrow that is an alarm ("TODAY"). Everything
+  /// else is green, and a third tone would make the distinction meaningless.
+  tone?: "green" | "stitch";
+}) {
+  return (
+    <>
+      <Text
+        style={{
+          ...eyebrowStyle,
+          color: tone === "stitch" ? EMAIL_COLOR.stitch : EMAIL_COLOR.green,
+        }}
+      >
+        {eyebrow}
+      </Text>
+      <Text style={headlineStyle}>{title}</Text>
+      {subtitle ? <Text style={subtitleStyle}>{subtitle}</Text> : null}
+    </>
+  );
+}
+
+/// Body copy. A named component rather than a bare `<Text>` so that no email
+/// has to remember the type size, and so "a paragraph" and "a paragraph that
+/// preserves the line breaks a human typed" are one decision apart.
+export function EmailText({
+  children,
+  preserveBreaks = false,
+  quiet = false,
+}: {
+  children: ReactNode;
+  preserveBreaks?: boolean;
+  quiet?: boolean;
+}) {
+  return (
+    <Text
+      style={{
+        ...bodyStyle,
+        ...(quiet ? { color: EMAIL_COLOR.quietInk, fontSize: "14px" } : {}),
+        ...(preserveBreaks ? { whiteSpace: "pre-wrap" } : {}),
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+/// The ticket stub: clay stock, a Field Green edge, and label/value rows. Holds
+/// the facts a parent is scanning for — when, where, anything the coach added.
+export function FactPanel({ children }: { children: ReactNode }) {
+  return <Section style={factPanelStyle}>{children}</Section>;
+}
+
+/// One row of the stub. The label is a monospaced caption in the margin, so the
+/// values line up as a column a thumb can scan.
+export function FactRow({
+  label,
+  children,
+  mono = false,
+}: {
+  label: string;
+  children: ReactNode;
+  /// Dates, times and anything else that is a readout rather than a sentence.
+  mono?: boolean;
+}) {
+  return (
+    <Row style={{ marginBottom: "10px" }}>
+      <Column style={factLabelCellStyle}>
+        <Text style={factLabelStyle}>{label}</Text>
+      </Column>
+      <Column>
+        <Text
+          style={{
+            ...factValueStyle,
+            // Monospace runs wide, and "Wed, Sep 16, 2026 at 5:45 PM" has to
+            // fit beside its label on a 360px phone without wrapping mid-date.
+            ...(mono
+              ? {
+                  fontFamily: EMAIL_FONT.mono,
+                  fontSize: "15px",
+                  letterSpacing: "-0.2px",
+                }
+              : {}),
+          }}
+        >
+          {children}
+        </Text>
+      </Column>
+    </Row>
+  );
+}
+
+/// Text a person typed, set apart from text the app wrote. Same job as the
+/// chalk box on screen: this is quoted material, and a parent should be able to
+/// tell at a glance that the coach chose these words.
+export function NoteBlock({ children }: { children: ReactNode }) {
+  return (
+    <Section style={noteBlockStyle}>
+      <Text style={{ ...bodyStyle, margin: 0, whiteSpace: "pre-wrap" }}>
+        {children}
+      </Text>
+    </Section>
+  );
+}
+
+/// The scoreboard: charcoal panel, chalk caption, floodlight figures.
+///
+/// Reserved for the single number a message exists to carry — today the sign-in
+/// code. Everything about it is the readout: the panel is dark in a cream email
+/// on purpose, so the eye lands there first and the code can be read at a
+/// glance and typed into another screen.
+export function ScoreboardPanel({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <Section style={scoreboardStyle}>
+      <Text style={scoreboardLabelStyle}>{label}</Text>
+      <Text style={scoreboardValueStyle}>{children}</Text>
+    </Section>
+  );
+}
+
+/// The Banana Yellow call to action — **one per email, or none**
+/// (design-plan.md §2). Navy on banana, never white, and a navy keyline so the
+/// button still reads as a button against cream stock in a client that ignores
+/// the radius.
+export function BananaButton({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  return (
+    <Section style={{ padding: "6px 0 4px" }}>
+      <Button href={href} style={bananaButtonStyle}>
+        {children}
+      </Button>
+    </Section>
+  );
+}
+
+/// The same URL as plain text under a button.
+///
+/// Kept from the original plain templates and deliberately not dropped for
+/// looking untidy: mail clients strip links, corporate gateways rewrite them,
+/// and a parent forwarding the message to the other parent sends the text. It
+/// is small and grey because it is a fallback, not an instruction.
+export function LinkFallback({ href }: { href: string }) {
+  return (
+    <Text style={fallbackStyle}>
+      Or paste this into your browser:
+      <br />
+      <span style={{ wordBreak: "break-all" }}>{href}</span>
+    </Text>
+  );
+}
+
+/// A quiet link for the calm emails — the ones whose point is the message
+/// itself, where a yellow button would be shouting over the sender.
+export function QuietLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  return (
+    <Text style={{ ...bodyStyle, fontSize: "14px" }}>
+      <Link href={href} style={linkStyle}>
+        {children}
+      </Link>
+    </Text>
+  );
+}
+
+/// The seam. Replaces a plain rule between sections.
+export function StitchRule() {
+  return <Hr style={stitchRuleStyle} />;
+}
+
+/// The jersey dot, as a squared-off chip a mail client can actually draw: navy
+/// ground, cream monospaced figure.
+export function SlotDot({ children }: { children: ReactNode }) {
+  return <span style={slotDotStyle}>{children}</span>;
+}
+
+/// A small caption above a list or a panel.
+export function SectionLabel({ children }: { children: ReactNode }) {
+  return <Text style={{ ...eyebrowStyle, color: EMAIL_COLOR.quietInk }}>{children}</Text>;
+}
+
+const eyebrowStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "11px",
+  fontWeight: 700,
+  letterSpacing: "1.5px",
+  textTransform: "uppercase",
+  margin: "0 0 6px",
+};
+
+const headlineStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.display,
+  fontSize: "26px",
+  lineHeight: "32px",
+  // Bold, because almost nobody receiving this has Rockwell: the stack lands
+  // on Georgia for most readers, and Georgia at regular weight is a book, not
+  // a scoreboard. Bold is the closest a system serif gets to Alfa Slab's heft.
+  fontWeight: 700,
+  color: EMAIL_COLOR.ink,
+  margin: "0 0 6px",
+};
+
+const subtitleStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.body,
+  fontSize: "15px",
+  lineHeight: "22px",
+  color: EMAIL_COLOR.quietInk,
+  margin: "0 0 18px",
+};
+
+const bodyStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.body,
+  fontSize: "16px",
+  lineHeight: "24px",
+  color: EMAIL_COLOR.ink,
+  margin: "0 0 16px",
+};
+
+const factPanelStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.stub,
+  borderLeft: `4px solid ${EMAIL_COLOR.green}`,
+  borderRadius: "10px",
+  padding: "16px 18px 6px",
+  margin: "0 0 20px",
+};
+
+const factLabelCellStyle: CSSProperties = {
+  width: "74px",
+  verticalAlign: "top",
+};
+
+const factLabelStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "11px",
+  fontWeight: 700,
+  letterSpacing: "1px",
+  textTransform: "uppercase",
+  color: EMAIL_COLOR.quietInk,
+  margin: "3px 0 0",
+};
+
+const factValueStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.body,
+  fontSize: "16px",
+  lineHeight: "22px",
+  fontWeight: 600,
+  color: EMAIL_COLOR.ink,
+  margin: 0,
+  whiteSpace: "pre-wrap",
+};
+
+const noteBlockStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.page,
+  border: `1px dashed ${EMAIL_COLOR.border}`,
+  borderRadius: "10px",
+  padding: "14px 16px",
+  margin: "0 0 20px",
+};
+
+const scoreboardStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.scoreboard,
+  borderRadius: "12px",
+  padding: "18px 20px",
+  margin: "0 0 20px",
+  textAlign: "center",
+};
+
+const scoreboardLabelStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "11px",
+  fontWeight: 700,
+  letterSpacing: "2px",
+  textTransform: "uppercase",
+  color: EMAIL_COLOR.onScoreboard,
+  margin: "0 0 8px",
+};
+
+const scoreboardValueStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "34px",
+  lineHeight: "40px",
+  fontWeight: 700,
+  letterSpacing: "5px",
+  color: EMAIL_COLOR.floodlight,
+  margin: 0,
+};
+
+const bananaButtonStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.banana,
+  color: EMAIL_COLOR.ink,
+  border: `2px solid ${EMAIL_COLOR.ink}`,
+  borderRadius: "10px",
+  fontFamily: EMAIL_FONT.body,
+  fontSize: "16px",
+  fontWeight: 700,
+  letterSpacing: "0.2px",
+  padding: "14px 24px",
+  textDecoration: "none",
+  display: "inline-block",
+};
+
+const fallbackStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "12px",
+  lineHeight: "18px",
+  color: EMAIL_COLOR.quietInk,
+  margin: "0 0 16px",
+};
+
+const linkStyle: CSSProperties = {
+  color: EMAIL_COLOR.green,
+  fontWeight: 600,
+  textDecoration: "underline",
+};
+
+const stitchRuleStyle: CSSProperties = {
+  width: "100%",
+  border: "none",
+  borderTop: `2px dashed ${EMAIL_COLOR.stitch}`,
+  margin: "20px 0",
+};
+
+const slotDotStyle: CSSProperties = {
+  display: "inline-block",
+  backgroundColor: EMAIL_COLOR.ink,
+  color: EMAIL_COLOR.page,
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "12px",
+  fontWeight: 700,
+  borderRadius: "999px",
+  padding: "3px 9px",
+  marginRight: "10px",
+};

--- a/src/emails/EmailKit.tsx
+++ b/src/emails/EmailKit.tsx
@@ -22,16 +22,28 @@ import { EMAIL_COLOR, EMAIL_FONT } from "./brand";
 ///   - **Ticket stub** → `FactPanel`. The perforated RSVP-able surface, flattened
 ///     to clay stock with a Field Green edge. This is where the when and where
 ///     live, which is the whole reason a parent opened the message.
-///   - **Chalk box** → `NoteBlock`, for text a human typed (a coach's note, an
-///     event's notes) so it reads as quoted rather than as app copy.
+///   - **Chalk box** → `NoteBlock`, for text a human typed (a coach's note) so
+///     it reads as quoted rather than as app copy; and `EdgePanel`, the same
+///     page-stock panel with a coloured edge carrying a state.
 ///   - **Scoreboard** → `ScoreboardPanel`. Charcoal in both themes, floodlight
 ///     mono figures. Used for the one number an email exists to deliver.
 ///   - **Jersey dot** → `SlotDot`, the batting-slot disc, spent here on the
 ///     index of each date in a repeat-weekly announcement.
 ///
-/// Everything is inline style objects rather than classes: a `<style>` block is
-/// stripped by Gmail's webmail, and Tailwind never had a chance — the class
-/// names would arrive with nothing to resolve them.
+/// Everything is inline style objects rather than classes. Gmail keeps a
+/// `<style>` block in the head but not every Gmail surface applies it, Outlook
+/// desktop applies its own subset, and Tailwind class names would arrive with
+/// nothing to resolve them — inline is the one form every client reads.
+///
+/// Two guarantees are built into components here rather than left to each
+/// template to remember. **Every link repeats its URL as text** (`BananaButton`
+/// and `QuietLink` both print it underneath), because mail clients strip
+/// links, gateways rewrite them, and a forwarded message is text. And **the
+/// banana budget is a marker**: the two pieces allowed to spend design-plan.md
+/// §2's one yellow per email — `BananaButton` and `ScoreboardPanel` — each
+/// carry a `data-banana` attribute, which is what `templates.test.tsx` counts.
+/// Nothing else in this directory may reference `EMAIL_COLOR.banana` or
+/// `EMAIL_COLOR.floodlight`.
 
 /// A page-level heading: a small monospaced eyebrow, then the slab headline,
 /// then one optional line of context.
@@ -58,7 +70,8 @@ export function EmailHeading({
     <>
       <Text
         style={{
-          ...eyebrowStyle,
+          ...captionStyle,
+          margin: "0 0 6px",
           color: tone === "stitch" ? EMAIL_COLOR.stitch : EMAIL_COLOR.green,
         }}
       >
@@ -71,15 +84,16 @@ export function EmailHeading({
 }
 
 /// Body copy. A named component rather than a bare `<Text>` so that no email
-/// has to remember the type size, and so "a paragraph" and "a paragraph that
-/// preserves the line breaks a human typed" are one decision apart.
+/// has to remember the type size. Line breaks a person typed are always kept
+/// (`bodyStyle` is `pre-wrap`): app copy is single-line by construction, so
+/// the setting only ever affects the coach's own paragraphs, and an opt-in
+/// flag was one more thing for a new template to forget.
 export function EmailText({
   children,
-  preserveBreaks = false,
   quiet = false,
 }: {
   children: ReactNode;
-  preserveBreaks?: boolean;
+  /// Footer-weight: the "if you didn't ask for this" line, never a fact.
   quiet?: boolean;
 }) {
   return (
@@ -87,7 +101,6 @@ export function EmailText({
       style={{
         ...bodyStyle,
         ...(quiet ? { color: EMAIL_COLOR.quietInk, fontSize: "14px" } : {}),
-        ...(preserveBreaks ? { whiteSpace: "pre-wrap" } : {}),
       }}
     >
       {children}
@@ -122,8 +135,11 @@ export function FactRow({
         <Text
           style={{
             ...factValueStyle,
-            // Monospace runs wide, and "Wed, Sep 16, 2026 at 5:45 PM" has to
-            // fit beside its label on a 360px phone without wrapping mid-date.
+            // Monospace runs wide. A full "Wed, Sep 16, 2026 at 5:45 PM" still
+            // wraps once beside its label on a 360px phone — the value cell is
+            // about 175px there — but at 15px it breaks at the space before
+            // the time rather than inside the date, which is the line that
+            // matters. Do not shrink it further to chase a single line.
             ...(mono
               ? {
                   fontFamily: EMAIL_FONT.mono,
@@ -146,7 +162,25 @@ export function FactRow({
 export function NoteBlock({ children }: { children: ReactNode }) {
   return (
     <Section style={noteBlockStyle}>
-      <Text style={{ ...bodyStyle, margin: 0, whiteSpace: "pre-wrap" }}>
+      <Text style={{ ...bodyStyle, margin: 0 }}>{children}</Text>
+    </Section>
+  );
+}
+
+/// A page-stock panel with a coloured left edge — the state carrier for the
+/// reminder's per-kid rows and the receipt's summary. The edge is never the
+/// only carrier: whatever text sits inside says the state in words.
+export function EdgePanel({
+  edge,
+  children,
+}: {
+  /// One of the palette's state colours.
+  edge: string;
+  children: ReactNode;
+}) {
+  return (
+    <Section style={{ ...edgePanelStyle, borderLeft: `4px solid ${edge}` }}>
+      <Text style={{ ...bodyStyle, margin: 0, fontWeight: 600 }}>
         {children}
       </Text>
     </Section>
@@ -158,7 +192,8 @@ export function NoteBlock({ children }: { children: ReactNode }) {
 /// Reserved for the single number a message exists to carry — today the sign-in
 /// code. Everything about it is the readout: the panel is dark in a cream email
 /// on purpose, so the eye lands there first and the code can be read at a
-/// glance and typed into another screen.
+/// glance and typed into another screen. Floodlight is the banana family after
+/// dark, so this **is** that email's banana, and it carries the marker.
 export function ScoreboardPanel({
   label,
   children,
@@ -167,17 +202,27 @@ export function ScoreboardPanel({
   children: ReactNode;
 }) {
   return (
-    <Section style={scoreboardStyle}>
+    <Section style={scoreboardStyle} data-banana="scoreboard">
       <Text style={scoreboardLabelStyle}>{label}</Text>
       <Text style={scoreboardValueStyle}>{children}</Text>
     </Section>
   );
 }
 
-/// The Banana Yellow call to action — **one per email, or none**
-/// (design-plan.md §2). Navy on banana, never white, and a navy keyline so the
-/// button still reads as a button against cream stock in a client that ignores
-/// the radius.
+/// The call to action — **one per email, or none** (design-plan.md §2).
+///
+/// Navy ground, banana lettering, banana keyline. It is built this way round,
+/// and not as a yellow button with navy text, because of what the Gmail and
+/// Outlook apps do to a message in dark mode: they leave dark grounds and
+/// saturated colours alone and lift dark text towards white. A banana ground
+/// under navy text comes out of that pass as light text on yellow — the one
+/// pairing §3 forbids — while this survives it unchanged. What is banana about
+/// the button is the lettering and the frame, and that is the budget spent.
+///
+/// The URL is repeated as plain text underneath, always. Mail clients strip
+/// links, gateways rewrite them, and a parent forwarding the message to the
+/// other parent sends the text — so the fallback is part of the button rather
+/// than a second component each template has to remember.
 export function BananaButton({
   href,
   children,
@@ -186,21 +231,38 @@ export function BananaButton({
   children: ReactNode;
 }) {
   return (
-    <Section style={{ padding: "6px 0 4px" }}>
+    <Section style={{ padding: "6px 0 4px" }} data-banana="cta">
       <Button href={href} style={bananaButtonStyle}>
         {children}
       </Button>
+      <LinkFallback href={href} />
     </Section>
   );
 }
 
-/// The same URL as plain text under a button.
-///
-/// Kept from the original plain templates and deliberately not dropped for
-/// looking untidy: mail clients strip links, corporate gateways rewrite them,
-/// and a parent forwarding the message to the other parent sends the text. It
-/// is small and grey because it is a fallback, not an instruction.
-export function LinkFallback({ href }: { href: string }) {
+/// A quiet link for the calm emails — the ones whose point is the message
+/// itself, where a yellow button would be shouting over the sender. Prints its
+/// URL underneath for the same reason the button does.
+export function QuietLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  return (
+    <>
+      <Text style={{ ...bodyStyle, fontSize: "14px", margin: "0 0 6px" }}>
+        <Link href={href} style={linkStyle}>
+          {children}
+        </Link>
+      </Text>
+      <LinkFallback href={href} />
+    </>
+  );
+}
+
+function LinkFallback({ href }: { href: string }) {
   return (
     <Text style={fallbackStyle}>
       Or paste this into your browser:
@@ -210,47 +272,46 @@ export function LinkFallback({ href }: { href: string }) {
   );
 }
 
-/// A quiet link for the calm emails — the ones whose point is the message
-/// itself, where a yellow button would be shouting over the sender.
-export function QuietLink({
-  href,
-  children,
-}: {
-  href: string;
-  children: ReactNode;
-}) {
-  return (
-    <Text style={{ ...bodyStyle, fontSize: "14px" }}>
-      <Link href={href} style={linkStyle}>
-        {children}
-      </Link>
-    </Text>
-  );
-}
-
 /// The seam. Replaces a plain rule between sections.
 export function StitchRule() {
   return <Hr style={stitchRuleStyle} />;
 }
 
-/// The jersey dot, as a squared-off chip a mail client can actually draw: navy
-/// ground, cream monospaced figure.
+/// The jersey dot, as a chip a mail client can actually draw: navy ground,
+/// cream monospaced figure. Followed by a real space, because Outlook ignores
+/// the margin on an inline element, a screen reader ignores every margin, and
+/// "1Sat, Apr 4" is what both would otherwise get.
 export function SlotDot({ children }: { children: ReactNode }) {
-  return <span style={slotDotStyle}>{children}</span>;
+  return (
+    <>
+      <span style={slotDotStyle}>{children}</span>{" "}
+    </>
+  );
 }
 
 /// A small caption above a list or a panel.
 export function SectionLabel({ children }: { children: ReactNode }) {
-  return <Text style={{ ...eyebrowStyle, color: EMAIL_COLOR.quietInk }}>{children}</Text>;
+  return (
+    <Text style={{ ...captionStyle, margin: "0 0 8px", color: EMAIL_COLOR.quietInk }}>
+      {children}
+    </Text>
+  );
 }
 
-const eyebrowStyle: CSSProperties = {
+/// The caption voice: 11px monospaced small caps. Every label, eyebrow and
+/// footer line in an email is this with a colour and a spacing, and the shell
+/// (`EmailLayout`) spends it too. `lineHeight` is set explicitly because
+/// React Email's `Text` defaults to 24px — which on an 11px caption is a
+/// 13px halo of phantom space that pushes every stub label visibly below the
+/// value it names.
+export const captionStyle: CSSProperties = {
   fontFamily: EMAIL_FONT.mono,
   fontSize: "11px",
+  lineHeight: "16px",
   fontWeight: 700,
   letterSpacing: "1.5px",
   textTransform: "uppercase",
-  margin: "0 0 6px",
+  margin: 0,
 };
 
 const headlineStyle: CSSProperties = {
@@ -279,6 +340,7 @@ const bodyStyle: CSSProperties = {
   lineHeight: "24px",
   color: EMAIL_COLOR.ink,
   margin: "0 0 16px",
+  whiteSpace: "pre-wrap",
 };
 
 const factPanelStyle: CSSProperties = {
@@ -295,12 +357,10 @@ const factLabelCellStyle: CSSProperties = {
 };
 
 const factLabelStyle: CSSProperties = {
-  fontFamily: EMAIL_FONT.mono,
-  fontSize: "11px",
-  fontWeight: 700,
+  ...captionStyle,
   letterSpacing: "1px",
-  textTransform: "uppercase",
   color: EMAIL_COLOR.quietInk,
+  // Sits the 16px caption box on the value's 22px baseline.
   margin: "3px 0 0",
 };
 
@@ -322,6 +382,13 @@ const noteBlockStyle: CSSProperties = {
   margin: "0 0 20px",
 };
 
+const edgePanelStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.page,
+  borderRadius: "0 10px 10px 0",
+  padding: "12px 16px",
+  margin: "0 0 8px",
+};
+
 const scoreboardStyle: CSSProperties = {
   backgroundColor: EMAIL_COLOR.scoreboard,
   borderRadius: "12px",
@@ -331,11 +398,8 @@ const scoreboardStyle: CSSProperties = {
 };
 
 const scoreboardLabelStyle: CSSProperties = {
-  fontFamily: EMAIL_FONT.mono,
-  fontSize: "11px",
-  fontWeight: 700,
+  ...captionStyle,
   letterSpacing: "2px",
-  textTransform: "uppercase",
   color: EMAIL_COLOR.onScoreboard,
   margin: "0 0 8px",
 };
@@ -351,9 +415,9 @@ const scoreboardValueStyle: CSSProperties = {
 };
 
 const bananaButtonStyle: CSSProperties = {
-  backgroundColor: EMAIL_COLOR.banana,
-  color: EMAIL_COLOR.ink,
-  border: `2px solid ${EMAIL_COLOR.ink}`,
+  backgroundColor: EMAIL_COLOR.ink,
+  color: EMAIL_COLOR.banana,
+  border: `2px solid ${EMAIL_COLOR.banana}`,
   borderRadius: "10px",
   fontFamily: EMAIL_FONT.body,
   fontSize: "16px",
@@ -369,7 +433,7 @@ const fallbackStyle: CSSProperties = {
   fontSize: "12px",
   lineHeight: "18px",
   color: EMAIL_COLOR.quietInk,
-  margin: "0 0 16px",
+  margin: "8px 0 16px",
 };
 
 const linkStyle: CSSProperties = {
@@ -394,5 +458,5 @@ const slotDotStyle: CSSProperties = {
   fontWeight: 700,
   borderRadius: "999px",
   padding: "3px 9px",
-  marginRight: "10px",
+  marginRight: "6px",
 };

--- a/src/emails/EmailLayout.tsx
+++ b/src/emails/EmailLayout.tsx
@@ -1,0 +1,159 @@
+import type { CSSProperties, ReactNode } from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+
+import { EMAIL_COLOR, EMAIL_FONT, EMAIL_WIDTH } from "./brand";
+import { StitchRule } from "./EmailKit";
+
+/// The shell every email in this directory wears: cream page stock, a charcoal
+/// scoreboard cap with the team's name on it, one card of warm white, and a
+/// seam-red rule above the footer.
+///
+/// It exists because eight templates each opening `<Body style={{fontFamily:
+/// "sans-serif", padding: "24px"}}>` is eight chances to be a slightly different
+/// product, and because the inbox is the app's **first** surface — a parent
+/// meets this before they ever open a page. See `brand.ts` for why the palette
+/// is frozen hex and why there are no images and no web fonts.
+///
+/// Two structural notes, both about Gmail rather than taste:
+///
+///   - The cream ground is painted by a full-width `Section` **as well as** the
+///     `Body`. Gmail's webmail drops `<body>` styling, so an email that puts its
+///     page colour only there is white in the client most of this roster reads
+///     mail in — and a cream card floating on white looks like a bug.
+///   - `color-scheme: light` asks clients not to auto-invert. A forced dark
+///     inversion of cream-and-navy produces mud, and the message is legible in
+///     its own colours; this is the one lever that stops it.
+///
+/// The header band carries the **team name**, not a logo. It is the fastest
+/// answer to the question a parent with kids on two teams actually has, and it
+/// works with images blocked.
+
+export type EmailLayoutProps = {
+  /// Inbox preview text — the line under the subject. Every template sets it
+  /// to the fact a parent needs before opening.
+  preview: string;
+  /// Shown on the scoreboard cap. Omitted only by the sign-in code email,
+  /// which is sent before we know which team the person is here for.
+  teamName?: string;
+  /// The grey line under the seam: why this message arrived. Templates say it
+  /// in their own words rather than sharing one sentence, because the reasons
+  /// genuinely differ — a roster, an invitation, something you asked for.
+  footnote?: ReactNode;
+  children: ReactNode;
+};
+
+export function EmailLayout({
+  preview,
+  teamName,
+  footnote,
+  children,
+}: EmailLayoutProps) {
+  return (
+    <Html lang="en">
+      <Head>
+        <meta name="color-scheme" content="light" />
+        <meta name="supported-color-schemes" content="light" />
+      </Head>
+      <Preview>{preview}</Preview>
+      <Body style={bodyStyle}>
+        <Section style={pageStyle}>
+          <Container style={containerStyle}>
+            <Section style={bandStyle}>
+              <Text style={bandProductStyle}>Team Manager</Text>
+              {teamName ? <Text style={bandTeamStyle}>{teamName}</Text> : null}
+            </Section>
+
+            <Section style={cardStyle}>{children}</Section>
+
+            <StitchRule />
+
+            {footnote ? <Text style={footnoteStyle}>{footnote}</Text> : null}
+            <Text style={signatureStyle}>Youth Baseball Team Manager</Text>
+          </Container>
+        </Section>
+      </Body>
+    </Html>
+  );
+}
+
+const bodyStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.page,
+  color: EMAIL_COLOR.ink,
+  fontFamily: EMAIL_FONT.body,
+  margin: 0,
+  padding: 0,
+};
+
+const pageStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.page,
+  padding: "24px 12px 32px",
+};
+
+const containerStyle: CSSProperties = {
+  maxWidth: EMAIL_WIDTH,
+  width: "100%",
+};
+
+const bandStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.scoreboard,
+  // The grass line: the field green edge that separates the scoreboard cap
+  // from the card, and the only place in the shell the brand's green is a
+  // surface rather than an accent.
+  borderBottom: `4px solid ${EMAIL_COLOR.green}`,
+  borderRadius: "14px 14px 0 0",
+  padding: "16px 24px 14px",
+};
+
+const bandProductStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "11px",
+  fontWeight: 700,
+  letterSpacing: "2.5px",
+  textTransform: "uppercase",
+  color: EMAIL_COLOR.onScoreboard,
+  margin: 0,
+};
+
+const bandTeamStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.display,
+  fontSize: "20px",
+  lineHeight: "26px",
+  fontWeight: 700,
+  color: EMAIL_COLOR.onScoreboard,
+  margin: "4px 0 0",
+};
+
+const cardStyle: CSSProperties = {
+  backgroundColor: EMAIL_COLOR.card,
+  border: `1px solid ${EMAIL_COLOR.border}`,
+  borderTop: "none",
+  borderRadius: "0 0 14px 14px",
+  padding: "26px 24px 22px",
+};
+
+const footnoteStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.body,
+  fontSize: "12px",
+  lineHeight: "18px",
+  color: EMAIL_COLOR.quietInk,
+  margin: "0 0 6px",
+  padding: "0 4px",
+};
+
+const signatureStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "11px",
+  letterSpacing: "1.5px",
+  textTransform: "uppercase",
+  color: EMAIL_COLOR.quietInk,
+  margin: 0,
+  padding: "0 4px",
+};

--- a/src/emails/EmailLayout.tsx
+++ b/src/emails/EmailLayout.tsx
@@ -10,7 +10,7 @@ import {
 } from "@react-email/components";
 
 import { EMAIL_COLOR, EMAIL_FONT, EMAIL_WIDTH } from "./brand";
-import { StitchRule } from "./EmailKit";
+import { StitchRule, captionStyle } from "./EmailKit";
 
 /// The shell every email in this directory wears: cream page stock, a charcoal
 /// scoreboard cap with the team's name on it, one card of warm white, and a
@@ -28,24 +28,31 @@ import { StitchRule } from "./EmailKit";
 ///     `Body`. Gmail's webmail drops `<body>` styling, so an email that puts its
 ///     page colour only there is white in the client most of this roster reads
 ///     mail in — and a cream card floating on white looks like a bug.
-///   - `color-scheme: light` asks clients not to auto-invert. A forced dark
-///     inversion of cream-and-navy produces mud, and the message is legible in
-///     its own colours; this is the one lever that stops it.
+///   - `color-scheme: light` asks clients not to auto-invert. Apple Mail
+///     listens; the Gmail and Outlook apps do not, and recolour regardless.
+///     So the meta is a courtesy, not a defence — the defence is that the
+///     palette is arranged to survive their pass (see `brand.ts`), and the
+///     call to action in particular is built so that the recolour cannot put
+///     light text on the banana.
 ///
 /// The header band carries the **team name**, not a logo. It is the fastest
 /// answer to the question a parent with kids on two teams actually has, and it
-/// works with images blocked.
+/// works with images blocked. It is required, as `string | null`, so that a
+/// template cannot forget it: the receipt did exactly that in the first cut,
+/// and a coach running two teams got a receipt that named neither.
 
 export type EmailLayoutProps = {
   /// Inbox preview text — the line under the subject. Every template sets it
   /// to the fact a parent needs before opening.
   preview: string;
-  /// Shown on the scoreboard cap. Omitted only by the sign-in code email,
-  /// which is sent before we know which team the person is here for.
-  teamName?: string;
-  /// The grey line under the seam: why this message arrived. Templates say it
-  /// in their own words rather than sharing one sentence, because the reasons
-  /// genuinely differ — a roster, an invitation, something you asked for.
+  /// Shown on the scoreboard cap. `null` only for the sign-in code, which is
+  /// sent before we know which team the person is here for — every other
+  /// email has a team, and passing it is not optional.
+  teamName: string | null;
+  /// The grey line under the seam: why this message arrived. One sentence
+  /// per *reason*, shared where the reason is shared (`rosterFootnote` in
+  /// `copy.ts` covers the four roster-triggered emails) and written here
+  /// where it is not — an invitation, a code someone asked for.
   footnote?: ReactNode;
   children: ReactNode;
 };
@@ -113,13 +120,9 @@ const bandStyle: CSSProperties = {
 };
 
 const bandProductStyle: CSSProperties = {
-  fontFamily: EMAIL_FONT.mono,
-  fontSize: "11px",
-  fontWeight: 700,
+  ...captionStyle,
   letterSpacing: "2.5px",
-  textTransform: "uppercase",
   color: EMAIL_COLOR.onScoreboard,
-  margin: 0,
 };
 
 const bandTeamStyle: CSSProperties = {
@@ -149,11 +152,8 @@ const footnoteStyle: CSSProperties = {
 };
 
 const signatureStyle: CSSProperties = {
-  fontFamily: EMAIL_FONT.mono,
-  fontSize: "11px",
-  letterSpacing: "1.5px",
-  textTransform: "uppercase",
+  ...captionStyle,
+  fontWeight: 400,
   color: EMAIL_COLOR.quietInk,
-  margin: 0,
   padding: "0 4px",
 };

--- a/src/emails/EventAnnouncementEmail.tsx
+++ b/src/emails/EventAnnouncementEmail.tsx
@@ -1,10 +1,10 @@
+import { rosterFootnote, whenWhere } from "./copy";
 import {
   BananaButton,
   EmailHeading,
   EmailText,
   FactPanel,
   FactRow,
-  LinkFallback,
 } from "./EmailKit";
 import { EmailLayout } from "./EmailLayout";
 
@@ -44,9 +44,9 @@ export function EventAnnouncementEmail({
 }: EventAnnouncementEmailProps) {
   return (
     <EmailLayout
-      preview={`${dateTimeLabel}${location ? ` — ${location}` : ""}`}
+      preview={whenWhere(dateTimeLabel, location)}
       teamName={teamName}
-      footnote={`You're getting this because your player is on ${teamName}'s roster.`}
+      footnote={rosterFootnote(teamName)}
     >
       <EmailHeading
         eyebrow="New on the schedule"
@@ -65,7 +65,6 @@ export function EventAnnouncementEmail({
       <EmailText>Can your player make it? One tap either way.</EmailText>
 
       <BananaButton href={eventUrl}>Let your coach know</BananaButton>
-      <LinkFallback href={eventUrl} />
     </EmailLayout>
   );
 }

--- a/src/emails/EventAnnouncementEmail.tsx
+++ b/src/emails/EventAnnouncementEmail.tsx
@@ -1,27 +1,27 @@
 import {
-  Body,
-  Container,
-  Head,
-  Hr,
-  Html,
-  Link,
-  Preview,
-  Text,
-} from "@react-email/components";
+  BananaButton,
+  EmailHeading,
+  EmailText,
+  FactPanel,
+  FactRow,
+  LinkFallback,
+} from "./EmailKit";
+import { EmailLayout } from "./EmailLayout";
 
-/// Plain like InvitationEmail, TeamMessageEmail and EventReminderEmail — no
-/// images, no layout cleverness. This is read on a phone, one-handed, and the
-/// date and place have to survive being skimmed in two seconds.
+/// "A new game is on the schedule." Read on a phone, one-handed, so the date
+/// and place sit in a ticket stub (`FactPanel`) where they survive being
+/// skimmed in two seconds — the layout equivalent of what these lines were
+/// already trying to do as bare paragraphs.
 ///
 /// **Nothing about any other family.** No roster, no attendance, no contact
 /// details. Contact details are staff-facing everywhere else in the app
 /// (`/directory` and the roster entry page are both COACH+), and an email
 /// mailed to every household is the last place to relax that.
 ///
-/// There is deliberately no RSVP section, which is the whole reason this is not
-/// a variant of EventReminderEmail: the event was created moments ago, so
-/// nobody has answered and there is no state to report. The single call to
-/// action is the link.
+/// There is deliberately no RSVP *state* section, which is the whole reason
+/// this is not a variant of EventReminderEmail: the event was created moments
+/// ago, so nobody has answered and there is no state to report. The single call
+/// to action is the button, and it is this email's banana.
 
 export type EventAnnouncementEmailProps = {
   teamName: string;
@@ -43,31 +43,29 @@ export function EventAnnouncementEmail({
   eventUrl,
 }: EventAnnouncementEmailProps) {
   return (
-    <Html>
-      <Head />
-      <Preview>{`${dateTimeLabel}${location ? ` — ${location}` : ""}`}</Preview>
-      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
-        <Container>
-          <Text style={{ fontSize: "18px", fontWeight: "bold" }}>
-            New on the schedule: {headline}
-          </Text>
-          <Text>
-            {teamName} — {dateTimeLabel}
-          </Text>
+    <EmailLayout
+      preview={`${dateTimeLabel}${location ? ` — ${location}` : ""}`}
+      teamName={teamName}
+      footnote={`You're getting this because your player is on ${teamName}'s roster.`}
+    >
+      <EmailHeading
+        eyebrow="New on the schedule"
+        title={headline}
+        subtitle={teamName}
+      />
 
-          {location ? <Text>Where: {location}</Text> : null}
-          {notes ? (
-            <Text style={{ whiteSpace: "pre-wrap" }}>Notes: {notes}</Text>
-          ) : null}
+      <FactPanel>
+        <FactRow label="When" mono>
+          {dateTimeLabel}
+        </FactRow>
+        {location ? <FactRow label="Where">{location}</FactRow> : null}
+        {notes ? <FactRow label="Notes">{notes}</FactRow> : null}
+      </FactPanel>
 
-          <Hr />
+      <EmailText>Can your player make it? One tap either way.</EmailText>
 
-          <Text>
-            Let your coach know if your player can make it:{" "}
-            <Link href={eventUrl}>{eventUrl}</Link>
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+      <BananaButton href={eventUrl}>Let your coach know</BananaButton>
+      <LinkFallback href={eventUrl} />
+    </EmailLayout>
   );
 }

--- a/src/emails/EventReminderEmail.tsx
+++ b/src/emails/EventReminderEmail.tsx
@@ -1,15 +1,15 @@
-import type { CSSProperties } from "react";
-import { Section, Text } from "@react-email/components";
+import { Section } from "@react-email/components";
 
 import type { RsvpState } from "@/lib/rsvp";
-import { EMAIL_COLOR, EMAIL_FONT, EMAIL_RSVP_COLOR } from "./brand";
+import { EMAIL_RSVP_COLOR } from "./brand";
+import { rosterFootnote, whenWhere } from "./copy";
 import {
   BananaButton,
+  EdgePanel,
   EmailHeading,
   EmailText,
   FactPanel,
   FactRow,
-  LinkFallback,
   SectionLabel,
 } from "./EmailKit";
 import { EmailLayout } from "./EmailLayout";
@@ -57,9 +57,9 @@ export function EventReminderEmail({
 
   return (
     <EmailLayout
-      preview={`Today at ${timeLabel}${location ? ` — ${location}` : ""}`}
+      preview={whenWhere(`Today at ${timeLabel}`, location)}
       teamName={teamName}
-      footnote={`You're getting this because your player is on ${teamName}'s roster.`}
+      footnote={rosterFootnote(teamName)}
     >
       <EmailHeading
         eyebrow="Today"
@@ -79,15 +79,9 @@ export function EventReminderEmail({
       <SectionLabel>{kids.length === 1 ? "Your player" : "Your players"}</SectionLabel>
       <Section style={{ margin: "0 0 20px" }}>
         {kids.map((kid) => (
-          <Text
-            key={kid.playerId}
-            style={{
-              ...kidRowStyle,
-              borderLeft: `3px solid ${EMAIL_RSVP_COLOR[kid.rsvp]}`,
-            }}
-          >
+          <EdgePanel key={kid.playerId} edge={EMAIL_RSVP_COLOR[kid.rsvp]}>
             {rsvpReminderLabel(kid.name, kid.rsvp)}
-          </Text>
+          </EdgePanel>
         ))}
       </Section>
 
@@ -100,19 +94,7 @@ export function EventReminderEmail({
       <BananaButton href={eventUrl}>
         {needsAnswer ? "Answer now" : "Update your answer"}
       </BananaButton>
-      <LinkFallback href={eventUrl} />
     </EmailLayout>
   );
 }
 
-const kidRowStyle: CSSProperties = {
-  fontFamily: EMAIL_FONT.body,
-  fontSize: "16px",
-  lineHeight: "22px",
-  fontWeight: 600,
-  color: EMAIL_COLOR.ink,
-  backgroundColor: EMAIL_COLOR.page,
-  margin: "0 0 8px",
-  padding: "10px 14px",
-  borderRadius: "0 8px 8px 0",
-};

--- a/src/emails/EventReminderEmail.tsx
+++ b/src/emails/EventReminderEmail.tsx
@@ -1,25 +1,36 @@
-import {
-  Body,
-  Container,
-  Head,
-  Hr,
-  Html,
-  Link,
-  Preview,
-  Text,
-} from "@react-email/components";
+import type { CSSProperties } from "react";
+import { Section, Text } from "@react-email/components";
 
 import type { RsvpState } from "@/lib/rsvp";
+import { EMAIL_COLOR, EMAIL_FONT, EMAIL_RSVP_COLOR } from "./brand";
+import {
+  BananaButton,
+  EmailHeading,
+  EmailText,
+  FactPanel,
+  FactRow,
+  LinkFallback,
+  SectionLabel,
+} from "./EmailKit";
+import { EmailLayout } from "./EmailLayout";
 import { rsvpReminderLabel } from "./event-reminder-email";
 
-/// Plain like InvitationEmail and TeamMessageEmail — no images, no layout
-/// cleverness. This is read on a phone, one-handed, at breakfast: the time and
-/// place have to survive being skimmed in two seconds.
+/// The day-of reminder — read on a phone, one-handed, at breakfast. Time and
+/// place go in the ticket stub so they survive being skimmed in two seconds,
+/// and the eyebrow is the one in this directory set in seam red rather than
+/// field green: **TODAY** is the entire claim, and it is competing with every
+/// other email that morning.
 ///
 /// Only the recipient's own kids appear. Contact details and other families'
-/// attendance are staff-facing everywhere else in the app (`/directory` and
-/// the roster entry page are both COACH+), and a reminder mailed to every
-/// household is the last place to relax that.
+/// attendance are staff-facing everywhere else in the app (`/directory` and the
+/// roster entry page are both COACH+), and a reminder mailed to every household
+/// is the last place to relax that.
+///
+/// Each kid's row keeps `rsvpReminderLabel`'s sentence and adds a coloured edge
+/// in that state's colour (`EMAIL_RSVP_COLOR`, the same green / seam red /
+/// muted the app uses). Colour is the second carrier, never the only one — the
+/// sentence says it in words, which is what survives a colour-blind reader, a
+/// plain-text client, and a screenshot forwarded to the other parent.
 
 export type EventReminderEmailProps = {
   teamName: string;
@@ -45,37 +56,63 @@ export function EventReminderEmail({
   const needsAnswer = kids.some((kid) => kid.rsvp === "no-response");
 
   return (
-    <Html>
-      <Head />
-      <Preview>{`Today at ${timeLabel}${location ? ` — ${location}` : ""}`}</Preview>
-      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
-        <Container>
-          <Text style={{ fontSize: "18px", fontWeight: "bold" }}>
-            Today: {headline}
+    <EmailLayout
+      preview={`Today at ${timeLabel}${location ? ` — ${location}` : ""}`}
+      teamName={teamName}
+      footnote={`You're getting this because your player is on ${teamName}'s roster.`}
+    >
+      <EmailHeading
+        eyebrow="Today"
+        tone="stitch"
+        title={headline}
+        subtitle={teamName}
+      />
+
+      <FactPanel>
+        <FactRow label="Time" mono>
+          {timeLabel}
+        </FactRow>
+        {location ? <FactRow label="Where">{location}</FactRow> : null}
+        {notes ? <FactRow label="Notes">{notes}</FactRow> : null}
+      </FactPanel>
+
+      <SectionLabel>{kids.length === 1 ? "Your player" : "Your players"}</SectionLabel>
+      <Section style={{ margin: "0 0 20px" }}>
+        {kids.map((kid) => (
+          <Text
+            key={kid.playerId}
+            style={{
+              ...kidRowStyle,
+              borderLeft: `3px solid ${EMAIL_RSVP_COLOR[kid.rsvp]}`,
+            }}
+          >
+            {rsvpReminderLabel(kid.name, kid.rsvp)}
           </Text>
-          <Text>
-            {teamName} — {timeLabel}
-          </Text>
+        ))}
+      </Section>
 
-          {location ? <Text>Where: {location}</Text> : null}
-          {notes ? (
-            <Text style={{ whiteSpace: "pre-wrap" }}>Notes: {notes}</Text>
-          ) : null}
+      <EmailText>
+        {needsAnswer
+          ? "Let your coach know if they can make it."
+          : "Something changed? You can still update the answer."}
+      </EmailText>
 
-          <Hr />
-
-          {kids.map((kid) => (
-            <Text key={kid.playerId}>{rsvpReminderLabel(kid.name, kid.rsvp)}</Text>
-          ))}
-
-          <Text>
-            {needsAnswer
-              ? "Let your coach know if they can make it:"
-              : "Need to change an answer?"}{" "}
-            <Link href={eventUrl}>{eventUrl}</Link>
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+      <BananaButton href={eventUrl}>
+        {needsAnswer ? "Answer now" : "Update your answer"}
+      </BananaButton>
+      <LinkFallback href={eventUrl} />
+    </EmailLayout>
   );
 }
+
+const kidRowStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.body,
+  fontSize: "16px",
+  lineHeight: "22px",
+  fontWeight: 600,
+  color: EMAIL_COLOR.ink,
+  backgroundColor: EMAIL_COLOR.page,
+  margin: "0 0 8px",
+  padding: "10px 14px",
+  borderRadius: "0 8px 8px 0",
+};

--- a/src/emails/EventsAnnouncementEmail.tsx
+++ b/src/emails/EventsAnnouncementEmail.tsx
@@ -2,13 +2,13 @@ import type { CSSProperties } from "react";
 import { Section, Text } from "@react-email/components";
 
 import { EMAIL_COLOR, EMAIL_FONT } from "./brand";
+import { rosterFootnote, whenWhere } from "./copy";
 import {
   BananaButton,
   EmailHeading,
   EmailText,
   FactPanel,
   FactRow,
-  LinkFallback,
   SectionLabel,
   SlotDot,
 } from "./EmailKit";
@@ -53,9 +53,9 @@ export function EventsAnnouncementEmail({
 }: EventsAnnouncementEmailProps) {
   return (
     <EmailLayout
-      preview={`${dateTimeLabels[0] ?? ""}${location ? ` — ${location}` : ""}`}
+      preview={whenWhere(dateTimeLabels[0] ?? "", location)}
       teamName={teamName}
-      footnote={`You're getting this because your player is on ${teamName}'s roster.`}
+      footnote={rosterFootnote(teamName)}
     >
       <EmailHeading
         eyebrow="New on the schedule"
@@ -73,9 +73,10 @@ export function EventsAnnouncementEmail({
             key={label}
             style={{
               ...dateRowStyle,
-              ...(index === dateTimeLabels.length - 1
-                ? { borderBottom: "none" }
-                : {}),
+              borderBottom:
+                index < dateTimeLabels.length - 1
+                  ? `1px dashed ${EMAIL_COLOR.border}`
+                  : "none",
             }}
           >
             <SlotDot>{index + 1}</SlotDot>
@@ -91,13 +92,15 @@ export function EventsAnnouncementEmail({
         </FactPanel>
       ) : null}
 
+      {/* The schedule page lists the dates; each one is answered on its own
+          event page. Say that, rather than promising buttons that are not
+          on the page the button opens. */}
       <EmailText>
-        Answer them one at a time — the schedule has every date with its own
-        buttons.
+        Open the schedule and let your coach know which ones your player can
+        make.
       </EmailText>
 
       <BananaButton href={scheduleUrl}>See the schedule</BananaButton>
-      <LinkFallback href={scheduleUrl} />
     </EmailLayout>
   );
 }
@@ -107,7 +110,6 @@ const dateRowStyle: CSSProperties = {
   fontSize: "15px",
   lineHeight: "22px",
   color: EMAIL_COLOR.ink,
-  borderBottom: `1px dashed ${EMAIL_COLOR.border}`,
   margin: 0,
   padding: "9px 2px",
 };

--- a/src/emails/EventsAnnouncementEmail.tsx
+++ b/src/emails/EventsAnnouncementEmail.tsx
@@ -1,34 +1,35 @@
-import {
-  Body,
-  Container,
-  Head,
-  Hr,
-  Html,
-  Link,
-  Preview,
-  Text,
-} from "@react-email/components";
+import type { CSSProperties } from "react";
+import { Section, Text } from "@react-email/components";
 
-/// Plain like every other email in this directory — no images, no layout
-/// cleverness. This is read on a phone, one-handed, and the dates have to
-/// survive being skimmed in two seconds.
-///
-/// **Nothing about any other family.** No roster, no attendance, no contact
-/// details. Contact details are staff-facing everywhere else in the app
-/// (`/directory` and the roster entry page are both COACH+), and an email
-/// mailed to every household is the last place to relax that.
-///
+import { EMAIL_COLOR, EMAIL_FONT } from "./brand";
+import {
+  BananaButton,
+  EmailHeading,
+  EmailText,
+  FactPanel,
+  FactRow,
+  LinkFallback,
+  SectionLabel,
+  SlotDot,
+} from "./EmailKit";
+import { EmailLayout } from "./EmailLayout";
+
 /// The sibling of `EventAnnouncementEmail`, for the repeat-weekly batch (#70).
 /// Two differences, both consequences of announcing N events rather than one:
-/// the dates are a list, and the link is the schedule rather than an event
+/// the dates are a list, and the button is the schedule rather than an event
 /// page — a batch has no single event to answer, and the schedule is where the
-/// whole run is. Like the single version there is deliberately no RSVP section:
-/// the events were created moments ago, so nobody has answered and there is no
-/// state to report.
+/// whole run is. Like the single version there is deliberately no RSVP state:
+/// the events were created moments ago, so nobody has answered.
 ///
-/// Location and notes appear once rather than per date. Every occurrence in a
-/// batch carries the same ones by construction — one form filled in once — so
-/// repeating them down the list would be noise that hides the dates.
+/// **Nothing about any other family**, for the same reason as its sibling.
+///
+/// The dates are a scorecard: a numbered dot per line, monospaced dates, a
+/// dashed rule between them. That is the one piece of layout this email has
+/// that the others do not, and it is the thing it exists to deliver — a season
+/// as a list a parent can run a thumb down. Location and notes appear once
+/// beneath, rather than per date: every occurrence in a batch carries the same
+/// ones by construction (one form, filled in once), so repeating them would be
+/// noise hiding the dates.
 
 export type EventsAnnouncementEmailProps = {
   teamName: string;
@@ -51,40 +52,62 @@ export function EventsAnnouncementEmail({
   scheduleUrl,
 }: EventsAnnouncementEmailProps) {
   return (
-    <Html>
-      <Head />
-      <Preview>
-        {`${dateTimeLabels[0] ?? ""}${location ? ` — ${location}` : ""}`}
-      </Preview>
-      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
-        <Container>
-          <Text style={{ fontSize: "18px", fontWeight: "bold" }}>
-            New on the schedule: {headline}
+    <EmailLayout
+      preview={`${dateTimeLabels[0] ?? ""}${location ? ` — ${location}` : ""}`}
+      teamName={teamName}
+      footnote={`You're getting this because your player is on ${teamName}'s roster.`}
+    >
+      <EmailHeading
+        eyebrow="New on the schedule"
+        title={headline}
+        subtitle={teamName}
+      />
+
+      <SectionLabel>The run</SectionLabel>
+      <Section style={{ margin: "0 0 20px" }}>
+        {/* Rows of Text rather than a <ul>: mail clients disagree about list
+            indentation far more than they do about paragraphs, and the dot
+            carries the counting anyway. */}
+        {dateTimeLabels.map((label, index) => (
+          <Text
+            key={label}
+            style={{
+              ...dateRowStyle,
+              ...(index === dateTimeLabels.length - 1
+                ? { borderBottom: "none" }
+                : {}),
+            }}
+          >
+            <SlotDot>{index + 1}</SlotDot>
+            {label}
           </Text>
-          <Text>{teamName}</Text>
+        ))}
+      </Section>
 
-          {/* A list of Text rows rather than a <ul>: the other five emails in
-              this directory are Text-only, and mail clients disagree about
-              list indentation far more than they do about paragraphs. */}
-          {dateTimeLabels.map((label) => (
-            <Text key={label} style={{ margin: "4px 0" }}>
-              {label}
-            </Text>
-          ))}
+      {location || notes ? (
+        <FactPanel>
+          {location ? <FactRow label="Where">{location}</FactRow> : null}
+          {notes ? <FactRow label="Notes">{notes}</FactRow> : null}
+        </FactPanel>
+      ) : null}
 
-          {location ? <Text>Where: {location}</Text> : null}
-          {notes ? (
-            <Text style={{ whiteSpace: "pre-wrap" }}>Notes: {notes}</Text>
-          ) : null}
+      <EmailText>
+        Answer them one at a time — the schedule has every date with its own
+        buttons.
+      </EmailText>
 
-          <Hr />
-
-          <Text>
-            Let your coach know which ones your player can make:{" "}
-            <Link href={scheduleUrl}>{scheduleUrl}</Link>
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+      <BananaButton href={scheduleUrl}>See the schedule</BananaButton>
+      <LinkFallback href={scheduleUrl} />
+    </EmailLayout>
   );
 }
+
+const dateRowStyle: CSSProperties = {
+  fontFamily: EMAIL_FONT.mono,
+  fontSize: "15px",
+  lineHeight: "22px",
+  color: EMAIL_COLOR.ink,
+  borderBottom: `1px dashed ${EMAIL_COLOR.border}`,
+  margin: 0,
+  padding: "9px 2px",
+};

--- a/src/emails/InvitationEmail.tsx
+++ b/src/emails/InvitationEmail.tsx
@@ -1,10 +1,4 @@
-import {
-  BananaButton,
-  EmailHeading,
-  EmailText,
-  LinkFallback,
-  NoteBlock,
-} from "./EmailKit";
+import { BananaButton, EmailHeading, EmailText, NoteBlock } from "./EmailKit";
 import { EmailLayout } from "./EmailLayout";
 
 /// The coach's very first message to a parent who has never used the app, and
@@ -57,11 +51,11 @@ export function InvitationEmail({
       {message ? <NoteBlock>{message}</NoteBlock> : null}
 
       <BananaButton href={acceptUrl}>Accept invitation</BananaButton>
-      <LinkFallback href={acceptUrl} />
 
-      <EmailText quiet>
-        {`This invitation expires on ${formatExpiry(expiresAt)}.`}
-      </EmailText>
+      {/* Body weight, not footer grey: the expiry is the one time-sensitive
+          fact in the message, and a parent who reads it as legal boilerplate
+          lets the invitation lapse. */}
+      <EmailText>{`This invitation expires on ${formatExpiry(expiresAt)}.`}</EmailText>
     </EmailLayout>
   );
 }

--- a/src/emails/InvitationEmail.tsx
+++ b/src/emails/InvitationEmail.tsx
@@ -1,16 +1,22 @@
 import {
-  Body,
-  Button,
-  Container,
-  Head,
-  Html,
-  Preview,
-  Text,
-} from "@react-email/components";
+  BananaButton,
+  EmailHeading,
+  EmailText,
+  LinkFallback,
+  NoteBlock,
+} from "./EmailKit";
+import { EmailLayout } from "./EmailLayout";
 
-/// Plain and short on purpose — no images, a single button, and the URL
-/// repeated as visible text for mail clients that strip links. This is the
-/// coach's very first message to a parent who has never used the app.
+/// The coach's very first message to a parent who has never used the app, and
+/// therefore the one email that is doing brand work as well as errand work:
+/// whatever this looks like is what the parent expects the app to look like.
+///
+/// Still no images and still one action. The flare is in the stock and the
+/// type — see `brand.ts` — not in anything that has to load.
+///
+/// **This email spends its banana on Accept.** There is exactly one thing to do
+/// with an invitation, the whole message is scaffolding around it, and the URL
+/// stays repeated as plain text underneath for clients that strip links.
 
 export type InvitationEmailProps = {
   teamName: string;
@@ -37,34 +43,25 @@ export function InvitationEmail({
   message,
 }: InvitationEmailProps) {
   return (
-    <Html>
-      <Head />
-      <Preview>You&apos;re invited to join {teamName}</Preview>
-      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
-        <Container>
-          <Text>You&apos;ve been invited to join {teamName}.</Text>
-          {message ? (
-            <Text style={{ whiteSpace: "pre-wrap" }}>{message}</Text>
-          ) : null}
-          <Button
-            href={acceptUrl}
-            style={{
-              background: "#111827",
-              color: "#ffffff",
-              padding: "12px 20px",
-              borderRadius: "6px",
-              textDecoration: "none",
-            }}
-          >
-            Accept invitation
-          </Button>
-          <Text>
-            Or paste this link into your browser: <br />
-            {acceptUrl}
-          </Text>
-          <Text>This invitation expires on {formatExpiry(expiresAt)}.</Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailLayout
+      preview={`You're invited to join ${teamName}`}
+      teamName={teamName}
+      footnote={`Someone coaching ${teamName} sent this invitation to your email address.`}
+    >
+      <EmailHeading
+        eyebrow="You're invited"
+        title={`Join ${teamName}`}
+        subtitle="Schedule, RSVPs, and the batting order — in one place, on your phone."
+      />
+
+      {message ? <NoteBlock>{message}</NoteBlock> : null}
+
+      <BananaButton href={acceptUrl}>Accept invitation</BananaButton>
+      <LinkFallback href={acceptUrl} />
+
+      <EmailText quiet>
+        {`This invitation expires on ${formatExpiry(expiresAt)}.`}
+      </EmailText>
+    </EmailLayout>
   );
 }

--- a/src/emails/SignInCodeEmail.tsx
+++ b/src/emails/SignInCodeEmail.tsx
@@ -29,12 +29,13 @@ export function SignInCodeEmail({
   return (
     <EmailLayout
       preview={`Your sign-in code is ${formattedCode}`}
+      teamName={null}
       footnote="Someone asked to sign in with this email address."
     >
       <EmailHeading
         eyebrow="Sign in"
         title="Here's your code"
-        subtitle="Type it into the sign-in screen you already have open."
+        subtitle="Type it into the sign-in screen."
       />
 
       <ScoreboardPanel label="Sign-in code">{formattedCode}</ScoreboardPanel>

--- a/src/emails/SignInCodeEmail.tsx
+++ b/src/emails/SignInCodeEmail.tsx
@@ -1,17 +1,20 @@
-import {
-  Body,
-  Container,
-  Head,
-  Html,
-  Preview,
-  Text,
-} from "@react-email/components";
+import { EmailHeading, EmailText, ScoreboardPanel } from "./EmailKit";
+import { EmailLayout } from "./EmailLayout";
 
 /// The sign-in code email — what `/signin` sends instead of a magic link
 /// (#60). Deliberately nothing to tap: a link would be redeemed by whichever
-/// browser the OS hands it to, which on a phone is routinely not the
-/// container the person requested it from. The code is read here and typed
-/// there, so it is large, monospaced, and the first thing in the body.
+/// browser the OS hands it to, which on a phone is routinely not the container
+/// the person requested it from.
+///
+/// **The code is set as a scoreboard readout**, which is the one place this
+/// directory's flare is doing a job rather than wearing a costume: the code is
+/// read off one screen and typed into another, so the panel is dark in a cream
+/// email to pull the eye straight to it, and the figures are floodlight yellow
+/// monospace at 34px because character shapes are the entire task. That panel
+/// is this email's banana; there is no button to spend it on, by design.
+///
+/// No team name on the cap — sign-in happens before we know which team the
+/// person came for, and the layout leaves it off rather than guessing.
 
 export type SignInCodeEmailProps = {
   /// Display form, e.g. "K3M7-QP2X" — the entry form strips the dash.
@@ -24,32 +27,30 @@ export function SignInCodeEmail({
   expiresMinutes,
 }: SignInCodeEmailProps) {
   return (
-    <Html>
-      <Head />
-      <Preview>Your sign-in code is {formattedCode}</Preview>
-      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
-        <Container>
-          <Text>Type this code into the sign-in screen:</Text>
-          <Text
-            style={{
-              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-              fontSize: "32px",
-              fontWeight: 700,
-              letterSpacing: "4px",
-            }}
-          >
-            {formattedCode}
-          </Text>
-          <Text>
-            It works once and expires in {expiresMinutes} minutes. Capitals
-            don&apos;t matter, and neither does the dash.
-          </Text>
-          <Text>
-            If you didn&apos;t ask for this code, you can ignore this email —
-            nothing happens without it.
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailLayout
+      preview={`Your sign-in code is ${formattedCode}`}
+      footnote="Someone asked to sign in with this email address."
+    >
+      <EmailHeading
+        eyebrow="Sign in"
+        title="Here's your code"
+        subtitle="Type it into the sign-in screen you already have open."
+      />
+
+      <ScoreboardPanel label="Sign-in code">{formattedCode}</ScoreboardPanel>
+
+      {/* One interpolated string rather than JSX text around `{expiresMinutes}`:
+          React splits that into separate text nodes with comment markers
+          between them, which is noise in an email and, worse, means the
+          sentence a person reads is not a contiguous string in the markup. */}
+      <EmailText>
+        {`It works once and expires in ${expiresMinutes} minutes. Capitals don't matter, and neither does the dash.`}
+      </EmailText>
+
+      <EmailText quiet>
+        If you didn&apos;t ask for this code, you can ignore this email —
+        nothing happens without it.
+      </EmailText>
+    </EmailLayout>
   );
 }

--- a/src/emails/TeamMessageEmail.tsx
+++ b/src/emails/TeamMessageEmail.tsx
@@ -38,7 +38,7 @@ export function TeamMessageEmail({
         subtitle={teamName}
       />
 
-      <EmailText preserveBreaks>{body}</EmailText>
+      <EmailText>{body}</EmailText>
 
       {/* No section rule above this link: the shell already draws the seam
           between the card and the footer, and on a two-line message the two

--- a/src/emails/TeamMessageEmail.tsx
+++ b/src/emails/TeamMessageEmail.tsx
@@ -1,18 +1,15 @@
-import {
-  Body,
-  Container,
-  Head,
-  Hr,
-  Html,
-  Link,
-  Preview,
-  Text,
-} from "@react-email/components";
+import { EmailHeading, EmailText, QuietLink } from "./EmailKit";
+import { EmailLayout } from "./EmailLayout";
 
-/// Plain on purpose, like InvitationEmail — no images, the message itself is
-/// the point. The sender's name leads because the From address is the app's
-/// domain, not the human's; their address rides in Reply-To instead, so
-/// hitting reply just works.
+/// A person's own words, forwarded by the app. The sender's name leads because
+/// the From address is the app's domain, not the human's; their address rides
+/// in Reply-To instead, so hitting reply just works.
+///
+/// **This email has no banana**, and that is the rule rather than an omission.
+/// design-plan.md §2 rations the yellow to one element per screen and §7 gives
+/// the calm surfaces none at all — a shouting button over somebody's message
+/// would be the app talking over the coach. The link at the bottom is a quiet
+/// green one.
 
 export type TeamMessageEmailProps = {
   teamName: string;
@@ -30,21 +27,23 @@ export function TeamMessageEmail({
   teamUrl,
 }: TeamMessageEmailProps) {
   return (
-    <Html>
-      <Head />
-      <Preview>{body.slice(0, 120)}</Preview>
-      <Body style={{ fontFamily: "sans-serif", padding: "24px" }}>
-        <Container>
-          <Text>
-            {senderName} — {teamName}
-          </Text>
-          <Text style={{ whiteSpace: "pre-wrap" }}>{body}</Text>
-          <Hr />
-          <Text>
-            Schedule, lineup, and RSVP: <Link href={teamUrl}>{teamUrl}</Link>
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailLayout
+      preview={body.slice(0, 120)}
+      teamName={teamName}
+      footnote={`Reply to this email to answer ${senderName} directly.`}
+    >
+      <EmailHeading
+        eyebrow="Team message"
+        title={senderName}
+        subtitle={teamName}
+      />
+
+      <EmailText preserveBreaks>{body}</EmailText>
+
+      {/* No section rule above this link: the shell already draws the seam
+          between the card and the footer, and on a two-line message the two
+          would land an inch apart. */}
+      <QuietLink href={teamUrl}>Schedule, lineup, and RSVP</QuietLink>
+    </EmailLayout>
   );
 }

--- a/src/emails/brand.test.ts
+++ b/src/emails/brand.test.ts
@@ -1,9 +1,7 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
 import { describe, expect, it } from "vitest";
 
-import { hslToHex } from "@/lib/hsl-to-hex";
+import { RSVP_STYLE } from "@/components/rsvp-style";
+import { lightThemeHex } from "@/lib/light-theme";
 
 import { EMAIL_COLOR, EMAIL_RSVP_COLOR } from "./brand";
 
@@ -16,8 +14,8 @@ import { EMAIL_COLOR, EMAIL_RSVP_COLOR } from "./brand";
  * than the one the link opens.
  *
  * So this redoes the conversion and compares, exactly as `app/manifest.test.ts`
- * does for the two colours a web app manifest freezes. Both use
- * `@/lib/hsl-to-hex` rather than each rolling their own.
+ * does for the two colours a web app manifest freezes. Both go through
+ * `@/lib/light-theme`, which owns the one parser of the stylesheet.
  *
  * The contrast block is the other half. design-plan.md §10 asks for AA on the
  * page, and an email is the one surface read in a car park with the brightness
@@ -25,23 +23,6 @@ import { EMAIL_COLOR, EMAIL_RSVP_COLOR } from "./brand";
  * button pop" edit lands white text on Banana Yellow, which is the one pairing
  * the plan forbids outright.
  */
-
-const repoRoot = process.cwd();
-const globalsCss = readFileSync(join(repoRoot, "src/app/globals.css"), "utf8");
-
-/// The light-theme value of one token. Reads the first match deliberately:
-/// `:root` precedes the dark override in the file, so this is the light value
-/// even though every token name appears twice.
-function lightToken(name: string): string {
-  const match = new RegExp(`--${name}:\\s*([^;]+);`).exec(globalsCss);
-  if (!match) {
-    throw new Error(
-      `--${name} is not in globals.css — this parser, not the stylesheet, ` +
-        "is probably what needs updating.",
-    );
-  }
-  return match[1].trim();
-}
 
 function relativeLuminance(hex: string): number {
   const channels = [1, 3, 5].map((offset) => {
@@ -67,16 +48,16 @@ function contrast(foreground: string, background: string): number {
 /// Written out rather than derived, because the mapping is the claim: the
 /// names differ on purpose (`stub` is `--secondary` used for one thing) and a
 /// clever derivation would only be able to check the names that already match.
+/// The `Record<keyof typeof EMAIL_COLOR, …>` type is what keeps this complete:
+/// a colour added to the palette without a row here is a type error.
 const COPIED_FROM: Record<keyof typeof EMAIL_COLOR, string> = {
   page: "background",
   card: "card",
   ink: "foreground",
   quietInk: "muted-foreground",
   border: "border",
-  muted: "muted",
   stub: "secondary",
   green: "primary",
-  onGreen: "primary-foreground",
   banana: "banana",
   stitch: "destructive",
   scoreboard: "scoreboard",
@@ -85,21 +66,25 @@ const COPIED_FROM: Record<keyof typeof EMAIL_COLOR, string> = {
 };
 
 describe("the email palette", () => {
-  it("covers every colour the emails are allowed to use", () => {
-    // A guard against the check below going vacuous: a new colour added to
-    // EMAIL_COLOR without a row in COPIED_FROM would otherwise be untested,
-    // which is precisely how an unverified hex gets in.
-    expect(Object.keys(COPIED_FROM).sort()).toEqual(
-      Object.keys(EMAIL_COLOR).sort(),
-    );
-  });
-
   it.each(Object.entries(COPIED_FROM))(
     "EMAIL_COLOR.%s is the light --%s from globals.css",
     (name, token) => {
       expect(EMAIL_COLOR[name as keyof typeof EMAIL_COLOR]).toBe(
-        hslToHex(lightToken(token)),
+        lightThemeHex(token),
       );
+    },
+  );
+
+  it.each(Object.keys(EMAIL_RSVP_COLOR) as (keyof typeof EMAIL_RSVP_COLOR)[])(
+    "colours %s the way the app's RSVP_STYLE does",
+    (state) => {
+      // `rsvp-style.ts` carries the on-screen vocabulary as Tailwind classes
+      // (`text-primary`, `text-destructive`, `text-muted-foreground`); the
+      // token name is the part after `text-`. Its docstring exists because two
+      // pages once drifted apart on exactly this, so the inbox does not get to
+      // be a third opinion.
+      const token = RSVP_STYLE[state].tagClassName.replace(/^text-/, "");
+      expect(EMAIL_RSVP_COLOR[state]).toBe(lightThemeHex(token));
     },
   );
 });
@@ -108,24 +93,21 @@ describe("email contrast", () => {
   it.each([
     ["ink on the page", EMAIL_COLOR.ink, EMAIL_COLOR.page],
     ["ink on card stock", EMAIL_COLOR.ink, EMAIL_COLOR.card],
-    // The pairing design-plan.md §3 ends on: "Banana Yellow never carries
-    // white text, ever." Navy on banana is the button, and this is the number
-    // that makes it allowed.
-    ["ink on the banana button", EMAIL_COLOR.ink, EMAIL_COLOR.banana],
-    ["cream on field green", EMAIL_COLOR.onGreen, EMAIL_COLOR.green],
+    // The button: banana lettering on a navy ground.
+    ["banana on ink", EMAIL_COLOR.banana, EMAIL_COLOR.ink],
     ["green links on card stock", EMAIL_COLOR.green, EMAIL_COLOR.card],
     ["seam red on card stock", EMAIL_COLOR.stitch, EMAIL_COLOR.card],
     ["the footer on the page", EMAIL_COLOR.quietInk, EMAIL_COLOR.page],
     ["chalk on the scoreboard", EMAIL_COLOR.onScoreboard, EMAIL_COLOR.scoreboard],
     ["the sign-in code on the scoreboard", EMAIL_COLOR.floodlight, EMAIL_COLOR.scoreboard],
-    ["the header wordmark", EMAIL_COLOR.onScoreboard, EMAIL_COLOR.scoreboard],
   ])("clears AA for %s", (_label, foreground, background) => {
     expect(contrast(foreground, background)).toBeGreaterThanOrEqual(4.5);
   });
 
   it("keeps white off the banana", () => {
-    // Stated as its own failure rather than left implicit in the row above:
-    // this is the edit the plan expects someone to try.
+    // design-plan.md §3 ends on "Banana Yellow never carries white text,
+    // ever." Stated as its own failure because this is the edit the plan
+    // expects someone to try; `templates.test.tsx` checks the rendered side.
     expect(contrast("#FFFFFF", EMAIL_COLOR.banana)).toBeLessThan(4.5);
   });
 

--- a/src/emails/brand.test.ts
+++ b/src/emails/brand.test.ts
@@ -1,0 +1,138 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { hslToHex } from "@/lib/hsl-to-hex";
+
+import { EMAIL_COLOR, EMAIL_RSVP_COLOR } from "./brand";
+
+/**
+ * `EMAIL_COLOR` is a copy of the light theme, and a copy is a thing that rots.
+ * A mail client gives an email no cascade, no `hsl(var(--x))`, and no reliable
+ * `prefers-color-scheme`, so the palette has to be frozen hex — but nothing at
+ * runtime would ever notice it drifting from `globals.css`, because a stale
+ * colour is not an error. It is just an email that looks like a different app
+ * than the one the link opens.
+ *
+ * So this redoes the conversion and compares, exactly as `app/manifest.test.ts`
+ * does for the two colours a web app manifest freezes. Both use
+ * `@/lib/hsl-to-hex` rather than each rolling their own.
+ *
+ * The contrast block is the other half. design-plan.md §10 asks for AA on the
+ * page, and an email is the one surface read in a car park with the brightness
+ * turned down — but it is also the surface where a well-meaning "make the
+ * button pop" edit lands white text on Banana Yellow, which is the one pairing
+ * the plan forbids outright.
+ */
+
+const repoRoot = process.cwd();
+const globalsCss = readFileSync(join(repoRoot, "src/app/globals.css"), "utf8");
+
+/// The light-theme value of one token. Reads the first match deliberately:
+/// `:root` precedes the dark override in the file, so this is the light value
+/// even though every token name appears twice.
+function lightToken(name: string): string {
+  const match = new RegExp(`--${name}:\\s*([^;]+);`).exec(globalsCss);
+  if (!match) {
+    throw new Error(
+      `--${name} is not in globals.css — this parser, not the stylesheet, ` +
+        "is probably what needs updating.",
+    );
+  }
+  return match[1].trim();
+}
+
+function relativeLuminance(hex: string): number {
+  const channels = [1, 3, 5].map((offset) => {
+    const value = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
+    return value <= 0.03928
+      ? value / 12.92
+      : ((value + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(foreground: string, background: string): number {
+  const [lighter, darker] = [
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  ].sort((a, b) => b - a);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/// Every entry in `EMAIL_COLOR`, paired with the token it was copied from.
+/// Written out rather than derived, because the mapping is the claim: the
+/// names differ on purpose (`stub` is `--secondary` used for one thing) and a
+/// clever derivation would only be able to check the names that already match.
+const COPIED_FROM: Record<keyof typeof EMAIL_COLOR, string> = {
+  page: "background",
+  card: "card",
+  ink: "foreground",
+  quietInk: "muted-foreground",
+  border: "border",
+  muted: "muted",
+  stub: "secondary",
+  green: "primary",
+  onGreen: "primary-foreground",
+  banana: "banana",
+  stitch: "destructive",
+  scoreboard: "scoreboard",
+  onScoreboard: "scoreboard-foreground",
+  floodlight: "scoreboard-accent",
+};
+
+describe("the email palette", () => {
+  it("covers every colour the emails are allowed to use", () => {
+    // A guard against the check below going vacuous: a new colour added to
+    // EMAIL_COLOR without a row in COPIED_FROM would otherwise be untested,
+    // which is precisely how an unverified hex gets in.
+    expect(Object.keys(COPIED_FROM).sort()).toEqual(
+      Object.keys(EMAIL_COLOR).sort(),
+    );
+  });
+
+  it.each(Object.entries(COPIED_FROM))(
+    "EMAIL_COLOR.%s is the light --%s from globals.css",
+    (name, token) => {
+      expect(EMAIL_COLOR[name as keyof typeof EMAIL_COLOR]).toBe(
+        hslToHex(lightToken(token)),
+      );
+    },
+  );
+});
+
+describe("email contrast", () => {
+  it.each([
+    ["ink on the page", EMAIL_COLOR.ink, EMAIL_COLOR.page],
+    ["ink on card stock", EMAIL_COLOR.ink, EMAIL_COLOR.card],
+    // The pairing design-plan.md §3 ends on: "Banana Yellow never carries
+    // white text, ever." Navy on banana is the button, and this is the number
+    // that makes it allowed.
+    ["ink on the banana button", EMAIL_COLOR.ink, EMAIL_COLOR.banana],
+    ["cream on field green", EMAIL_COLOR.onGreen, EMAIL_COLOR.green],
+    ["green links on card stock", EMAIL_COLOR.green, EMAIL_COLOR.card],
+    ["seam red on card stock", EMAIL_COLOR.stitch, EMAIL_COLOR.card],
+    ["the footer on the page", EMAIL_COLOR.quietInk, EMAIL_COLOR.page],
+    ["chalk on the scoreboard", EMAIL_COLOR.onScoreboard, EMAIL_COLOR.scoreboard],
+    ["the sign-in code on the scoreboard", EMAIL_COLOR.floodlight, EMAIL_COLOR.scoreboard],
+    ["the header wordmark", EMAIL_COLOR.onScoreboard, EMAIL_COLOR.scoreboard],
+  ])("clears AA for %s", (_label, foreground, background) => {
+    expect(contrast(foreground, background)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("keeps white off the banana", () => {
+    // Stated as its own failure rather than left implicit in the row above:
+    // this is the edit the plan expects someone to try.
+    expect(contrast("#FFFFFF", EMAIL_COLOR.banana)).toBeLessThan(4.5);
+  });
+
+  it.each(Object.entries(EMAIL_RSVP_COLOR))(
+    "reads %s on card stock",
+    (_state, color) => {
+      expect(contrast(color, EMAIL_COLOR.card)).toBeGreaterThanOrEqual(4.5);
+    },
+  );
+});

--- a/src/emails/brand.ts
+++ b/src/emails/brand.ts
@@ -32,9 +32,18 @@ import type { RsvpState } from "@/lib/rsvp";
 ///     package. `EMAIL_FONT.display` is a slab *stack* instead — Rockwell and
 ///     friends where they exist, Georgia everywhere else — so the display
 ///     voice degrades to a serif rather than to Arial.
-///   - **No dark variant.** See above; the layout also asks clients not to
-///     auto-invert (`color-scheme: light`), because a forced inversion of a
-///     cream-and-navy card is muddier than the light original.
+///   - **No dark variant, and no pretence that one can be asked for.** The
+///     shell declares `color-scheme: light`, which Apple Mail honours and the
+///     Gmail and Outlook apps ignore: those two recolour on their own,
+///     darkening light grounds and lifting dark text, and no stylesheet
+///     reaches Gmail at all. So the palette is designed to *survive* that pass
+///     rather than to prevent it. Dark grounds stay dark and saturated
+///     colours are left alone, which is why the call to action is navy ground
+///     with banana lettering (see `EmailKit`'s `BananaButton`) and not the
+///     other way round — a banana ground with navy text is exactly the pairing
+///     Gmail's pass turns into light text on yellow, the one combination
+///     design-plan.md §3 forbids outright. What a dark-mode phone gets is a
+///     night-game version of the same card, not an inversion of the CTA.
 export const EMAIL_COLOR = {
   /// `--background` — the cream page stock the whole message sits on.
   page: "#FAF4E5",
@@ -47,16 +56,12 @@ export const EMAIL_COLOR = {
   quietInk: "#6D6155",
   /// `--border` — warm sand. Borders that stop disappearing.
   border: "#DBCFBD",
-  /// `--muted` — quiet fills, a step down from the card.
-  muted: "#E7DFD0",
   /// `--secondary` — the clay tint used for the ticket stub's stock.
   stub: "#EBDED1",
   /// `--primary` — Field Green. Links, rules, and the "attending" state.
   green: "#2F6A3A",
-  /// `--primary-foreground` — cream, for text on green.
-  onGreen: "#FCF8EE",
-  /// `--banana` — the one-per-email wow. Never carries white text; see
-  /// `EMAIL_COLOR.ink` (9.2:1 on banana) and the test that pins it.
+  /// `--banana` — the one-per-email wow, spent as lettering and keyline on a
+  /// navy ground (9.2:1). Never carries white text; see the test that pins it.
   banana: "#FFC72E",
   /// `--destructive` — Stitch Red. The seam divider and the "not going" state.
   stitch: "#C6102E",

--- a/src/emails/brand.ts
+++ b/src/emails/brand.ts
@@ -1,0 +1,109 @@
+import type { RsvpState } from "@/lib/rsvp";
+
+/// The email half of "Pastoral Banana Ball" (`docs/design/design-plan.md`).
+///
+/// Every screen in the app is cream paper, field green, midnight navy and one
+/// rationed Banana Yellow. The emails were plain white sans-serif with a
+/// near-black button, which is a different product arriving in the family's
+/// inbox — the one surface a parent sees *before* they ever open the app. This
+/// module is the shared vocabulary that fixes that, and `EmailLayout` /
+/// `EmailKit` spend it.
+///
+/// **Everything here is frozen hex from the LIGHT theme**, the same trade
+/// `app/manifest.ts` makes and for a stricter version of the same reason: a
+/// mail client is not a browser. There is no cascade to read `hsl(var(--x))`
+/// from, `@media (prefers-color-scheme: dark)` is dropped by most clients that
+/// matter, and Tailwind class names never arrive at all — so an email is styled
+/// with inline hex or it is styled by Gmail. `brand.test.ts` redoes the
+/// HSL-to-hex conversion out of `globals.css` and fails when a token moves,
+/// because a copied palette that nothing checks is a palette that rots.
+///
+/// Three deliberate omissions, each of which looks like something missing:
+///
+///   - **No images.** Not the crest, not the field art, not a spacer. Images
+///     are off by default in most inboxes, so a header that carries the brand
+///     in a PNG is a header that is blank for half the roster — and every
+///     remote fetch reports back when a family opened their mail. The identity
+///     is carried by type, colour and rules, all of which render with images
+///     blocked.
+///   - **No web font.** `--font-display` is Alfa Slab One, loaded by
+///     `next/font` for the app; an email would have to pull it from a third
+///     party at open time, which is the same beacon problem in a smaller
+///     package. `EMAIL_FONT.display` is a slab *stack* instead — Rockwell and
+///     friends where they exist, Georgia everywhere else — so the display
+///     voice degrades to a serif rather than to Arial.
+///   - **No dark variant.** See above; the layout also asks clients not to
+///     auto-invert (`color-scheme: light`), because a forced inversion of a
+///     cream-and-navy card is muddier than the light original.
+export const EMAIL_COLOR = {
+  /// `--background` — the cream page stock the whole message sits on.
+  page: "#FAF4E5",
+  /// `--card` — warm white, a shade lighter than the page, which is where the
+  /// depth comes from without a single shadow.
+  card: "#FDFBF7",
+  /// `--foreground` — Midnight Navy. 13.9:1 on card stock.
+  ink: "#1E2948",
+  /// `--muted-foreground` — secondary lines and the footer. 5.8:1 on card.
+  quietInk: "#6D6155",
+  /// `--border` — warm sand. Borders that stop disappearing.
+  border: "#DBCFBD",
+  /// `--muted` — quiet fills, a step down from the card.
+  muted: "#E7DFD0",
+  /// `--secondary` — the clay tint used for the ticket stub's stock.
+  stub: "#EBDED1",
+  /// `--primary` — Field Green. Links, rules, and the "attending" state.
+  green: "#2F6A3A",
+  /// `--primary-foreground` — cream, for text on green.
+  onGreen: "#FCF8EE",
+  /// `--banana` — the one-per-email wow. Never carries white text; see
+  /// `EMAIL_COLOR.ink` (9.2:1 on banana) and the test that pins it.
+  banana: "#FFC72E",
+  /// `--destructive` — Stitch Red. The seam divider and the "not going" state.
+  stitch: "#C6102E",
+  /// `--scoreboard` — charcoal in both themes, because a scoreboard is dark
+  /// and light mode only means it is daytime around it.
+  scoreboard: "#14181F",
+  /// `--scoreboard-foreground` — chalk readout text.
+  onScoreboard: "#EBE6D5",
+  /// `--scoreboard-accent` — the lit figures. Floodlight yellow, 12.4:1 on the
+  /// panel: this is the banana family after dark, and it is what the sign-in
+  /// code is set in.
+  floodlight: "#FFD24D",
+} as const;
+
+/// Font stacks, not families. Nothing is loaded, so each of these has to look
+/// deliberate on a phone that has none of the first choices.
+export const EMAIL_FONT = {
+  /// Headlines and hero numbers only, at 20px+ — design-plan.md §4's rule,
+  /// which holds here for the same reason it holds in the app: slab body text
+  /// is a ransom note.
+  display:
+    'Rockwell, "Rockwell Nova", "Roboto Slab", "DejaVu Serif", Georgia, "Times New Roman", serif',
+  /// Geist is not installable in mail, so body text is the recipient's own
+  /// system sans — the face their inbox already reads in.
+  body: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  /// Dates, times, jersey numbers and the sign-in code. Tabular by habit and
+  /// unmistakably a readout.
+  mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+} as const;
+
+/// The three RSVP states in email, keyed to the same colours
+/// `src/components/rsvp-style.ts` gives them on screen — green for going, seam
+/// red for not going, muted for the answer that has not arrived.
+///
+/// Colour is never the only carrier here either: every place this is spent
+/// prints the family's own sentence beside it (`rsvpReminderLabel`), so a
+/// colour-blind parent, a plain-text client and a forwarded screenshot all
+/// still say who is coming. This is a small map rather than an import of
+/// `RSVP_STYLE` on purpose — that module is Tailwind class names, which mean
+/// nothing in an inbox.
+export const EMAIL_RSVP_COLOR: Record<RsvpState, string> = {
+  attending: EMAIL_COLOR.green,
+  declined: EMAIL_COLOR.stitch,
+  "no-response": EMAIL_COLOR.quietInk,
+};
+
+/// The card's outer width. 600px is the width every mail client has agreed on
+/// for two decades; `Container`'s own default (37.5em) is the same number in
+/// ems, which a client with a resized base font gets wrong.
+export const EMAIL_WIDTH = "600px";

--- a/src/emails/copy.test.ts
+++ b/src/emails/copy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { rosterFootnote, whenWhere } from "./copy";
+
+describe("rosterFootnote", () => {
+  it("names the team", () => {
+    expect(rosterFootnote("Hawks")).toBe(
+      "You're getting this because your player is on Hawks's roster.",
+    );
+  });
+});
+
+describe("whenWhere", () => {
+  it("joins the time and the place with an em dash", () => {
+    expect(whenWhere("Today at 5:45 PM", "Field 5")).toBe(
+      "Today at 5:45 PM — Field 5",
+    );
+  });
+
+  it("is just the time when there is no place", () => {
+    expect(whenWhere("Today at 5:45 PM", null)).toBe("Today at 5:45 PM");
+  });
+});

--- a/src/emails/copy.ts
+++ b/src/emails/copy.ts
@@ -1,0 +1,18 @@
+/// Sentences more than one template says, written once. Pure, like the
+/// builders beside it, so a wording change is one edit and one test.
+
+/// The footer line for every email that goes out because a player is on a
+/// team's roster. Four templates say this — the added-to-team notice, both
+/// announcements and the day-of reminder — and they said it in two different
+/// ways before this existed.
+export function rosterFootnote(teamName: string): string {
+  return `You're getting this because your player is on ${teamName}'s roster.`;
+}
+
+/// The inbox preview line for anything with a when and a where: the date (or
+/// "Today at 5:45 PM"), then the place if there is one. The em dash and the
+/// nothing-when-no-location rule are the same claim in three templates, so
+/// they are one function.
+export function whenWhere(when: string, location: string | null): string {
+  return location ? `${when} — ${location}` : when;
+}

--- a/src/emails/templates.test.tsx
+++ b/src/emails/templates.test.tsx
@@ -1,0 +1,269 @@
+import type { ReactElement } from "react";
+import { render } from "@react-email/components";
+import { describe, expect, it } from "vitest";
+
+import { EMAIL_COLOR } from "./brand";
+import { AddedToTeamEmail } from "./AddedToTeamEmail";
+import { AnnouncementReceiptEmail } from "./AnnouncementReceiptEmail";
+import { EventAnnouncementEmail } from "./EventAnnouncementEmail";
+import { EventReminderEmail } from "./EventReminderEmail";
+import { EventsAnnouncementEmail } from "./EventsAnnouncementEmail";
+import { InvitationEmail } from "./InvitationEmail";
+import { SignInCodeEmail } from "./SignInCodeEmail";
+import { TeamMessageEmail } from "./TeamMessageEmail";
+
+/**
+ * Every template, actually rendered.
+ *
+ * Nothing else in the suite renders these: the builders next door are pure and
+ * well covered, and the markup they feed was previously simple enough to read.
+ * It is not any more — the eight templates now share a shell, a palette and a
+ * texture kit — and the failure mode of shared email markup is silent. A
+ * template that stops rendering, loses its URL, or quietly spends a second
+ * banana still returns a string, still sends, and is only ever seen by the
+ * families it was sent to.
+ *
+ * So this checks the three things that would otherwise be found in an inbox:
+ *
+ * 1. **Every template renders and still carries its facts** — the team name,
+ *    the date, the code, the link.
+ * 2. **The banana budget** (design-plan.md §2). At most one Banana Yellow
+ *    surface per email, and the calm emails have none.
+ * 3. **The link survives a client that strips links.** Every template with a
+ *    button repeats its URL as plain text.
+ */
+
+const TEAM = "Cornelius 7/8 Baseball";
+
+/// The eight templates with realistic props, including the awkward ones: a
+/// team name with a slash, an event with no location, and a family with two
+/// kids in different RSVP states.
+const TEMPLATES: {
+  name: string;
+  element: ReactElement;
+  /// Whether design-plan.md §2's one banana is spent in this email. The calm
+  /// ones (`false`) are a claim, not an oversight — see each template's own
+  /// comment.
+  banana: boolean;
+  /// Text that has to survive, whatever the styling does.
+  contains: string[];
+}[] = [
+  {
+    name: "InvitationEmail",
+    element: (
+      <InvitationEmail
+        teamName={TEAM}
+        acceptUrl="https://baseball.example.com/invite/tok123"
+        expiresAt={new Date("2026-09-20T12:00:00Z")}
+        message={"Practice moves indoors if it rains.\nSee you Saturday."}
+      />
+    ),
+    banana: true,
+    contains: [
+      TEAM,
+      "https://baseball.example.com/invite/tok123",
+      "September 20, 2026",
+      "See you Saturday.",
+    ],
+  },
+  {
+    name: "AddedToTeamEmail",
+    element: (
+      <AddedToTeamEmail
+        teamName={TEAM}
+        teamUrl="https://baseball.example.com/t/team-1"
+      />
+    ),
+    banana: true,
+    contains: [TEAM, "https://baseball.example.com/t/team-1"],
+  },
+  {
+    name: "SignInCodeEmail",
+    element: <SignInCodeEmail formattedCode="K3M7-QP2X" expiresMinutes={10} />,
+    // The code panel is a scoreboard, and floodlight yellow on charcoal is the
+    // banana family after dark. There is no button to spend a yellow surface
+    // on, which is the whole design of this email.
+    banana: false,
+    contains: ["K3M7-QP2X", "10 minutes"],
+  },
+  {
+    name: "EventAnnouncementEmail",
+    element: (
+      <EventAnnouncementEmail
+        teamName={TEAM}
+        headline="Game vs Robert"
+        dateTimeLabel="Wed, Sep 16, 2026 at 5:45 PM"
+        location="Lakeview Playground - Field 5"
+        notes={null}
+        eventUrl="https://baseball.example.com/t/team-1/schedule/ev-1"
+      />
+    ),
+    banana: true,
+    contains: [
+      TEAM,
+      "Game vs Robert",
+      "Wed, Sep 16, 2026 at 5:45 PM",
+      "Lakeview Playground - Field 5",
+      "https://baseball.example.com/t/team-1/schedule/ev-1",
+    ],
+  },
+  {
+    name: "EventsAnnouncementEmail",
+    element: (
+      <EventsAnnouncementEmail
+        teamName={TEAM}
+        headline="3 games vs Hawks"
+        dateTimeLabels={[
+          "Sat, Apr 4, 2026 at 5:30 PM",
+          "Sat, Apr 11, 2026 at 5:30 PM",
+          "Sat, Apr 18, 2026 at 5:30 PM",
+        ]}
+        location={null}
+        notes="Bring both jerseys."
+        scheduleUrl="https://baseball.example.com/t/team-1/schedule"
+      />
+    ),
+    banana: true,
+    contains: [
+      "3 games vs Hawks",
+      "Sat, Apr 4, 2026 at 5:30 PM",
+      "Sat, Apr 18, 2026 at 5:30 PM",
+      "Bring both jerseys.",
+      "https://baseball.example.com/t/team-1/schedule",
+    ],
+  },
+  {
+    name: "EventReminderEmail",
+    element: (
+      <EventReminderEmail
+        teamName={TEAM}
+        headline="Game vs Hawks"
+        timeLabel="5:45 PM"
+        location="Lakeview Playground - Field 5"
+        notes={null}
+        kids={[
+          { playerId: "p1", name: "Ava", rsvp: "attending" },
+          { playerId: "p2", name: "Sam", rsvp: "no-response" },
+        ]}
+        eventUrl="https://baseball.example.com/t/team-1/schedule/ev-1"
+      />
+    ),
+    banana: true,
+    contains: [
+      "Game vs Hawks",
+      "5:45 PM",
+      // rsvpReminderLabel's sentences, which are what carry each state in
+      // words rather than in colour.
+      "Ava — you said yes",
+      "Sam — no answer yet",
+      "https://baseball.example.com/t/team-1/schedule/ev-1",
+    ],
+  },
+  {
+    name: "TeamMessageEmail",
+    element: (
+      <TeamMessageEmail
+        teamName={TEAM}
+        senderName="Coach Cornelius"
+        body={"Fields are wet.\n\nWe'll decide by 4."}
+        teamUrl="https://baseball.example.com/t/team-1"
+      />
+    ),
+    banana: false,
+    contains: ["Coach Cornelius", "Fields are wet.", "We'll decide by 4."],
+  },
+  {
+    name: "AnnouncementReceiptEmail",
+    element: (
+      <AnnouncementReceiptEmail
+        summary="Game vs Hawks on Sat, Apr 4, 2026 at 5:30 PM went to 12 parents."
+        needsAttention={false}
+        scheduleUrl="https://baseball.example.com/t/team-1/schedule"
+      />
+    ),
+    banana: false,
+    contains: ["went to 12 parents", "Announcement sent"],
+  },
+];
+
+/// The rendered markup, with the two entities React escapes decoded again.
+/// The assertions below are about what a parent reads, and "We&#x27;ll decide
+/// by 4." is the same sentence as the one the coach typed — a test that made
+/// every apostrophe in this file an escape sequence would be testing React's
+/// escaping, not the email.
+async function html(element: ReactElement): Promise<string> {
+  const markup = await render(element);
+  return markup.replaceAll("&#x27;", "'").replaceAll("&amp;", "&");
+}
+
+/// Occurrences of a colour used as a *background*, which is what "a banana
+/// surface" means. Deliberately not a count of the hex anywhere: the button
+/// also draws a navy keyline, and a state colour appears as a border on rows
+/// that are not surfaces at all.
+function backgrounds(markup: string, color: string): number {
+  return markup.split(`background-color:${color}`).length - 1;
+}
+
+describe.each(TEMPLATES)("$name", ({ element, banana, contains }) => {
+  it("renders the facts it exists to deliver", async () => {
+    const markup = await html(element);
+
+    for (const fragment of contains) {
+      expect(markup).toContain(fragment);
+    }
+  });
+
+  it("wears the shell", async () => {
+    const markup = await html(element);
+
+    // Cream page, warm card, charcoal cap: the three surfaces that make an
+    // email from this app recognisable at a glance.
+    expect(backgrounds(markup, EMAIL_COLOR.page)).toBeGreaterThanOrEqual(1);
+    expect(backgrounds(markup, EMAIL_COLOR.card)).toBe(1);
+    expect(backgrounds(markup, EMAIL_COLOR.scoreboard)).toBeGreaterThanOrEqual(
+      1,
+    );
+    expect(markup).toContain("Youth Baseball Team Manager");
+    // Auto-inversion turns cream and navy to mud; this is the only lever that
+    // asks a client not to.
+    expect(markup).toContain('name="color-scheme"');
+  });
+
+  it("spends at most one banana, and none where the plan says none", async () => {
+    const markup = await html(element);
+
+    expect(backgrounds(markup, EMAIL_COLOR.banana)).toBe(banana ? 1 : 0);
+  });
+
+  it("never puts white on the banana, or anywhere else", async () => {
+    const markup = await html(element);
+
+    // design-plan.md §3 ends on "Banana Yellow never carries white text,
+    // ever." The palette has no white in it at all — the lightest surface is
+    // warm card stock — so any pure white here is a hand-written colour that
+    // skipped `brand.ts`, which is exactly how the yellow-and-white pairing
+    // would arrive.
+    expect(markup.toUpperCase()).not.toContain("#FFFFFF");
+    expect(markup).not.toContain("#fff;");
+  });
+});
+
+describe("links", () => {
+  it.each(
+    TEMPLATES.filter(({ banana }) => banana).map(({ name, element, contains }) => ({
+      name,
+      element,
+      url: contains.find((fragment) => fragment.startsWith("https://"))!,
+    })),
+  )(
+    "$name repeats its URL as text for clients that strip links",
+    async ({ element, url }) => {
+      const markup = await html(element);
+
+      // Once in the href, once in the body copy. Corporate gateways rewrite
+      // links and some clients strip them outright; a parent who cannot tap
+      // has to be able to copy.
+      expect(markup.split(url).length - 1).toBeGreaterThanOrEqual(2);
+    },
+  );
+});

--- a/src/emails/templates.test.tsx
+++ b/src/emails/templates.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { render } from "@react-email/components";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { EMAIL_COLOR } from "./brand";
 import { AddedToTeamEmail } from "./AddedToTeamEmail";
@@ -23,17 +23,22 @@ import { TeamMessageEmail } from "./TeamMessageEmail";
  * banana still returns a string, still sends, and is only ever seen by the
  * families it was sent to.
  *
- * So this checks the three things that would otherwise be found in an inbox:
+ * So this checks the four things that would otherwise be found in an inbox:
  *
- * 1. **Every template renders and still carries its facts** — the team name,
- *    the date, the code, the link.
- * 2. **The banana budget** (design-plan.md §2). At most one Banana Yellow
- *    surface per email, and the calm emails have none.
- * 3. **The link survives a client that strips links.** Every template with a
- *    button repeats its URL as plain text.
+ * 1. **Every template renders and still carries its facts** — the team name
+ *    on the cap, the date, the code, the link.
+ * 2. **The banana budget** (design-plan.md §2). At most one banana surface per
+ *    email, counted by the `data-banana` marker the two permitted components
+ *    carry, and none at all on the calm emails.
+ * 3. **Every colour comes from the palette.** No hand-typed hex, no React
+ *    Email default leaking through, and therefore no white anywhere — which is
+ *    how "white on the banana" would arrive.
+ * 4. **The link survives a client that strips links.** Every template with a
+ *    URL repeats it as plain text.
  */
 
 const TEAM = "Cornelius 7/8 Baseball";
+const URL = "https://baseball.example.com";
 
 /// The eight templates with realistic props, including the awkward ones: a
 /// team name with a slash, an event with no location, and a family with two
@@ -45,6 +50,8 @@ const TEMPLATES: {
   /// ones (`false`) are a claim, not an oversight — see each template's own
   /// comment.
   banana: boolean;
+  /// The URL the template links to, if any — asserted to appear as text.
+  url: string | null;
   /// Text that has to survive, whatever the styling does.
   contains: string[];
 }[] = [
@@ -53,38 +60,31 @@ const TEMPLATES: {
     element: (
       <InvitationEmail
         teamName={TEAM}
-        acceptUrl="https://baseball.example.com/invite/tok123"
+        acceptUrl={`${URL}/invite/tok123`}
         expiresAt={new Date("2026-09-20T12:00:00Z")}
         message={"Practice moves indoors if it rains.\nSee you Saturday."}
       />
     ),
     banana: true,
-    contains: [
-      TEAM,
-      "https://baseball.example.com/invite/tok123",
-      "September 20, 2026",
-      "See you Saturday.",
-    ],
+    url: `${URL}/invite/tok123`,
+    contains: [TEAM, "September 20, 2026", "See you Saturday."],
   },
   {
     name: "AddedToTeamEmail",
-    element: (
-      <AddedToTeamEmail
-        teamName={TEAM}
-        teamUrl="https://baseball.example.com/t/team-1"
-      />
-    ),
+    element: <AddedToTeamEmail teamName={TEAM} teamUrl={`${URL}/t/team-1`} />,
     banana: true,
-    contains: [TEAM, "https://baseball.example.com/t/team-1"],
+    url: `${URL}/t/team-1`,
+    contains: [TEAM],
   },
   {
     name: "SignInCodeEmail",
     element: <SignInCodeEmail formattedCode="K3M7-QP2X" expiresMinutes={10} />,
     // The code panel is a scoreboard, and floodlight yellow on charcoal is the
-    // banana family after dark. There is no button to spend a yellow surface
-    // on, which is the whole design of this email.
-    banana: false,
-    contains: ["K3M7-QP2X", "10 minutes"],
+    // banana family after dark. There is no button, by design; the panel is
+    // the banana.
+    banana: true,
+    url: null,
+    contains: ["K3M7-QP2X", "expires in 10 minutes"],
   },
   {
     name: "EventAnnouncementEmail",
@@ -95,16 +95,15 @@ const TEMPLATES: {
         dateTimeLabel="Wed, Sep 16, 2026 at 5:45 PM"
         location="Lakeview Playground - Field 5"
         notes={null}
-        eventUrl="https://baseball.example.com/t/team-1/schedule/ev-1"
+        eventUrl={`${URL}/t/team-1/schedule/ev-1`}
       />
     ),
     banana: true,
+    url: `${URL}/t/team-1/schedule/ev-1`,
     contains: [
-      TEAM,
       "Game vs Robert",
       "Wed, Sep 16, 2026 at 5:45 PM",
       "Lakeview Playground - Field 5",
-      "https://baseball.example.com/t/team-1/schedule/ev-1",
     ],
   },
   {
@@ -120,16 +119,16 @@ const TEMPLATES: {
         ]}
         location={null}
         notes="Bring both jerseys."
-        scheduleUrl="https://baseball.example.com/t/team-1/schedule"
+        scheduleUrl={`${URL}/t/team-1/schedule`}
       />
     ),
     banana: true,
+    url: `${URL}/t/team-1/schedule`,
     contains: [
       "3 games vs Hawks",
       "Sat, Apr 4, 2026 at 5:30 PM",
       "Sat, Apr 18, 2026 at 5:30 PM",
       "Bring both jerseys.",
-      "https://baseball.example.com/t/team-1/schedule",
     ],
   },
   {
@@ -145,10 +144,11 @@ const TEMPLATES: {
           { playerId: "p1", name: "Ava", rsvp: "attending" },
           { playerId: "p2", name: "Sam", rsvp: "no-response" },
         ]}
-        eventUrl="https://baseball.example.com/t/team-1/schedule/ev-1"
+        eventUrl={`${URL}/t/team-1/schedule/ev-1`}
       />
     ),
     banana: true,
+    url: `${URL}/t/team-1/schedule/ev-1`,
     contains: [
       "Game vs Hawks",
       "5:45 PM",
@@ -156,7 +156,6 @@ const TEMPLATES: {
       // words rather than in colour.
       "Ava — you said yes",
       "Sam — no answer yet",
-      "https://baseball.example.com/t/team-1/schedule/ev-1",
     ],
   },
   {
@@ -166,104 +165,121 @@ const TEMPLATES: {
         teamName={TEAM}
         senderName="Coach Cornelius"
         body={"Fields are wet.\n\nWe'll decide by 4."}
-        teamUrl="https://baseball.example.com/t/team-1"
+        teamUrl={`${URL}/t/team-1`}
       />
     ),
     banana: false,
+    url: `${URL}/t/team-1`,
     contains: ["Coach Cornelius", "Fields are wet.", "We'll decide by 4."],
   },
   {
     name: "AnnouncementReceiptEmail",
     element: (
       <AnnouncementReceiptEmail
+        teamName={TEAM}
         summary="Game vs Hawks on Sat, Apr 4, 2026 at 5:30 PM went to 12 parents."
         needsAttention={false}
-        scheduleUrl="https://baseball.example.com/t/team-1/schedule"
+        scheduleUrl={`${URL}/t/team-1/schedule`}
       />
     ),
     banana: false,
+    url: `${URL}/t/team-1/schedule`,
     contains: ["went to 12 parents", "Announcement sent"],
   },
 ];
 
-/// The rendered markup, with the two entities React escapes decoded again.
-/// The assertions below are about what a parent reads, and "We&#x27;ll decide
-/// by 4." is the same sentence as the one the coach typed — a test that made
-/// every apostrophe in this file an escape sequence would be testing React's
-/// escaping, not the email.
-async function html(element: ReactElement): Promise<string> {
-  const markup = await render(element);
-  return markup.replaceAll("&#x27;", "'").replaceAll("&amp;", "&");
+/// Rendered once per template, with the one entity React escapes in this copy
+/// decoded again: the assertions are about what a parent reads, and "We&#x27;ll
+/// decide by 4." is the same sentence as the one the coach typed.
+const rendered = new Map<string, string>();
+
+beforeAll(async () => {
+  for (const { name, element } of TEMPLATES) {
+    const markup = await render(element);
+    rendered.set(name, markup.replaceAll("&#x27;", "'"));
+  }
+});
+
+function markupOf(name: string): string {
+  const markup = rendered.get(name);
+  if (!markup) {
+    throw new Error(`${name} was not rendered`);
+  }
+  return markup;
 }
 
-/// Occurrences of a colour used as a *background*, which is what "a banana
-/// surface" means. Deliberately not a count of the hex anywhere: the button
-/// also draws a navy keyline, and a state colour appears as a border on rows
-/// that are not surfaces at all.
-function backgrounds(markup: string, color: string): number {
-  return markup.split(`background-color:${color}`).length - 1;
+/// Every `#hex` colour the markup paints with. `&#8202;`-style entities are
+/// not colours and are skipped; everything else has to be in the palette.
+function paintedColors(markup: string): string[] {
+  return [...markup.matchAll(/(?<!&)#[0-9a-fA-F]{3,8}\b/g)].map((m) =>
+    m[0].toUpperCase(),
+  );
 }
 
-describe.each(TEMPLATES)("$name", ({ element, banana, contains }) => {
-  it("renders the facts it exists to deliver", async () => {
-    const markup = await html(element);
+describe.each(TEMPLATES)("$name", ({ name, banana, url, contains }) => {
+  it("renders the facts it exists to deliver", () => {
+    const markup = markupOf(name);
 
     for (const fragment of contains) {
       expect(markup).toContain(fragment);
     }
   });
 
-  it("wears the shell", async () => {
-    const markup = await html(element);
+  it("wears the shell", () => {
+    const markup = markupOf(name);
 
     // Cream page, warm card, charcoal cap: the three surfaces that make an
     // email from this app recognisable at a glance.
-    expect(backgrounds(markup, EMAIL_COLOR.page)).toBeGreaterThanOrEqual(1);
-    expect(backgrounds(markup, EMAIL_COLOR.card)).toBe(1);
-    expect(backgrounds(markup, EMAIL_COLOR.scoreboard)).toBeGreaterThanOrEqual(
-      1,
-    );
+    expect(markup).toContain(`background-color:${EMAIL_COLOR.page}`);
+    expect(markup).toContain(`background-color:${EMAIL_COLOR.card}`);
+    expect(markup).toContain(`background-color:${EMAIL_COLOR.scoreboard}`);
     expect(markup).toContain("Youth Baseball Team Manager");
-    // Auto-inversion turns cream and navy to mud; this is the only lever that
-    // asks a client not to.
-    expect(markup).toContain('name="color-scheme"');
   });
 
-  it("spends at most one banana, and none where the plan says none", async () => {
-    const markup = await html(element);
+  it("names the team on the cap, unless it is the pre-team sign-in code", () => {
+    const markup = markupOf(name);
+    const capCount = markup.split(TEAM).length - 1;
 
-    expect(backgrounds(markup, EMAIL_COLOR.banana)).toBe(banana ? 1 : 0);
+    if (name === "SignInCodeEmail") {
+      expect(capCount).toBe(0);
+    } else {
+      // At least on the cap; most templates also say it in the body.
+      expect(capCount).toBeGreaterThanOrEqual(1);
+    }
   });
 
-  it("never puts white on the banana, or anywhere else", async () => {
-    const markup = await html(element);
+  it("spends at most one banana, and none where the plan says none", () => {
+    const markup = markupOf(name);
 
+    expect(markup.split("data-banana=").length - 1).toBe(banana ? 1 : 0);
+  });
+
+  it("paints only palette colours", () => {
     // design-plan.md §3 ends on "Banana Yellow never carries white text,
     // ever." The palette has no white in it at all — the lightest surface is
-    // warm card stock — so any pure white here is a hand-written colour that
-    // skipped `brand.ts`, which is exactly how the yellow-and-white pairing
-    // would arrive.
-    expect(markup.toUpperCase()).not.toContain("#FFFFFF");
-    expect(markup).not.toContain("#fff;");
+    // warm card stock — so the general check subsumes that one: any colour
+    // not in EMAIL_COLOR is a hand-typed hex that skipped brand.ts, or a
+    // React Email default (its Hr is #eaeaea) leaking through an override
+    // that stopped overriding.
+    const palette = new Set<string>(Object.values(EMAIL_COLOR));
+    const offPalette = paintedColors(markupOf(name)).filter(
+      (color) => !palette.has(color),
+    );
+
+    expect(offPalette).toEqual([]);
+    expect(markupOf(name)).not.toMatch(/color:\s*white\b/i);
   });
-});
 
-describe("links", () => {
-  it.each(
-    TEMPLATES.filter(({ banana }) => banana).map(({ name, element, contains }) => ({
-      name,
-      element,
-      url: contains.find((fragment) => fragment.startsWith("https://"))!,
-    })),
-  )(
-    "$name repeats its URL as text for clients that strip links",
-    async ({ element, url }) => {
-      const markup = await html(element);
+  it("repeats its URL as text for clients that strip links", () => {
+    if (url === null) {
+      // The sign-in code is deliberately link-free — see its docstring.
+      expect(markupOf(name)).not.toContain("href=");
+      return;
+    }
 
-      // Once in the href, once in the body copy. Corporate gateways rewrite
-      // links and some clients strip them outright; a parent who cannot tap
-      // has to be able to copy.
-      expect(markup.split(url).length - 1).toBeGreaterThanOrEqual(2);
-    },
-  );
+    // Once in the href, once in the body copy. Corporate gateways rewrite
+    // links and some clients strip them outright; a parent who cannot tap
+    // has to be able to copy.
+    expect(markupOf(name).split(url).length - 1).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/src/lib/hsl-to-hex.test.ts
+++ b/src/lib/hsl-to-hex.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { hslToHex } from "./hsl-to-hex";
+
+describe("hslToHex", () => {
+  it.each([
+    // The two colours app/manifest.ts freezes, and the three the email brand
+    // leans on hardest — spot values a reader can check against globals.css by
+    // eye.
+    ["42 70% 94%", "#FAF4E5"],
+    ["131 39% 30%", "#2F6A3A"],
+    ["224 42% 20%", "#1E2948"],
+    ["44 100% 59%", "#FFC72E"],
+    ["218 22% 10%", "#14181F"],
+  ])("converts %s to %s", (triple, hex) => {
+    expect(hslToHex(triple)).toBe(hex);
+  });
+
+  it("handles the achromatic and full-saturation edges", () => {
+    expect(hslToHex("0 0% 100%")).toBe("#FFFFFF");
+    expect(hslToHex("0 0% 0%")).toBe("#000000");
+    expect(hslToHex("0 100% 50%")).toBe("#FF0000");
+    expect(hslToHex("120 100% 50%")).toBe("#00FF00");
+    expect(hslToHex("240 100% 50%")).toBe("#0000FF");
+    // Hue 360 is hue 0 — the modulo in the sector lookup, which is the one
+    // place an off-by-one would silently return black.
+    expect(hslToHex("360 100% 50%")).toBe("#FF0000");
+  });
+
+  it("throws rather than guessing at anything that is not a token triple", () => {
+    // A silent fallback would make a stale colour look verified, which is the
+    // one job this function has.
+    expect(() => hslToHex("#FAF4E5")).toThrow(/Not an HSL triple/);
+    expect(() => hslToHex("42 70 94")).toThrow(/Not an HSL triple/);
+    expect(() => hslToHex("")).toThrow(/Not an HSL triple/);
+  });
+});

--- a/src/lib/hsl-to-hex.ts
+++ b/src/lib/hsl-to-hex.ts
@@ -1,0 +1,51 @@
+/// `H S% L%` — the shape every colour token in `globals.css` is written in —
+/// to `#RRGGBB`.
+///
+/// Pure and DB-free like the rest of `src/lib/`, but unusual in that nothing
+/// in the running app calls it: the two surfaces that cannot express an HSL
+/// token (`app/manifest.ts` and `src/emails/brand.ts`) both hold **frozen hex**
+/// copied from the light theme, and their tests redo this conversion to prove
+/// the copies still match. It lives here rather than inside either test
+/// because two hand-rolled colour converters that disagree would fail exactly
+/// one of them, and the reader would have no way to tell which one lied.
+///
+/// Rejects anything that is not the token shape rather than guessing. A silent
+/// fallback here would make a stale colour look verified.
+
+export function hslToHex(triple: string): string {
+  const match = /^(\d+(?:\.\d+)?) (\d+(?:\.\d+)?)% (\d+(?:\.\d+)?)%$/.exec(
+    triple.trim(),
+  );
+
+  if (!match) {
+    throw new Error(`Not an HSL triple: ${triple}`);
+  }
+
+  const h = Number(match[1]);
+  const s = Number(match[2]) / 100;
+  const l = Number(match[3]) / 100;
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  const [r, g, b] = (
+    [
+      [c, x, 0],
+      [x, c, 0],
+      [0, c, x],
+      [0, x, c],
+      [x, 0, c],
+      [c, 0, x],
+    ] as const
+  )[Math.floor(h / 60) % 6];
+
+  return `#${[r, g, b]
+    .map((channel) =>
+      Math.round((channel + m) * 255)
+        .toString(16)
+        .padStart(2, "0")
+        .toUpperCase(),
+    )
+    .join("")}`;
+}

--- a/src/lib/light-theme.test.ts
+++ b/src/lib/light-theme.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { lightThemeHex } from "./light-theme";
+
+describe("lightThemeHex", () => {
+  it("reads the light value of a token that the dark theme also overrides", () => {
+    // `--background` is 42 70% 94% in :root and 218 22% 10% in the dark
+    // block; the whole point of scoping to :root is that this stays cream.
+    expect(lightThemeHex("background")).toBe("#FAF4E5");
+  });
+
+  it("throws on a token that does not exist rather than returning a guess", () => {
+    expect(() => lightThemeHex("no-such-token")).toThrow(/not in globals.css/);
+  });
+});

--- a/src/lib/light-theme.ts
+++ b/src/lib/light-theme.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { hslToHex } from "./hsl-to-hex";
+
+/// The light-theme value of one `globals.css` token, as hex.
+///
+/// Test support, not app code: nothing at runtime reads the stylesheet, and
+/// nothing should — this exists for the two surfaces that hold **frozen hex**
+/// copied from the light theme (`app/manifest.ts`, `src/emails/brand.ts`) and
+/// the tests that prove the copies still match. It lives in `src/lib/` rather
+/// than inside either test because two hand-rolled parsers of one file that
+/// disagree fail exactly one suite and give a reader no way to tell which one
+/// lied, which is the argument `hslToHex` already made for itself.
+///
+/// Reads the `:root { … }` block only, so the value is the light one however
+/// the dark override and the `@theme inline` block are ordered around it — a
+/// first-match regex over the whole file would silently pick up the dark
+/// value if the blocks were ever reordered.
+export function lightThemeHex(token: string): string {
+  const css = readFileSync(
+    join(process.cwd(), "src/app/globals.css"),
+    "utf8",
+  );
+  // `[\s\S]` rather than `.` with the dotAll flag: tsconfig targets below
+  // es2018, where `/s/` is a compile error.
+  const root = /:root \{([\s\S]*?)\n\}/.exec(css);
+  if (!root) {
+    throw new Error(
+      "Could not find the :root block in globals.css — this parser, not the " +
+        "stylesheet, is probably what needs updating.",
+    );
+  }
+
+  const match = new RegExp(`--${token}:\\s*([^;]+);`).exec(root[1]);
+  if (!match) {
+    throw new Error(
+      `--${token} is not in globals.css's :root block — this parser, not the ` +
+        "stylesheet, is probably what needs updating.",
+    );
+  }
+
+  return hslToHex(match[1]);
+}


### PR DESCRIPTION
## Summary

The eight emails were plain white sans-serif with a near-black button while every screen in the app is cream paper, field green, midnight navy and one rationed banana. The inbox is the app's first surface (a parent meets a message before they ever open a page), so every template now wears the same clothes: a shared shell, a texture kit, and a frozen palette that a test re-derives from `globals.css`. Props, subjects, builders and send paths are untouched.

## Key Decisions

- **Frozen light-theme hex, not tokens.** A mail client has no cascade for `hsl(var(--x))`, drops `prefers-color-scheme`, and never sees a Tailwind class. `src/emails/brand.ts` copies the light theme as hex, the same trade `app/manifest.ts` makes, and `brand.test.ts` re-derives every value through the one shared parser (`@/lib/light-theme`) so the copy cannot rot.
- **No images, no web font.** Images are off by default in most inboxes and every remote fetch reports when a family opened their mail. Identity is carried by type, colour and rules; Alfa Slab degrades to a bold system slab stack.
- **The CTA is navy ground with banana lettering, not banana with navy text.** The Gmail and Outlook apps recolour dark-mode mail on their own: they lift dark text and leave saturated grounds alone, so a yellow button with navy text comes out as light text on yellow, the pairing design-plan.md §3 forbids. Built this way round it survives the pass unchanged. The `color-scheme: light` meta is kept as a courtesy Apple Mail honours, not as a defence.
- **One banana per email, counted by a marker.** Only `BananaButton` and `ScoreboardPanel` carry `data-banana`; `templates.test.tsx` asserts at most one per email and none on the calm ones (team message, receipt). The sign-in code spends its banana as floodlight figures on the scoreboard, since there is deliberately nothing to tap.
- **URL fallbacks are built into the link components.** `BananaButton` and `QuietLink` each print their href as plain text, so no template has to remember to, and the test runs over every template with a URL.
- **`teamName` is required on the layout as `string | null`.** Null only for the pre-team sign-in code. The first cut's receipt forgot it, and a coach running two teams got a receipt naming neither.

## What's in Scope

- `EmailLayout`: cream page, charcoal scoreboard cap carrying the team name, warm card, seam-red rule, footer.
- `EmailKit`: `EmailHeading`, `FactPanel`/`FactRow` (ticket stub), `NoteBlock`, `EdgePanel`, `ScoreboardPanel`, `BananaButton`, `QuietLink`, `StitchRule`, `SlotDot`, `SectionLabel`, shared `captionStyle`.
- `brand.ts` palette, font stacks, `EMAIL_RSVP_COLOR` (cross-checked against `rsvp-style.ts`).
- `copy.ts`: `rosterFootnote`, `whenWhere`, shared by the four roster-triggered templates.
- All eight templates restyled; the receipt now takes `teamName` and the action passes it.
- `@/lib/hsl-to-hex` and `@/lib/light-theme`, extracted so the manifest test and the email tests share one converter and one parser.
- `templates.test.tsx` renders all eight and checks facts, shell, team on cap, banana budget, palette allowlist, and URL-as-text.
- AGENTS.md gotcha and design-plan.md §7 entry describing the above.

### Out of Scope

- Outlook desktop's Word engine ignores padding on tables and `white-space` on paragraphs, so the card is tighter there and a coach's typed line breaks collapse. Fixing it means MSO conditional comments in every template; documented in AGENTS.md as a known trade instead.
- A `@media (prefers-color-scheme: dark)` / `[data-ogsc]` stylesheet mapping to the night-game tokens for Apple Mail and Outlook. The palette is arranged to survive recolouring rather than to prevent it.
- Subject lines and the `EMAIL_FROM` display name (the `DO-NOT-REPLY` sender in the original screenshot is an env var, not code).

## Bugs Found and Fixed During Self-Review

A code review of the first commit found these, all fixed in the second commit:

- The banana-ground CTA was the exact pairing Gmail's dark-mode pass turns into light-on-yellow. Rebuilt navy/banana.
- Every 11px caption inherited React Email's 24px line-height, so stub labels sat visibly below their values in every client. One shared `captionStyle` sets the line box.
- The team message and receipt had lost their visible URL (old templates printed the raw link; the quiet link showed only anchor text; no plain-text part is sent). Fallback now built into both link components; test covers every template with a URL.
- The receipt named no team. `teamName` required on the layout; action passes it through.
- The repeat-weekly copy promised per-date buttons on a page that has none; the sign-in copy assumed the screen was still open; the invitation's expiry had dropped to footer grey. All reverted to honest wording.
- `SlotDot` had no space after it, so Outlook and screen readers read "1Sat, Apr 4". A real space follows the chip.
- The invite action test's `whiteSpace` assertion had gone vacuous once the template delegated to a kit component; it now renders the element.
- Docs and the test disagreed about whether the sign-in code spends a banana. Resolved by the marker (it does).

## Known Gaps / Follow-ups

- Rendering was verified in headless Chromium at phone width, not in real mail clients. The Gmail dark-mode reasoning is from documented client behaviour, not a test on a device.
- Which `P2002` shape and which Outlook version a given parent has are unknowable here; the Outlook degradation is documented, not measured.

## Test Plan

- [ ] Run this repo's full check gate (see `AGENTS.md` → `## Commands`) — lint, typecheck, tests, and build must all pass. (`pnpm check`: 133 files, 2116 tests green; `pnpm exec next build` green.)
- [ ] Create a game on a team with at least one guardian on the roster and open the announcement email on a phone: charcoal cap with the team name, "NEW ON THE SCHEDULE" eyebrow, the when/where stub, a navy button with yellow lettering, the URL repeated under it.
- [ ] Open the same email with the phone in dark mode (Gmail app): the button text stays yellow on a dark ground, never light on yellow.
- [ ] Request a sign-in code: the code is set in yellow monospace on a charcoal panel, with no link anywhere in the message.
- [ ] Send a team message: no yellow anywhere, a green "Schedule, lineup, and RSVP" link with the URL printed under it, and the cap names the team.
- [ ] Create a repeat-weekly run: numbered dates with a space after each number, location shown once, the button opening the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VkKWVPJ6bC2CD7eK8SYxz

---
_Generated by [Claude Code](https://claude.ai/code/session_013VkKWVPJ6bC2CD7eK8SYxz)_